### PR TITLE
BlamLibrary Addon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ xliveless.v12.suo
 /Halo2
 /xlive/Debug
 /xlive/Release
+*.opensdf

--- a/xlive/Blam/BlamLibrary.h
+++ b/xlive/Blam/BlamLibrary.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "stdafx.h"
+#include "Engine\EngineDefinitions.h"
+#include "Enums\Enums.h"
+#include "Maths\Maths.h"
+#include "Shared\SharedDefinitions.h"

--- a/xlive/Blam/Engine/EngineDefinitions.h
+++ b/xlive/Blam/Engine/EngineDefinitions.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "stdafx.h"
+#include "Players\Players.h"
+
+#include "Extras\Skulls.h"
+
+#include "Game\GameManager.h"
+#include "Game\GameTimeGlobals.h"
+
+#include "Objects\Objects.h"
+#include "Objects\ObjectsHeader.h"
+#include "Objects\ObjectPlacementData.h"

--- a/xlive/Blam/Engine/Extras/Skulls.h
+++ b/xlive/Blam/Engine/Extras/Skulls.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "stdafx.h"
+#include "..\Blam\Shared\SharedDefinitions.h"
+namespace Blam
+{
+	namespace EngineDefinitions
+	{
+		namespace Extras
+		{			
+			struct IceCreamFlavor
+			{
+				Blam::SharedDefinitions::IceCreamFlavorStock Envy;
+				Blam::SharedDefinitions::IceCreamFlavorStock GruntBirthdayParty;
+				Blam::SharedDefinitions::IceCreamFlavorStock Assassins;
+				Blam::SharedDefinitions::IceCreamFlavorStock Thunderstorm;
+				Blam::SharedDefinitions::IceCreamFlavorStock Famine;
+				Blam::SharedDefinitions::IceCreamFlavorStock IWHBYD;
+				Blam::SharedDefinitions::IceCreamFlavorStock Blind;
+				Blam::SharedDefinitions::IceCreamFlavorStock Ghost;
+				Blam::SharedDefinitions::IceCreamFlavorStock BlackEye;
+				Blam::SharedDefinitions::IceCreamFlavorStock Catch;
+				Blam::SharedDefinitions::IceCreamFlavorStock Sputnik;
+				Blam::SharedDefinitions::IceCreamFlavorStock Iron;
+				Blam::SharedDefinitions::IceCreamFlavorStock Mythic;
+				Blam::SharedDefinitions::IceCreamFlavorStock Anger;
+				Blam::SharedDefinitions::IceCreamFlavorStock Unknown;
+			};
+		}
+	}
+}

--- a/xlive/Blam/Engine/Game/GameManager.h
+++ b/xlive/Blam/Engine/Game/GameManager.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace EngineDefinitions
+	{
+		namespace Game
+		{			//Broken atm
+			struct GameManager
+			{
+				BOOL MapReset;
+				BOOL RevertCheckPoint;
+				BOOL SaveCheckpoint;
+				BOOL LoadMainmenu;
+				BOOL unk_0;
+				BOOL LoadingDone;
+				BOOL unk_1;
+				BOOL unk_2;
+				BOOL UpdateProfile;
+				BOOL unk_3;
+				INT16 structure_bsp_index;			
+				DWORD unk_4[8];
+			};
+		}
+	}
+}

--- a/xlive/Blam/Engine/Game/GameTimeGlobals.h
+++ b/xlive/Blam/Engine/Game/GameTimeGlobals.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "stdafx.h"
+#include "../Blam/Enums/Enums.h"
+namespace Blam
+{
+	namespace EngineDefinitions
+	{
+		namespace Game
+		{
+			//size: 0x24
+			struct game_time_globals
+			{
+				Blam::Enums::Game::CameraState CameraState;//0
+				Blam::Enums::Game::GameState GameState;//1
+				WORD GameEngineClockSpeed;//2
+				FLOAT GameEngineTickRate;//4
+				DWORD GameTimeElapsed;//8
+				FLOAT GameSpeedMultiplier;//0xC
+				FLOAT unk_0;//0x10
+				FLOAT unk_1;//0x14
+				DWORD unk_2;//0x18
+				FLOAT unk_3;//0x20
+				DWORD unk_4;//0x24
+			};
+		}
+	}
+}

