### PR TITLE
Sanity checks on Discord Rich Presence 

### DIFF
--- a/xlive/H2ConsoleCommands.cpp
+++ b/xlive/H2ConsoleCommands.cpp
@@ -365,7 +365,7 @@ void ConsoleCommands::handle_command(std::string command) {
 		}
 		else if (firstCommand == "$controller_sens") {
 			if (splitCommands.size() != 2) {
-				output(L"Invalid usage, usage $sens_controller value");
+				output(L"Invalid usage, usage $controller_sens value");
 				return;
 			}
 			std::string sensVal = splitCommands[1];
@@ -383,7 +383,7 @@ void ConsoleCommands::handle_command(std::string command) {
 		}
 		else if (firstCommand == "$mouse_sens") {
 			if (splitCommands.size() != 2) {
-				output(L"Invalid usage, usage $sens_mouse value");
+				output(L"Invalid usage, usage $mouse_sens value");
 				return;
 			}
 			std::string sensVal = splitCommands[1];

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -77,6 +77,7 @@ signed int __cdecl call_unit_inventory_next_weapon(unsigned short unit_datum_ind
 bool __cdecl call_assign_equipment_to_unit(int uint, int object_index, short unk);
 int __cdecl call_object_placement_data_new(void*, int, int, int);
 signed int __cdecl call_object_new(void*);
+int call_assignObjDatumToPlayer(int pIndex, int unitDatum);
 void GivePlayerWeapon(int PlayerIndex, int WeaponId, bool bReset);
 DWORD WINAPI NetworkThread(LPVOID lParam);
 

--- a/xlive/H2MOD_H2X.cpp
+++ b/xlive/H2MOD_H2X.cpp
@@ -1,52 +1,41 @@
 #include <Windows.h>
 #include "H2MOD_H2X.h"
-#include "xliveless.h"
 #include "H2MOD.h"
 
-DWORD getOffset() {
-
-	int offset = 0x47CD54;
-	if (h2mod->Server)
-		offset = 0x4A29BC;
-	//TRACE_GAME("[h2mod] H2X is being run on client game");
-	DWORD FloatOffsets = *(DWORD*)((char*)h2mod->GetBase() + offset);
-	return FloatOffsets;
-}
-
+/* This crap doesn't need and shouldn't run on dedis */
 
 void H2X::Initialize()
-{
-	
-	DWORD FloatOffsets = getOffset();
+{	
+	DWORD FloatOffset = *(DWORD*)(h2mod->GetBase() + 0x47CD54);
 
-	*(float*)(FloatOffsets + 0xA49A7C) = 0.295f; /*H2X BR fire recovery time*/
-	*(float*)(FloatOffsets + 0xB7A330) = 0.535f; /*H2X Sniper Rifle fire recovery time*/
-	*(float*)(FloatOffsets + 0xCE049C) = 0.25875f; /*H2X Beam Rifle fire recovery time*/
-	*(float*)(FloatOffsets + 0xA7C3D4) = 0.20f; /*H2X Carbine fire recovery time*/
-	*(float*)(FloatOffsets + 0xAF1DA4) = 1.035f; /*H2X Shotgun fire recovery time*/
-	*(float*)(FloatOffsets + 0x96EC34) = 0.13f; /*H2X Magnum fire recovery time*/
-	*(float*)(FloatOffsets + 0xC0EABC) = 0.39f;  /*H2X Brute Shot fire recovery time*/
-	*(float*)(FloatOffsets + 0xA03250) = 0.11f; /*H2X Plasma Pistol fire recovery time*/
-	*(float*)(FloatOffsets + 0xBDBF50) = 0.85f;  /*H2X Rocket Launcher fire recovery time*/
-	*(float*)(FloatOffsets + 0xAAE544) = 8.5f; /*H2X Plasma Rifle rounds per second max*/
-	*(float*)(FloatOffsets + 0xD0F960) = 10.0f; /*H2X Brute Plasma Rifle rounds per second max*/
+	*(float*)(FloatOffset + 0xA49A7C) = 0.295f; /*H2X BR fire recovery time*/
+	*(float*)(FloatOffset + 0xB7A330) = 0.535f; /*H2X Sniper Rifle fire recovery time*/
+	*(float*)(FloatOffset + 0xCE049C) = 0.25875f; /*H2X Beam Rifle fire recovery time*/
+	*(float*)(FloatOffset + 0xA7C3D4) = 0.20f; /*H2X Carbine fire recovery time*/
+	*(float*)(FloatOffset + 0xAF1DA4) = 1.035f; /*H2X Shotgun fire recovery time*/
+	*(float*)(FloatOffset + 0x96EC34) = 0.13f; /*H2X Magnum fire recovery time*/
+	*(float*)(FloatOffset + 0xC0EABC) = 0.39f;  /*H2X Brute Shot fire recovery time*/
+	*(float*)(FloatOffset + 0xA03250) = 0.11f; /*H2X Plasma Pistol fire recovery time*/
+	*(float*)(FloatOffset + 0xBDBF50) = 0.85f;  /*H2X Rocket Launcher fire recovery time*/
+	*(float*)(FloatOffset + 0xAAE544) = 8.5f; /*H2X Plasma Rifle rounds per second max*/
+	*(float*)(FloatOffset + 0xD0F960) = 10.0f; /*H2X Brute Plasma Rifle rounds per second max*/
 }
 
 void H2X::Deinitialize()
 {
 
-	DWORD FloatOffsets = getOffset();
+	DWORD FloatOffset = *(DWORD*)(h2mod->GetBase() + 0x47CD54);
 
-	*(float*)(FloatOffsets + 0xA49A7C) = 0.26f; /*H2V BR fire recovery time*/
-	*(float*)(FloatOffsets + 0xB7A330) = 0.5f; /*H2V Sniper Rifle fire recovery time*/
-	*(float*)(FloatOffsets + 0xCE049C) = 0.25f; /*H2V Beam Rifle fire recovery time*/
-	*(float*)(FloatOffsets + 0xA7C3D4) = 0.14f; /*H2V Carbine fire recovery time*/
-	*(float*)(FloatOffsets + 0xAF1DA4) = 1.0f; /*H2V Shotgun fire recovery time*/
-	*(float*)(FloatOffsets + 0x96EC34) = 0.1f; /*H2V Magnum fire recovery time*/
-	*(float*)(FloatOffsets + 0xC0EABC) = 0.3f; /*H2V Brute Shot fire recovery time*/
-	*(float*)(FloatOffsets + 0xA03250) = 0.05f; /*H2V Plasma Pistol fire recovery time*/
-	*(float*)(FloatOffsets + 0xBDBF50) = 0.8f; /*H2V Rocket Launcher fire recovery time*/
-	*(float*)(FloatOffsets + 0xAAE544) = 9.0f; /*H2V Plasma Rifle rounds per second max*/
-	*(float*)(FloatOffsets + 0xD0F960) = 11.0f; /*H2V Brute Plasma Rifle rounds per second max*/
+	*(float*)(FloatOffset + 0xA49A7C) = 0.26f; /*H2V BR fire recovery time*/
+	*(float*)(FloatOffset + 0xB7A330) = 0.5f; /*H2V Sniper Rifle fire recovery time*/
+	*(float*)(FloatOffset + 0xCE049C) = 0.25f; /*H2V Beam Rifle fire recovery time*/
+	*(float*)(FloatOffset + 0xA7C3D4) = 0.14f; /*H2V Carbine fire recovery time*/
+	*(float*)(FloatOffset + 0xAF1DA4) = 1.0f; /*H2V Shotgun fire recovery time*/
+	*(float*)(FloatOffset + 0x96EC34) = 0.1f; /*H2V Magnum fire recovery time*/
+	*(float*)(FloatOffset + 0xC0EABC) = 0.3f; /*H2V Brute Shot fire recovery time*/
+	*(float*)(FloatOffset + 0xA03250) = 0.05f; /*H2V Plasma Pistol fire recovery time*/
+	*(float*)(FloatOffset + 0xBDBF50) = 0.8f; /*H2V Rocket Launcher fire recovery time*/
+	*(float*)(FloatOffset + 0xAAE544) = 9.0f; /*H2V Plasma Rifle rounds per second max*/
+	*(float*)(FloatOffset + 0xD0F960) = 11.0f; /*H2V Brute Plasma Rifle rounds per second max*/
 }
 	

--- a/xlive/H2MOD_Network.cpp
+++ b/xlive/H2MOD_Network.cpp
@@ -564,9 +564,10 @@ char __stdcall receivePacket(void *thisx, int a2, int packetType, unsigned int *
 
 void patchBYTEs(BYTE* orig, BYTE* values, int size) {
 	DWORD dwBack;
+	DWORD temp; //same as WriteBytes, exception fix
 	VirtualProtect(orig, size, PAGE_EXECUTE_READWRITE, &dwBack);
 	memcpy(orig, (BYTE*)values, size);
-	VirtualProtect(orig, size, dwBack, NULL);
+	VirtualProtect(orig, size, dwBack, &temp);
 }
 
 void CustomNetwork::applyNetworkHooks() {

--- a/xlive/Project_Cartographer.vcxproj.user
+++ b/xlive/Project_Cartographer.vcxproj.user
@@ -21,7 +21,6 @@
     <LocalDebuggerWorkingDirectory>$(OutDir)</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerDebuggerType>NativeOnly</LocalDebuggerDebuggerType>
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-windowed</LocalDebuggerCommandArguments>
   </PropertyGroup>
 </Project>

--- a/xlive/xlive_network.cpp
+++ b/xlive/xlive_network.cpp
@@ -64,7 +64,11 @@ int WINAPI XSessionEnd(DWORD, DWORD)
 	NetworkActive = false;
 	Connected = false;
 	ThreadCreated = false;
-	H2MOD_Network = 0;
+	if (H2MOD_Network) {
+		TerminateThread(H2MOD_Network, 0);
+		H2MOD_Network = 0;
+	}
+
 	isServer = false;
 	mapManager->cleanup();
 	TRACE("XSessionEnd");
@@ -80,7 +84,10 @@ INT WINAPI XNetCleanup()
 	ThreadCreated = false;
 	Connected = false;
 	isHost = false;
-	H2MOD_Network = 0;
+	if (H2MOD_Network) {
+		TerminateThread(H2MOD_Network, 0);
+		H2MOD_Network = 0;
+	}
 
 	TRACE("XNetCleanup");
 	return 0;

--- a/xlive/xlive_network.cpp
+++ b/xlive/xlive_network.cpp
@@ -66,9 +66,8 @@ int WINAPI XSessionEnd(DWORD, DWORD)
 	ThreadCreated = false;
 	if (H2MOD_Network) {
 		TerminateThread(H2MOD_Network, 0);
-		H2MOD_Network = 0;
 	}
-
+	H2MOD_Network = 0;
 	isServer = false;
 	mapManager->cleanup();
 	TRACE("XSessionEnd");
@@ -86,9 +85,8 @@ INT WINAPI XNetCleanup()
 	isHost = false;
 	if (H2MOD_Network) {
 		TerminateThread(H2MOD_Network, 0);
-		H2MOD_Network = 0;
 	}
-
+	H2MOD_Network = 0;
 	TRACE("XNetCleanup");
 	return 0;
 }

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -2832,9 +2832,9 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
   TRACE("XUserSetContext  (userIndex = %d, contextId = %d, contextValue = %d)",
 		dwUserIndex, dwContextId, dwContextValue );
 
-  if (h2mod->Server)
-	  return ERROR_SUCCESS;
-  if (!H2Config_discord_enable)
+  extern int H2GetInstanceId();
+
+  if (h2mod->Server || H2GetInstanceId() > 1 || !H2Config_discord_enable)
 	  return ERROR_SUCCESS;
 
   if (dwContextId == 0x00000003)


### PR DESCRIPTION
Check for instances so we don't run rich presence twice on the same PC. 
Disable H2X changes on dedis because it's useless since players can change rate of fire client side.
Fixed exception caused by "patchBYTEs" function.
Always run H2 windowed if debugging using VS.
Properly terminate the network thread.
Added himanshu's "possession hack" code. (unused)

Tested and everything works.