### PR TITLE
Updated WritebytesASM

### DIFF
--- a/xlive/CUser.h
+++ b/xlive/CUser.h
@@ -1,5 +1,5 @@
-#ifndef CUSER_H
-#define CUSER_H
+#pragma once 
+
 #include "stdafx.h"
 #include <unordered_map>
 #include <mutex>
@@ -91,4 +91,3 @@ public:
 
 	int LastUser = 1;
 };
-#endif

--- a/xlive/GSCustomMenu.cpp
+++ b/xlive/GSCustomMenu.cpp
@@ -1682,38 +1682,38 @@ void RefreshToggleIngameKeyboardControls() {
 	if (H2Config_disable_ingame_keyboard) {
 		//Allows to repeat last movement when lose focus in mp, unlocks METHOD E from point after intro vid
 		BYTE getFocusB[] = { 0x00 };
-		WriteBytesASM(H2BaseAddr + 0x2E3C5, getFocusB, 1);
+		WriteBytes(H2BaseAddr + 0x2E3C5, getFocusB, 1);
 		//Allows input when not in focus.
 		BYTE getFocusE[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 };
-		WriteBytesASM(H2BaseAddr + 0x2F9EA, getFocusE, 6);
-		WriteBytesASM(H2BaseAddr + 0x2F9FC, getFocusE, 6);
-		WriteBytesASM(H2BaseAddr + 0x2FA09, getFocusE, 6);
+		WriteBytes(H2BaseAddr + 0x2F9EA, getFocusE, 6);
+		WriteBytes(H2BaseAddr + 0x2F9FC, getFocusE, 6);
+		WriteBytes(H2BaseAddr + 0x2FA09, getFocusE, 6);
 		//Disables the keyboard only when in-game and not in a menu.
 		BYTE disableKeyboard1[] = { 0x90, 0x90, 0x90 };
-		WriteBytesASM(H2BaseAddr + 0x2FA8A, disableKeyboard1, 3);
+		WriteBytes(H2BaseAddr + 0x2FA8A, disableKeyboard1, 3);
 		BYTE disableKeyboard2[] = { 0x00 };
-		WriteBytesASM(H2BaseAddr + 0x2FA92, disableKeyboard2, 1);
+		WriteBytes(H2BaseAddr + 0x2FA92, disableKeyboard2, 1);
 		BYTE disableKeyboard3[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 };
-		WriteBytesASM(H2BaseAddr + 0x2FA67, disableKeyboard3, 6);
+		WriteBytes(H2BaseAddr + 0x2FA67, disableKeyboard3, 6);
 	}
 	else {
 		//Reset them all back.
 		BYTE getFocusB[] = { 0x01 };
-		WriteBytesASM(H2BaseAddr + 0x2E3C5, getFocusB, 1);
+		WriteBytes(H2BaseAddr + 0x2E3C5, getFocusB, 1);
 		
 		BYTE getFocusE[] = { 0x0F, 0x85, 0x02, 0x02, 0x00, 0x00 };
-		WriteBytesASM(H2BaseAddr + 0x2F9EA, getFocusE, 6);
+		WriteBytes(H2BaseAddr + 0x2F9EA, getFocusE, 6);
 		getFocusE[2] = 0xF0;
 		getFocusE[3] = 0x01;
-		WriteBytesASM(H2BaseAddr + 0x2F9FC, getFocusE, 6);
+		WriteBytes(H2BaseAddr + 0x2F9FC, getFocusE, 6);
 		getFocusE[2] = 0xE3;
-		WriteBytesASM(H2BaseAddr + 0x2FA09, getFocusE, 6);
+		WriteBytes(H2BaseAddr + 0x2FA09, getFocusE, 6);
 		
 		BYTE disableKeyboard1[] = { 0x56, 0xFF, 0xD3 };
-		WriteBytesASM(H2BaseAddr + 0x2FA8A, disableKeyboard1, 3);
+		WriteBytes(H2BaseAddr + 0x2FA8A, disableKeyboard1, 3);
 		BYTE disableKeyboard2[] = { 0x01 };
-		WriteBytesASM(H2BaseAddr + 0x2FA92, disableKeyboard2, 1);
-		WriteBytesASM(H2BaseAddr + 0x2FA67, enableKeyboard3, 6);
+		WriteBytes(H2BaseAddr + 0x2FA92, disableKeyboard2, 1);
+		WriteBytes(H2BaseAddr + 0x2FA67, enableKeyboard3, 6);
 	}
 }
 
