### PR TITLE
Xbox tickrate

### DIFF
--- a/xlive/H2Config.cpp
+++ b/xlive/H2Config.cpp
@@ -95,6 +95,7 @@ bool H2Config_chatbox_commands = false;
 bool H2Config_debug_log = false;
 char H2Config_login_identifier[255] = { "" };
 char H2Config_login_password[255] = { "" };
+bool H2Config_30tick = false;
 
 int H2Config_hotkeyIdHelp = VK_F3;
 int H2Config_hotkeyIdToggleDebug = VK_F2;
@@ -266,6 +267,11 @@ void SaveH2Config() {
 			fputs("# login_password Options (Server):", fileConfig);
 			fputs("\n# The password used to login to the defined account.", fileConfig);
 			fputs("\n\n", fileConfig);
+
+			fputs("# tick_30 Options (Server):", fileConfig);
+			fputs("\n# *EXPERIMENTAL*", fileConfig);
+			fputs("\n# Enable xbox tickrate. *May* improve hit-reg.", fileConfig);
+			fputs("\n\n", fileConfig);
 		}
 		if (!H2IsDediServer) {
 			fputs("# hotkey_... Options (Client):", fileConfig);
@@ -344,6 +350,8 @@ void SaveH2Config() {
 			fputs("\nserver_name = ", fileConfig); fputs(H2Config_dedi_server_name, fileConfig);
 
 			fputs("\nserver_playlist = ", fileConfig); fputs(H2Config_dedi_server_playlist, fileConfig);
+
+			fputs("\ntick_30 = ", fileConfig); fputs(H2Config_30tick ? "1" : "0", fileConfig);
 		}
 
 		//fputs("\nmap_downloading_enable = ", fileConfig); fputs(H2Config_map_downloading_enable ? "1" : "0", fileConfig);
@@ -441,6 +449,7 @@ static bool est_debug_log = false;
 static bool est_custom_resolution = false;
 static bool est_server_name = false;
 static bool est_server_playlist = false;
+static bool est_30tick = false;
 static bool est_map_downloading_enable = false;
 static bool est_chatbox_commands = false;
 static bool est_login_token = false;
@@ -452,6 +461,7 @@ static bool est_hotkey_align_window = false;
 static bool est_hotkey_window_mode = false;
 static bool est_hotkey_hide_ingame_chat = false;
 static bool est_hotkey_guide = false;
+
 
 static void est_reset_vars() {
 	est_h2portable = false;
@@ -477,6 +487,7 @@ static void est_reset_vars() {
 	est_custom_resolution = false;
 	est_server_name = false;
 	est_server_playlist = false;
+	est_30tick = false;
 	est_map_downloading_enable = false;
 	est_chatbox_commands = false;
 	est_login_token = false;
@@ -846,6 +857,18 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 					}
 				}
 				est_server_playlist = true;
+			}
+		}
+		else if (H2IsDediServer && sscanf(fileLine, "tick_30 =%d", &tempint1) == 1) {
+			if (est_30tick) {
+				duplicated = true;
+			}
+			else if (!(tempint1 == 0 || tempint1 == 1)) {
+				incorrect = true;
+			}
+			else {
+				H2Config_30tick = (bool)tempint1;
+				est_30tick = true;
 			}
 		}
 		else if (sscanf(fileLine, "map_downloading_enable =%d", &tempint1) == 1) {

--- a/xlive/H2Config.h
+++ b/xlive/H2Config.h
@@ -44,6 +44,7 @@ extern int H2Config_custom_resolution_x;
 extern int H2Config_custom_resolution_y;
 extern char H2Config_dedi_server_name[32];
 extern char H2Config_dedi_server_playlist[256];
+extern bool H2Config_30tick;
 extern bool H2Config_map_downloading_enable;
 extern bool H2Config_chatbox_commands;
 extern bool H2Config_debug_log;

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1614,6 +1614,8 @@ void H2MOD::Initialize()
 	{
 		this->Base = (DWORD)GetModuleHandleA("H2Server.exe");
 		this->Server = TRUE;
+		if (H2Config_30tick)
+			init30Tick();
 	}
 	else
 	{

--- a/xlive/H2MOD_H2X.cpp
+++ b/xlive/H2MOD_H2X.cpp
@@ -50,3 +50,29 @@ void H2X::Deinitialize()
 	*(float*)(FloatOffsets + 0xD0F960) = 11.0f; /*H2V Brute Plasma Rifle rounds per second max*/
 }
 	
+/*EXPERIMENTAL*/
+/*Xbox tickrate for Dedis*/
+/*May improve hit-registration*/
+
+DWORD retnAddress;
+static const float xboxVal = 0.03333333333;
+
+__declspec(naked) void set30Tick() {
+
+	__asm
+	{
+		pop retnAddress
+
+		mov byte ptr[eax+2],30
+		movss xmm3,[xboxVal]
+		movss [eax+4],xmm3
+
+		push retnAddress
+		ret
+	}
+
+}
+
+void init30Tick() {
+	Codecave(h2mod->GetBase() + 0x4BE25, set30Tick, 0x12);
+}

--- a/xlive/H2MOD_H2X.h
+++ b/xlive/H2MOD_H2X.h
@@ -7,3 +7,5 @@ public:
 	static void Deinitialize();
 
 };
+
+void init30Tick();


### PR DESCRIPTION
Allow server hosters to change the tickrate on dedicated servers.
No need of changes on client.
May improve hit-reg (at least for me from what I tested).