### PR TITLE
Removed Test.cpp from compile includes in vcxproj file.

### DIFF
--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -278,7 +278,6 @@
     <ClCompile Include="Network.cpp" />
     <ClCompile Include="packet.pb.cc" />
     <ClCompile Include="H2MOD_Infection.cpp" />
-    <ClCompile Include="Test.cpp" />
     <ClCompile Include="xliveless.cpp" />
     <ClCompile Include="xlive_network.cpp" />
   </ItemGroup>


### PR DESCRIPTION
This was added in the previous commit and prevents compiling of the developer branch.  Test.cpp was not uploaded or included in the previous commit.