@@ -2158,7 +2158,7 @@ static bool CMButtonHandler_OtherSettings(int button_id) {
 		BYTE assmDisableVehicleFlipEject[] = { 0xEB };
 		if (vehicleFlipoverEject)
 			assmDisableVehicleFlipEject[0] = 0x7E;
-		WriteBytesASM(H2BaseAddr + 0x159e5d, assmDisableVehicleFlipEject, 1);
+		WriteBytes(H2BaseAddr + 0x159e5d, assmDisableVehicleFlipEject, 1);
 	}
 	return false;
 }

--- a/xlive/GSUtils.cpp
+++ b/xlive/GSUtils.cpp
@@ -22,7 +22,7 @@ void PatchCall(DWORD call_addr, DWORD new_function_ptr) {
 void WritePointer(DWORD offset, void *ptr) {
 	BYTE* pbyte = (BYTE*)&ptr;
 	BYTE assmNewFuncRel[0x4] = { pbyte[0], pbyte[1], pbyte[2], pbyte[3] };
-	WriteBytesASM(offset, assmNewFuncRel, 0x4);
+	WriteBytes(offset, assmNewFuncRel, 0x4);
 }
 
 void HexToByteArray(BYTE* byteArray, char* pointerHex) {

--- a/xlive/GSUtils.h
+++ b/xlive/GSUtils.h
@@ -89,4 +89,4 @@ bool StrnCaseInsensEqu(char* str1, char* str2, unsigned int chk_len);
 #define NopFill(Address, len)                       \
 	BYTE J(NopFIll_, __LINE__ )[len];               \
 	std::fill_n(J(NopFIll_, __LINE__ ), len, 0x90); \
-	WriteBytesASM(Address, J(NopFIll_, __LINE__ ), len)
+	WriteBytes(Address, J(NopFIll_, __LINE__ ), len)

--- a/xlive/GUI.h
+++ b/xlive/GUI.h
@@ -1,7 +1,4 @@
 #pragma once
-#ifndef GUI_H
-#define GUI_H
-
 
 static void drawText(int x, int y, DWORD color, const char* text, LPD3DXFONT pFont);
 static void drawRect(FLOAT X, FLOAT Y, FLOAT Width, FLOAT Height, D3DCOLOR dColor);
@@ -31,12 +28,9 @@ static CONST D3DCOLOR COLOR_GREY_TRANSPARENT = D3DCOLOR_ARGB(150, 112, 112, 112)
 static CONST D3DCOLOR COLOR_BLACK_TRANSPARENT = D3DCOLOR_ARGB(150, 0, 0, 0);
 
 
-
 namespace GUI
 {
 	extern void Initialize();
 
 };
 
-
-#endif

--- a/xlive/Globals.h
+++ b/xlive/Globals.h
@@ -1,5 +1,5 @@
-#ifndef GLOBALS_H
-#define GLOBALS_H
+#pragma once
+
 #include <string>
 #include <sstream>
 #include <vector>
@@ -26,4 +26,3 @@ extern ConsoleCommands* commands;
 std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems);
 std::vector<std::string> split(const std::string &s, char delim);
 int stripWhitespace(wchar_t *inputStr);
-#endif

--- a/xlive/H2ConsoleCommands.h
+++ b/xlive/H2ConsoleCommands.h
@@ -1,5 +1,4 @@
-#ifndef CHATBOX_COMMANDS_H
-#define CHATBOX_COMMANDS_H
+#pragma once
 
 class ConsoleCommands {
 public:
@@ -23,5 +22,3 @@ private:
 	std::unordered_map<std::string, unsigned int> object_ids;
 	DWORD sleepTime;
 };
-
-#endif

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -505,7 +505,7 @@ void H2MOD::set_unit_speed_patch(bool hackit) {
 
 	BYTE assmPatchSpeed[8];
 	memset(assmPatchSpeed, 0x90, 8);
-	WriteBytesASM(h2mod->GetBase() + ((!h2mod->Server) ? 0x6AB7f : 0x6A3BA), assmPatchSpeed, 8);
+	WriteBytes(h2mod->GetBase() + ((!h2mod->Server) ? 0x6AB7f : 0x6A3BA), assmPatchSpeed, 8);
 }
 
 void H2MOD::set_unit_speed(float speed, int pIndex)
@@ -743,7 +743,7 @@ void PatchFixRankIcon() {
 			}
 		}
 		if (shouldPatch) {
-			WriteBytesASM((DWORD)assmOffset, assmPatchFixRankIcon, assmlen);
+			WriteBytes((DWORD)assmOffset, assmPatchFixRankIcon, assmlen);
 			addDebugText("Patching Rank Icon Fix.");
 		}
 	}