--- a/xlive/Blam/Engine/Objects/ObjectPlacementData.h
+++ b/xlive/Blam/Engine/Objects/ObjectPlacementData.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "stdafx.h"
+#include "..\Blam\Shared\SharedDefinitions.h"
+#include "..\Blam\Maths\Maths.h"
+namespace Blam
+{
+	namespace EngineDefinitions
+	{
+		namespace Objects
+		{
+			//0xC4
+			struct ObjectPlacementData //To Do
+			{
+				Blam::SharedDefinitions::DatumIndex DatumIndex;//0
+				DWORD unk_0;//0x4
+				WORD unk_10;//0x8;
+				BYTE unk_11;//0xA
+				BYTE unk_12;//0xB
+				DWORD unk_13;//0xC
+				DWORD unk_14;//0x10
+				BYTE unk_15;//0x14
+				BYTE unk_16;//0x15
+				WORD unk_17;//0x16
+				DWORD unk_18;//0x18
+				Blam::Maths::RealPoint3D Placement;//0x1C
+				Blam::Maths::RealVector3D Orientation;//0x28
+				Blam::Maths::RealVector3D unk_1;//0x34
+				Blam::Maths::RealPoint3D TranslationalVelocity;//0x40
+				Blam::Maths::RealVector3D AngularVelocity;//0x4C
+				FLOAT Scale;//0x58
+				DWORD unk_2[5];//0x5C
+				WORD unk_3;//0x70
+				WORD unk_4;//0x72
+				DWORD unk_5[0xF];//0x74
+				WORD unk_20;//0xB0
+				WORD unk_21;//0xB2
+				WORD unk_6;//0xB4
+				WORD unk_7;//0xB6
+				BYTE unk_19;//0xB8
+				BYTE unk_22;//0xB9
+				WORD unk_23;//0xBA
+				CHAR unk_24;//0xBC
+				BYTE unk_25[3];//0xBD
+				DWORD unk_26;//0xC0
+				DWORD unk_9;//0xC4				
+			};
+		}
+	}
+}

--- a/xlive/Blam/Engine/Objects/Objects.h
+++ b/xlive/Blam/Engine/Objects/Objects.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "stdafx.h"
+#include "..\Blam\Shared\SharedDefinitions.h"
+#include "..\Blam\Enums\Enums.h"
+namespace Blam
+{
+	namespace EngineDefinitions
+	{
+		namespace Objects
+		{
+			struct ObjectEntityDefinition//To Do
+			{
+				Blam::SharedDefinitions::DatumIndex DatumIndex;//0
+				DWORD ObjectFlags;//4
+				DWORD unk_0;//8
+				Blam::SharedDefinitions::c_object_index VehicleSeat1;//0xC
+				Blam::SharedDefinitions::c_object_index CurrentWeaponDatum;//0x10
+				Blam::SharedDefinitions::c_object_index VehicleSeat2;//0x14
+				WORD UnitInVehicleFlag;//0x18
+				WORD unk_1;				//0x1A
+				DWORD unk_2;//0x1C
+			};
+		}
+	}
+}

--- a/xlive/Blam/Engine/Objects/ObjectsHeader.h
+++ b/xlive/Blam/Engine/Objects/ObjectsHeader.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "stdafx.h"
+#include "..\Blam\Shared\SharedDefinitions.h"
+#include "..\Blam\Engine\Objects\Objects.h"
+
+namespace Blam
+{
+	namespace EngineDefinitions
+	{
+		namespace Objects
+		{	
+			//size : 0xC
+			struct  GameStateObjectsHeader
+			{
+				DWORD unk_offset_0;
+				DWORD unk_offset_1;
+				Blam::EngineDefinitions::Objects::ObjectEntityDefinition& ObjectEntity;
+			};
+			
+		}
+	}
+	
+	
+}
+
+

--- a/xlive/Blam/Engine/Players/PlayerControls.h
+++ b/xlive/Blam/Engine/Players/PlayerControls.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "..\stdafx.h"
+#include "..\Blam\Enums\Enums.h"
+
+typedef DWORD c_object_entity;
+namespace Blam 
+{
+	namespace EngineDefinitions
+	{
+		namespace Players
+		{
+			//size  : 0xB0
+			struct GameStatePlayerControls//TO DO
+			{
+				DWORD unk_0[5];
+				c_object_entity ControllingObjectDatum;
+
+			};
+		}
+	}
+}

