### PR TITLE
Save the state of weapon recovery tags and restore it when done with H2X.

### DIFF
--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -853,9 +853,8 @@ int __cdecl OnMapLoad(int a1)
 	{
 		if (b_Halo2Final && !h2mod->Server)
 			h2f->Dispose();
-		if (b_Infection) {
+		if (b_Infection)
 			inf->Deinitialize();
-		}
 
 		PatchFixRankIcon();
 
@@ -960,12 +959,13 @@ int __cdecl OnMapLoad(int a1)
 			if (b_GunGame && isHost)
 				gg->Initialize();
 
-			if (b_H2X)
-				H2X_Initialize();
-
 			if (b_Halo2Final)
 				h2f->Initialize(isHost);
-			
+
+			if (b_H2X)
+				H2X_Enable();
+			else
+				H2X_Disable();
 		}
 
 
@@ -981,9 +981,6 @@ int __cdecl OnMapLoad(int a1)
 
 			if (b_GunGame)
 				gg->Initialize();
-
-			if (b_H2X)
-				H2X_Initialize();
 		}
 
 	}

--- a/xlive/H2MOD_H2X.cpp
+++ b/xlive/H2MOD_H2X.cpp
@@ -3,20 +3,72 @@
 #include "xliveless.h"
 #include "H2MOD.h"
 
-void H2X_Initialize()
+struct tag_vaules
+{
+	float BR_recovery         = 0.295f;   /*H2X BR fire recovery time*/
+	float Sniper_recovery     = 0.535f;   /*H2X Sniper Rifle fire recovery time*/
+	float Beam_Rifle_recovery = 0.25875f; /*H2X Beam Rifle fire recovery time*/
+	float Carbine_recovery    = 0.20f;    /*H2X Carbine fire recovery time*/
+	float Shotgun_recovery    = 1.035f;   /*H2X Shotgun fire recovery time*/
+	float Magnum_recovery     = 0.13f;    /*H2X Magnum fire recovery time*/
+	float Brute_recovery      = 0.39f;    /*H2X Brute Shot fire recovery time*/
+	float Plasma_recovery     = 0.11f;   /*H2X Plasma Pistol fire recovery time*/
+};
+
+tag_vaules default_vaules;
+bool currently_enabled = false;
+
+DWORD get_floatoffsets()
 {
 	int offset = 0x47CD54;
 	if (h2mod->Server)
 		offset = 0x4A29BC;
 	TRACE_GAME("[h2mod] H2X is being run on client game");
-	DWORD FloatOffsets = *(DWORD*)((char*)h2mod->GetBase() + offset);
+	return *(DWORD*)((char*)h2mod->GetBase() + offset);
+}
 
-	*(float*)(FloatOffsets + 0xA49A7C) = 0.295f; /*H2X BR fire recovery time*/
-	*(float*)(FloatOffsets + 0xB7A330) = 0.535f; /*H2X Sniper Rifle fire recovery time*/
-	*(float*)(FloatOffsets + 0xCE049C) = 0.25875f; /*H2X Beam Rifle fire recovery time*/
-	*(float*)(FloatOffsets + 0xA7C3D4) = 0.20f; /*H2X Carbine fire recovery time*/
-	*(float*)(FloatOffsets + 0xAF1DA4) = 1.035f; /*H2X Shotgun fire recovery time*/
-	*(float*)(FloatOffsets + 0x96EC34) = 0.13f; /*H2X Magnum fire recovery time*/
-	*(float*)(FloatOffsets + 0xC0EABC) = 0.39f; /*H2X Brute Shot fire recovery time*/
-	*(float*)(FloatOffsets + 0xA03250) = 0.11f; /*H2X Plasma Pistol fire recovery time*/
+void Set(tag_vaules &values)
+{
+	DWORD FloatOffsets = get_floatoffsets();
+
+	*(float*)(FloatOffsets + 0xA49A7C) = values.BR_recovery;
+	*(float*)(FloatOffsets + 0xB7A330) = values.Sniper_recovery;
+	*(float*)(FloatOffsets + 0xCE049C) = values.Beam_Rifle_recovery;
+	*(float*)(FloatOffsets + 0xA7C3D4) = values.Carbine_recovery;
+	*(float*)(FloatOffsets + 0xAF1DA4) = values.Shotgun_recovery;
+	*(float*)(FloatOffsets + 0x96EC34) = values.Magnum_recovery;
+	*(float*)(FloatOffsets + 0xC0EABC) = values.Brute_recovery;
+	*(float*)(FloatOffsets + 0xA03250) = values.Plasma_recovery;
+}
+
+void Save(tag_vaules &values)
+{
+	DWORD FloatOffsets = get_floatoffsets();
+
+	values.BR_recovery         = *(float*)(FloatOffsets + 0xA49A7C);
+	values.Sniper_recovery     = *(float*)(FloatOffsets + 0xB7A330);
+	values.Beam_Rifle_recovery = *(float*)(FloatOffsets + 0xCE049C);
+	values.Carbine_recovery    = *(float*)(FloatOffsets + 0xA7C3D4);
+	values.Shotgun_recovery    = *(float*)(FloatOffsets + 0xAF1DA4);
+	values.Magnum_recovery     = *(float*)(FloatOffsets + 0x96EC34);
+	values.Brute_recovery      = *(float*)(FloatOffsets + 0xC0EABC);
+	values.Plasma_recovery     = *(float*)(FloatOffsets + 0xA03250);
+}
+
+void H2X_Enable()
+{
+	if (currently_enabled)
+		return;
+	Save(default_vaules);
+	tag_vaules new_vaules;
+	Set(new_vaules);
+	currently_enabled = true;
+}
+
+void H2X_Disable()
+{
+	if (currently_enabled) {
+		Set(default_vaules);
+		currently_enabled = false;
+	}
 }

--- a/xlive/H2MOD_H2X.h
+++ b/xlive/H2MOD_H2X.h
@@ -1,3 +1,4 @@
 #pragma once
-	void H2X_Initialize();
+	void H2X_Enable();
+	void H2X_Disable();
 


### PR DESCRIPTION
Requires the previous fix attempt to be reverted.