@@ -751,7 +751,7 @@ void PatchFixRankIcon() {
 void PatchGameDetailsCheck()
 {
 	BYTE assmPatchGamedetails[2] = { 0x75,0x18};	
-	WriteBytesASM(h2mod->GetBase() + 0x219D6D, assmPatchGamedetails, 2);
+	WriteBytes(h2mod->GetBase() + 0x219D6D, assmPatchGamedetails, 2);
 }
 
 void H2MOD::PatchWeaponsInteraction(bool b_Enable)
@@ -763,7 +763,7 @@ void H2MOD::PatchWeaponsInteraction(bool b_Enable)
 	{
 		memset(assm, 0x90, 5);
 	}
-	WriteBytesASM(offset, assm, 5);
+	WriteBytes(offset, assm, 5);
 }
 
 void PatchPingMeterCheck(bool hackit)
@@ -774,9 +774,9 @@ void PatchPingMeterCheck(bool hackit)
 	BYTE assmPatchPingCheck[2] = { 0x90,0x90 };
 
 	if (hackit)
-		WriteBytesASM(h2mod->GetBase() + 0x1D4E35, assmPatchPingCheck, 2);
+		WriteBytes(h2mod->GetBase() + 0x1D4E35, assmPatchPingCheck, 2);
 	else
-		WriteBytesASM(h2mod->GetBase() + 0x1D4E35, assmOrgLine, 2);
+		WriteBytes(h2mod->GetBase() + 0x1D4E35, assmOrgLine, 2);
 
 }
 

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -1,6 +1,5 @@
 #pragma once
-#ifndef H2MOD_H
-#define H2MOD_H
+
 #include "Hook.h"
 #include <unordered_map>
 #include <set>
@@ -147,6 +146,3 @@ private:
 
 extern H2MOD* h2mod;
 
-
-
-#endif

--- a/xlive/H2MOD_GunGame.h
+++ b/xlive/H2MOD_GunGame.h
@@ -1,6 +1,5 @@
 #pragma once
-#ifndef H2GUNGAME_H
-#define H2GUNGAME_H
+
 #include "Hook.h"
 #include <unordered_map>
 
@@ -26,4 +25,3 @@ public:
 	std::unordered_map<GunGamePlayer*, bool> GunGamePlayers;
 
 };
-#endif

--- a/xlive/H2MOD_Halo2Final.h
+++ b/xlive/H2MOD_Halo2Final.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef H2MOD_H2FINAL
-#define H2MOD_H2FINAL
 
 class Halo2FinalSettings
 {
@@ -121,4 +119,3 @@ public:
 private:
 	Halo2FinalSettings *settings;
 };
-#endif

--- a/xlive/H2MOD_Infection.h
+++ b/xlive/H2MOD_Infection.h
@@ -1,6 +1,5 @@
 #pragma once
-#ifndef H2INFECTION_H
-#define H2INFECTION_H
+
 #include <unordered_map>
 
 class InfectionPlayer
@@ -25,4 +24,4 @@ public:
 
 
 };
-#endif
+

--- a/xlive/H2MOD_MapManager.h
+++ b/xlive/H2MOD_MapManager.h
@@ -1,5 +1,4 @@
-#ifndef MAP_DOWNLOAD_H
-#define MAP_DOWNLOAD_H
+#pragma once
 
 #include <set>
 
@@ -45,5 +44,3 @@ private:
 	std::unordered_map<int, std::string> precalculatedDownloadPercentageStrings;
 	volatile BOOL threadRunning = false;
 };
-
-#endif

--- a/xlive/H2MOD_Mouseinput.cpp
+++ b/xlive/H2MOD_Mouseinput.cpp
@@ -59,15 +59,15 @@ void Mouseinput::Initialize()
 
 	auto setDx = (base + 0x627CC);
 	VirtualProtect((LPVOID)setDx, 8, PAGE_EXECUTE_READWRITE, &dwBack);
-	WriteBytesASM(base + 0x627CC, assmNop, 8);
+	WriteBytes(base + 0x627CC, assmNop, 8);
 
 	auto setDy = (base + 0x62802);
 	VirtualProtect((LPVOID)setDy, 8, PAGE_EXECUTE_READWRITE, &dwBack);
-	WriteBytesASM(base + 0x62802, assmNop, 8);
+	WriteBytes(base + 0x62802, assmNop, 8);
 
 	auto setDx2 = (base + 0x627E7);
 	VirtualProtect((LPVOID)setDx2, 8, PAGE_EXECUTE_READWRITE, &dwBack);
-	WriteBytesASM(base + 0x627E7, assmNop, 8);
+	WriteBytes(base + 0x627E7, assmNop, 8);
 
 	Codecave(base + 0x622AA, CC_Fug, 0x8);
 }