--- a/xlive/Blam/Engine/Players/Players.h
+++ b/xlive/Blam/Engine/Players/Players.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "..\stdafx.h"
+#include "..\Blam\Enums\Enums.h"
+#include "..\Blam\Shared\SharedDefinitions.h"
+
+
+namespace Blam 
+{
+	namespace EngineDefinitions
+	{
+		namespace Players
+		{
+			//size:0x204
+			struct GameStatePlayers
+			{
+				DWORD unk_0;
+				DWORD GamertagID;
+				char unk_block_0[0x20];//unknown,so skipping them
+				Blam::SharedDefinitions::c_object_index ObjectDatum;
+				Blam::SharedDefinitions::c_object_index DeadObjectDatum;//Holds the object datum for spectate period
+				DWORD unk_1[4];//4*4 bytes related to action or something
+				WCHAR PlayerName[32];				
+				Blam::Enums::Player::PrimaryArmorColor PrimaryArmorColor;
+				Blam::Enums::Player::PrimaryArmorColor SecondaryArmorColor;
+				Blam::Enums::Player::PrimaryEmblemColor PrimaryEmblemColor;
+				Blam::Enums::Player::SecondaryEmblemColor SecondaryEmblemColor;
+				Blam::Enums::Player::Biped Biped;
+				Blam::Enums::Player::EmblemForeground EmblemForeground;
+				Blam::Enums::Player::EmblemBackground EmblemBackground;
+				Blam::Enums::Player::EmblemToggle EmblemToggle;
+				DWORD unk_3[13];//13*4 bytes still unknown
+				Blam::Enums::Player::Team Team;
+				Blam::Enums::Player::Handicap Handicap;
+				INT16 unk_4;//2 Unused bytes
+				INT32 unk_5;//4 unused bytes
+				char unk_block_1[0x80];//20*4 bytes unknown,so skipping them
+				INT32 unk_6;//4 unused bytes
+				INT32 MillisecondsToSpawn;
+				DWORD unk_7[2];//unused 8 bytes
+				DWORD RespawnCountDown;
+				char unk_block_2[0x28];
+				FLOAT PlayerSpeed;
+				char unk_block_3[0x80];			
+				
+			};
+		}
+	}
+}

--- a/xlive/Blam/Enums/Enums.h
+++ b/xlive/Blam/Enums/Enums.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "stdafx.h"
+#include "Players\Players.h"
+#include "Game\GameTimeGlobals.h"

--- a/xlive/Blam/Enums/Game/GameTimeGlobals.h
+++ b/xlive/Blam/Enums/Game/GameTimeGlobals.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "..\stdafx.h"
+namespace Blam
+{
+	namespace Enums
+	{
+		namespace Game
+		{
+			enum class CameraState : BOOL
+			{
+				Frozen = FALSE,
+				Normal = TRUE
+			};
+			enum class GameState : BOOL
+			{
+				Running = FALSE,
+				Paused = TRUE			    
+			};
+		}
+	}
+}

--- a/xlive/Blam/Enums/Players/Players.h
+++ b/xlive/Blam/Enums/Players/Players.h
@@ -1,0 +1,228 @@
+#pragma once
+#include "..\stdafx.h"
+namespace Blam
+{
+	namespace Enums
+	{
+		namespace Player
+		{
+			enum class PrimaryArmorColor : BYTE
+			{
+				White = 0,
+				Steel = 1,
+				Red = 2,
+				Orange = 3,
+				Gold = 4,
+				Olive = 5,
+				Green = 6,
+				Sage = 7,
+				Cyan = 8,
+				Teal = 9,
+				Colbat = 10,
+				Blue = 11,
+				Violet = 12,
+				Purple = 13,
+				Pink = 14,
+				Crimson = 15,
+				Brown = 16,
+				Tan = 17
+			};
+			enum class SecondaryArmorColor : BYTE
+			{
+				White = 0,
+				Steel = 1,
+				Red = 2,
+				Orange = 3,
+				Gold = 4,
+				Olive = 5,
+				Green = 6,
+				Sage = 7,
+				Cyan = 8,
+				Teal = 9,
+				Colbat = 10,
+				Blue = 11,
+				Violet = 12,
+				Purple = 13,
+				Pink = 14,
+				Crimson = 15,
+				Brown = 16,
+				Tan = 17
+			};
+			enum class PrimaryEmblemColor : BYTE
+			{
+				White = 0,
+				Steel = 1,
+				Red = 2,
+				Orange = 3,
+				Gold = 4,
+				Olive = 5,
+				Green = 6,
+				Sage = 7,
+				Cyan = 8,
+				Teal = 9,
+				Colbat = 10,
+				Blue = 11,
+				Violet = 12,
+				Purple = 13,
+				Pink = 14,
+				Crimson = 15,
+				Brown = 16,
+				Tan = 17
+			};
+			enum class SecondaryEmblemColor : BYTE
+			{
+				White = 0,
+				Steel = 1,
+				Red = 2,
+				Orange = 3,
+				Gold = 4,
+				Olive = 5,
+				Green = 6,
+				Sage = 7,
+				Cyan = 8,
+				Teal = 9,
+				Colbat = 10,
+				Blue = 11,
+				Violet = 12,
+				Purple = 13,
+				Pink = 14,
+				Crimson = 15,
+				Brown = 16,
+				Tan = 17
+			};
+			enum class Biped : BYTE
+			{
+				MasterChief = 0,
+				Dervish = 1,
+				Spartan = 2,
+				Elite = 3
+			};
+			enum class EmblemForeground : BYTE
+			{
+				SeventhColumn = 0,
+				Bullseye = 1,
+				Vortex = 2,
+				Halt = 3,
+				Spartan = 4,
+				DaBomb = 5,
+				Trinity = 6,
+				Delta = 7,
+				Rampancy = 8,
+				Sergeant = 9,
+				Phenoix = 10,
+				Champion = 11,
+				JollyRoger = 12,
+				Marathon = 13,
+				Cube = 14,
+				Radioactive = 15,
+				Smiley = 16,
+				Frowney = 17,
+				Spearhead = 18,
+				Sol = 19,
+				Waypoint = 20,
+				YingYang = 21,
+				Helmet = 22,
+				Triad = 23,
+				GruntSymbol = 24,
+				Cleave = 25,
+				Thor = 26,
+				SkullKing = 27,
+				Triplicate = 28,
+				Subnova = 29,
+				FlamingNinja = 30,
+				DoubleCresent = 31,
+				Spades = 32,
+				Clubs = 33,
+				Diamonds = 34,
+				Hearts = 35,
+				Wasp = 36,
+				MarkOfShame = 37,
+				Snake = 38,
+				Hawk = 39,
+				Lips = 40,
+				Capsule = 41,
+				Cancel = 42,
+				GasMask = 43,
+				Grenade = 44,
+				Tsanta = 45,
+				Race = 46,
+				Valkyire = 47,
+				Drone = 48,
+				Grunt = 49,
+				GruntHead = 50,
+				BruteHead = 51,
+				Runes = 52,
+				Trident = 53,
+				Number0 = 54,
+				Number1 = 55,
+				Number2 = 56,
+				Number3 = 57,
+				Number4 = 58,
+				Number5 = 59,
+				Number6 = 60,
+				Number7 = 61,
+				Number8 = 62,
+				Number9 = 63
+			};
+			enum class EmblemBackground : BYTE
+			{
+				Solid = 0,
+				VerticalSplit = 1,
+				HorizontalSplit1 = 2,
+				HorizontalSplit2 = 3,
+				VerticalGradient = 4,
+				HorizontalGradient = 5,
+				TripleColumn = 6,
+				TripleRow = 7,
+				Quadrants1 = 8,
+				Quadrants2 = 9,
+				DiagonalSlice = 10,
+				Cleft = 11,
+				X1 = 12,
+				X2 = 13,
+				Circle = 14,
+				Diamond = 15,
+				Cross = 16,
+				Square = 17,
+				DualHalfCircle = 18,
+				Triangle = 19,
+				DiagonalQuadrant = 20,
+				ThreeQuaters = 21,
+				Quarter = 22,
+				FourRows1 = 23,
+				FourRows2 = 24,
+				SplitCircle = 25,
+				OneThird = 26,
+				TwoThirds = 27,
+				UpperField = 28,
+				TopandBottom = 29,
+				CenterStripe = 30,
+				LeftandRight = 31
+			};
+			enum class EmblemToggle : BYTE
+			{
+				Off = 0,
+				On = 1
+			};
+			enum class Team : BYTE
+			{
+				Red = 0,
+				Blue = 1,
+				Yellow = 2,
+				Green = 3,
+				Purple = 4,
+				Orange = 5,
+				Bronwn = 6,
+				Pink = 7,
+				Observer = 255
+			};
+			enum class Handicap : BYTE
+			{
+				None = 0,
+				Minor = 1,
+				Moderate = 2,
+				Severe = 3
+			};
+		}
+	}
+}