--- a/xlive/H2Startup.cpp
+++ b/xlive/H2Startup.cpp
@@ -67,7 +67,7 @@ void configureXinput() {
 	if (!H2IsDediServer) {
 		if (H2GetInstanceId() > 1) {
 			BYTE xinputNumFix[] = { '0' + (H2GetInstanceId() / 10), 0, '0' + (H2GetInstanceId() % 10) };
-			WriteBytesASM((DWORD)xinputdllPath + 16, xinputNumFix, 3);
+			WriteBytes((DWORD)xinputdllPath + 16, xinputNumFix, 3);
 
 			char pointerHex[20];
 			sprintf(pointerHex, "%x", (DWORD)xinputdllPath);
@@ -79,7 +79,7 @@ void configureXinput() {
 			addDebugText(totext);
 
 			BYTE assmXinputPushIntructionPart[] = { byteArray[3], byteArray[2], byteArray[1], byteArray[0] };
-			WriteBytesASM(H2BaseAddr + 0x8AD28, assmXinputPushIntructionPart, 4);
+			WriteBytes(H2BaseAddr + 0x8AD28, assmXinputPushIntructionPart, 4);
 
 			char xinputName[40];
 			char xinputdir[12];

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -160,22 +160,22 @@ void InitH2Tweaks() {
 
 		if (H2Config_skip_intro) {
 			BYTE assmIntroSkip[] = { 0x3F };
-			WriteBytesASM(H2BaseAddr + 0x221C0E, assmIntroSkip, 1);
+			WriteBytes(H2BaseAddr + 0x221C0E, assmIntroSkip, 1);
 		}
 
 		if (!H2Config_skip_intro && IntroHQ) {
 			BYTE assmIntroHQ[] = { 0xEB };
-			WriteBytesASM(H2BaseAddr + 0x221C29, assmIntroHQ, 1);
+			WriteBytes(H2BaseAddr + 0x221C29, assmIntroHQ, 1);
 		}
 
 		//Allows unlimited clients
 		BYTE assmUnlimitedClients[41];
 		memset(assmUnlimitedClients, 0x00, 41);
-		WriteBytesASM(H2BaseAddr + 0x39BCF0, assmUnlimitedClients, 41);
+		WriteBytes(H2BaseAddr + 0x39BCF0, assmUnlimitedClients, 41);
 
 		//Allows on a remote desktop connection
 		BYTE assmRemoteDesktop[] = { 0xEB };
-		WriteBytesASM(H2BaseAddr + 0x7E54, assmRemoteDesktop, 1);
+		WriteBytes(H2BaseAddr + 0x7E54, assmRemoteDesktop, 1);
 
 		//Disables the ESRB warning (only occurs for English Language).
 		//disables the one if no intro vid occurs.
@@ -183,8 +183,8 @@ void InitH2Tweaks() {
 		ESRB = 0;
 		//disables the one after the intro video.
 		BYTE assmIntroESRBSkip[] = { 0x00 };
-		WriteBytesASM(H2BaseAddr + 0x3a0fa, assmIntroESRBSkip, 1);
-		WriteBytesASM(H2BaseAddr + 0x3a1ce, assmIntroESRBSkip, 1);
+		WriteBytes(H2BaseAddr + 0x3a0fa, assmIntroESRBSkip, 1);
+		WriteBytes(H2BaseAddr + 0x3a1ce, assmIntroESRBSkip, 1);
 
 		//Redirects the is_campaign call that the in-game chat renderer makes so we can show/hide it as we like.
 		PatchCall(H2BaseAddr + 0x22667B, (DWORD)NotDisplayIngameChat);

--- a/xlive/Hook.h
+++ b/xlive/Hook.h
@@ -1,5 +1,4 @@
-#ifndef _DETOURS_H
-#define _DETOURS_H
+#pragma once
 
 void *DetourFunc(BYTE *src, const BYTE *dst, const int len);
 void RetourFunc(BYTE *src, BYTE *restore, const int len);
@@ -8,6 +7,5 @@ void RetourClassFunc(BYTE *src, BYTE *restore, const int len);
 
 void *VTableFunction(void *ClassPtr, DWORD index);
 void Codecave(DWORD destAddress, VOID(*func)(VOID), BYTE nopCount);
-void WriteBytesASM(DWORD destAddress, LPVOID patch, DWORD numBytes);
+void WriteBytes(uintptr_t destAddress, LPVOID bytesToWrite, int numBytes);
 
-#endif

--- a/xlive/Network.h
+++ b/xlive/Network.h
@@ -1,14 +1,6 @@
 #pragma once
-#ifndef NETWORK_H
-#define NETWORK_H
-
 
 namespace Network
 {
 	extern void Initialize();
 }
-
-
-
-
-#endif


### PR DESCRIPTION
- Removed redundant assembly usage in such simple function that just writes a bunch of memory using memcpy/VirtualProtect
- Replace `#ifndef` directive usage with newer and simpler `#pragma once`  directive, supported by most compilers