--- a/xlive/Blam/Maths/Angle.h
+++ b/xlive/Blam/Maths/Angle.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace Maths
+	{
+		struct Angle
+		{
+			FLOAT Value;
+		};
+	}
+}

--- a/xlive/Blam/Maths/Maths.h
+++ b/xlive/Blam/Maths/Maths.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "Angle.h"
+#include "RealColorRGB.h"
+#include "RealPoint2D.h"
+#include "RealPoint3D.h"
+#include "RealVector2D.h"
+#include "RealVector3D.h"

--- a/xlive/Blam/Maths/RealColorRGB.h
+++ b/xlive/Blam/Maths/RealColorRGB.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace Maths
+	{
+		struct RealColorRGB
+		{
+			FLOAT Red;
+			FLOAT Green;
+			FLOAT Blue;
+		};
+	}
+}

--- a/xlive/Blam/Maths/RealPoint2D.h
+++ b/xlive/Blam/Maths/RealPoint2D.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace Maths
+	{
+		struct RealPoint2D
+		{
+			FLOAT X;
+			FLOAT Y;
+		};
+	}
+}

--- a/xlive/Blam/Maths/RealPoint3D.h
+++ b/xlive/Blam/Maths/RealPoint3D.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace Maths
+	{
+		struct RealPoint3D
+		{
+			FLOAT X;
+			FLOAT Y;
+			FLOAT Z;
+		};
+	}
+}

--- a/xlive/Blam/Maths/RealVector2D.h
+++ b/xlive/Blam/Maths/RealVector2D.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace Maths
+	{
+		struct RealVector2D
+		{
+			FLOAT I;
+			FLOAT J;		
+		};
+	}
+}

--- a/xlive/Blam/Maths/RealVector3D.h
+++ b/xlive/Blam/Maths/RealVector3D.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "stdafx.h"
+namespace Blam
+{
+	namespace Maths
+	{
+		struct RealVector3D
+		{
+			FLOAT I;
+			FLOAT J;
+			FLOAT K;
+		};
+	}
+}

--- a/xlive/Blam/Shared/SharedDefinitions.h
+++ b/xlive/Blam/Shared/SharedDefinitions.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "stdafx.h"
+
+namespace Blam
+{
+	namespace SharedDefinitions
+	{
+		typedef DWORD c_object_index;
+		typedef DWORD DatumIndex;
+		typedef BOOL IceCreamFlavorStock;
+
+		//size : 0x44
+		struct s_globals_struct
+		{
+			DWORD unk[0x10];//First 0x40 Bytes no idea
+			DWORD RunTimeBase;//Game Uses global+0x44 for every global to get runtime base
+		};
+	}			
+	
+}

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -282,6 +282,27 @@
     <ClCompile Include="xlive_network.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Blam\BlamLibrary.h" />
+    <ClInclude Include="Blam\Engine\EngineDefinitions.h" />
+    <ClInclude Include="Blam\Engine\Extras\Skulls.h" />
+    <ClInclude Include="Blam\Engine\Game\GameManager.h" />
+    <ClInclude Include="Blam\Engine\Game\GameTimeGlobals.h" />
+    <ClInclude Include="Blam\Engine\Objects\ObjectPlacementData.h" />
+    <ClInclude Include="Blam\Engine\Objects\Objects.h" />
+    <ClInclude Include="Blam\Engine\Objects\ObjectsHeader.h" />
+    <ClInclude Include="Blam\Engine\Players\PlayerControls.h" />
+    <ClInclude Include="Blam\Engine\Players\Players.h" />
+    <ClInclude Include="Blam\Enums\Enums.h" />
+    <ClInclude Include="Blam\Enums\Game\GameTimeGlobals.h" />
+    <ClInclude Include="Blam\Enums\Players\Players.h" />
+    <ClInclude Include="Blam\Maths\Angle.h" />
+    <ClInclude Include="Blam\Maths\Maths.h" />
+    <ClInclude Include="Blam\Maths\RealColorRGB.h" />
+    <ClInclude Include="Blam\Maths\RealPoint2D.h" />
+    <ClInclude Include="Blam\Maths\RealPoint3D.h" />
+    <ClInclude Include="Blam\Maths\RealVector2D.h" />
+    <ClInclude Include="Blam\Maths\RealVector3D.h" />
+    <ClInclude Include="Blam\Shared\SharedDefinitions.h" />
     <ClInclude Include="cartographer_main.hpp" />
     <ClInclude Include="CUser.h" />
     <ClInclude Include="Detour.h" />

--- a/xlive/Project_Cartographer.vcxproj.filters
+++ b/xlive/Project_Cartographer.vcxproj.filters
@@ -46,6 +46,39 @@
     <Filter Include="Source Files\GlitchyScripts">
       <UniqueIdentifier>{c50ed4e8-db51-43bf-bc48-a7d5abc06719}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Blam">
+      <UniqueIdentifier>{cc2c99fc-365a-4378-8c80-48e7fc3c5e79}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Engine">
+      <UniqueIdentifier>{1756db8f-ba07-4777-b4ef-1b6de3bf674f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Engine\Extras">
+      <UniqueIdentifier>{ee386d18-ee75-4f64-ab14-4ef7bedf702c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Engine\Game">
+      <UniqueIdentifier>{08197ffa-f27b-417e-8a0f-8e0c7f1e36b3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Engine\Objects">
+      <UniqueIdentifier>{20a09ede-d2c0-4755-8abf-e84f4d8efca9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Engine\Players">
+      <UniqueIdentifier>{4d7ace68-c64c-4829-907a-04ea9f259105}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Enums">
+      <UniqueIdentifier>{f9c50c86-269f-48c1-b6db-37bd6ca68e06}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Enums\Players">
+      <UniqueIdentifier>{06078d05-7eda-4844-b030-d46c92832dfb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Enums\Game">
+      <UniqueIdentifier>{0f6b82bd-b3fa-4887-baec-fd8d60b66c1c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Maths">
+      <UniqueIdentifier>{c4fb9ac0-3d6c-4137-8a24-eac1146f5614}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Blam\Shared">
+      <UniqueIdentifier>{b66746a4-d12d-44e8-9b07-93611bdb2c72}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -271,6 +304,69 @@
     </ClInclude>
     <ClInclude Include="H2MOD_Network.h">
       <Filter>Source Files\H2MOD\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\BlamLibrary.h">
+      <Filter>Source Files\Blam</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Enums\Enums.h">
+      <Filter>Source Files\Blam\Enums</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Enums\Players\Players.h">
+      <Filter>Source Files\Blam\Enums\Players</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Enums\Game\GameTimeGlobals.h">
+      <Filter>Source Files\Blam\Enums\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\Angle.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\Maths.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\RealColorRGB.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\RealPoint2D.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\RealPoint3D.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\RealVector2D.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Maths\RealVector3D.h">
+      <Filter>Source Files\Blam\Maths</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Shared\SharedDefinitions.h">
+      <Filter>Source Files\Blam\Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\EngineDefinitions.h">
+      <Filter>Source Files\Blam\Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Objects\ObjectPlacementData.h">
+      <Filter>Source Files\Blam\Engine\Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Objects\Objects.h">
+      <Filter>Source Files\Blam\Engine\Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Objects\ObjectsHeader.h">
+      <Filter>Source Files\Blam\Engine\Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Players\PlayerControls.h">
+      <Filter>Source Files\Blam\Engine\Players</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Players\Players.h">
+      <Filter>Source Files\Blam\Engine\Players</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Game\GameTimeGlobals.h">
+      <Filter>Source Files\Blam\Engine\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Game\GameManager.h">
+      <Filter>Source Files\Blam\Engine\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Blam\Engine\Extras\Skulls.h">
+      <Filter>Source Files\Blam\Engine\Extras</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description ###
Adds a list of BlamLibrary Support for Project Cartographer
Its still initial stage and lots of things need to be added but the definitions can still be put into very much use
### Why This should be merged ###
Properly arranges the game definitions into structs and enums and makes the code more readable

### Issues ###
Havent found any issues beside the incomplete structures that need to be still done