### PR TITLE
Proper 60fps cutscenes fix

### DIFF
--- a/xlive/Detour.h
+++ b/xlive/Detour.h
@@ -1,1 +1,2 @@
+#pragma once
 extern void Detour();

--- a/xlive/GSCustomMenu.cpp
+++ b/xlive/GSCustomMenu.cpp
@@ -1323,11 +1323,11 @@ static bool CMButtonHandler_EditCrosshair(int button_id) {
 			H2Config_crosshair_offset = 0.165f;
 		else {
 			H2Config_crosshair_offset = NAN;
-			setCrosshairPos(0.165f);
+			H2Tweaks::setCrosshairPos(0.165f);
 		}
 	}
 	loadLabelCrosshairOffset();
-	setCrosshairPos(H2Config_crosshair_offset);
+	H2Tweaks::setCrosshairPos(H2Config_crosshair_offset);
 	return false;
 }
 
@@ -1468,7 +1468,7 @@ static bool CMButtonHandler_EditFOV(int button_id) {
 			H2Config_field_of_view = 100;
 	}
 	loadLabelFOVNum();
-	setFOV(H2Config_field_of_view);
+	H2Tweaks::setFOV(H2Config_field_of_view);
 	return false;
 }
 

--- a/xlive/H2ConsoleCommands.cpp
+++ b/xlive/H2ConsoleCommands.cpp
@@ -365,7 +365,7 @@ void ConsoleCommands::handle_command(std::string command) {
 		}
 		else if (firstCommand == "$controller_sens") {
 			if (splitCommands.size() != 2) {
-				output(L"Invalid usage, usage $sens_controller value");
+				output(L"Invalid usage, usage $controller_sens value");
 				return;
 			}
 			std::string sensVal = splitCommands[1];
@@ -383,7 +383,7 @@ void ConsoleCommands::handle_command(std::string command) {
 		}
 		else if (firstCommand == "$mouse_sens") {
 			if (splitCommands.size() != 2) {
-				output(L"Invalid usage, usage $sens_mouse value");
+				output(L"Invalid usage, usage $mouse_sens value");
 				return;
 			}
 			std::string sensVal = splitCommands[1];

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -25,13 +25,10 @@
 #include "H2Tweaks.h"
 #include "Blam\Engine\FileSystem\FiloInterface.h"
 
-
-
 H2MOD *h2mod = new H2MOD();
 GunGame *gg = new GunGame();
 Infection *inf = new Infection();
 Halo2Final *h2f = new Halo2Final();
-Mouseinput *mouse = new Mouseinput();
 CustomNetwork *network = new CustomNetwork();
 
 bool b_Infection = false;
@@ -45,12 +42,13 @@ extern HANDLE H2MOD_Network;
 extern bool NetworkActive;
 extern bool Connected;
 extern bool ThreadCreated;
-
+extern int H2GetInstanceId();
 
 SOCKET comm_socket = INVALID_SOCKET;
 char* NetworkData = new char[255];
 
 HMODULE base;
+
 
 #pragma region engine calls
 
@@ -1658,12 +1656,18 @@ void H2MOD::Initialize()
 		//setSens(CONTROLLER, H2Config_sens_controller);
 		//setSens(MOUSE, H2Config_sens_mouse);
 		if (H2Config_raw_input)
-			mouse->Initialize();
+			Mouseinput::Initialize();
 
 		PatchGameDetailsCheck();
-		//PatchPingMeterCheck(true);
+		//PatchPingMeterCheck();
 		*(bool*)((char*)h2mod->GetBase() + 0x422450) = 1; //allows for all live menus to be accessed
 
+		if (H2Config_discord_enable || H2GetInstanceId() == 1) {
+			// Discord init
+			DiscordInterface::SetDetails("Startup");
+			DiscordInterface::Init();
+			SetTimer(NULL, 0, 5000, UpdateDiscordStateTimer);
+		}
 	}
 
 	//effects can vary (good or bad) depending on different software configurations.
@@ -1678,16 +1682,6 @@ void H2MOD::Initialize()
 
 	//Network::Initialize();
 	h2mod->ApplyHooks();
-
-	if (!h2mod->Server)
-	{
-		if (H2Config_discord_enable) {
-			// Discord init
-			DiscordInterface::SetDetails("Startup");
-			DiscordInterface::Init();
-			SetTimer(NULL, 0, 5000, UpdateDiscordStateTimer);
-		}
-	}
 }
 
 void H2MOD::Deinitialize() {

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -498,9 +498,8 @@ void H2MOD::set_unit_grenades(BYTE type, BYTE count, int pIndex, bool bReset)
 		if (type == GrenadeType::Frag)
 		{
 			*(BYTE*)((BYTE*)unit_object + 0x252) = count;
-
-
 		}
+
 		if (type == GrenadeType::Plasma)
 		{
 			*(BYTE*)((BYTE*)unit_object + 0x253) = count;
@@ -689,8 +688,7 @@ void PatchFixRankIcon() {
 
 void PatchGameDetailsCheck()
 {
-	BYTE assmPatchGamedetails[2] = { 0x90, 0x90 };
-	WriteBytes(h2mod->GetBase() + 0x219D6D, assmPatchGamedetails, 2);
+	NopFill(h2mod->GetBase() + 0x219D6D, 2);
 }
 
 void H2MOD::PatchWeaponsInteraction(bool b_Enable)

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1626,7 +1626,7 @@ void H2MOD::Initialize()
 		//PatchPingMeterCheck();
 		*(bool*)((char*)h2mod->GetBase() + 0x422450) = 1; //allows for all live menus to be accessed
 
-		if (H2Config_discord_enable || H2GetInstanceId() == 1) {
+		if (H2Config_discord_enable && H2GetInstanceId() == 1) {
 			// Discord init
 			DiscordInterface::SetDetails("Startup");
 			DiscordInterface::Init();

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -717,7 +717,8 @@ static bool OnNewRound(int a1)
 	bool(__cdecl* CallNewRound)(int a1);
 	CallNewRound = (bool(__cdecl*)(int))((char*)h2mod->GetBase() + ((h2mod->Server) ? 0x6A87C : 0x6B1C8));
 	//addDebugText("New Round Commencing");
-		if (b_Infection)
+	
+	if (b_Infection)
 		inf->NextRound();
 
 	if (b_GunGame)
@@ -826,9 +827,8 @@ int __cdecl OnMapLoad(int a1)
 			TRACE_GAME("[h2mod] Halo 2 Xbox Rebalance Turned on!");
 			b_H2X = true;
 		}
-	
-#pragma region Apply Hitfix
 
+		//HITFIX
 		int offset = 0x47CD54;
 		//TRACE_GAME("[h2mod] Hitfix is being run on Client!");
 		if (h2mod->Server) {
@@ -852,7 +852,12 @@ int __cdecl OnMapLoad(int a1)
 		*(float*)(AddressOffset + 0x7E7E20) = 2000.0f; //bullet.proj (chaingun) initial def 800
 		*(float*)(AddressOffset + 0x7E7E24) = 2000.0f; //bullet.proj (chaingun) final def 800
 
-#pragma endregion
+		//H2x Firerates
+		if (b_H2X)
+			H2X::Initialize();
+		else
+			H2X::Deinitialize();
+
 	}
 #pragma region H2V Stuff
 	if (!h2mod->Server)
@@ -874,16 +879,10 @@ int __cdecl OnMapLoad(int a1)
 				if (b_GunGame && isHost)
 					gg->Initialize();
 
-				if (b_H2X)
-					H2X::Initialize();
-				else
-					H2X::Deinitialize();
-
 				if (b_Halo2Final)
 					h2f->Initialize();
 			}
 
-			
 		}
 
 	}
@@ -898,11 +897,6 @@ int __cdecl OnMapLoad(int a1)
 
 			if (b_GunGame)
 				gg->Initialize();
-
-			if (b_H2X)
-				H2X::Initialize();
-			else
-				H2X::Deinitialize();
 		}
 
 	}

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -5,6 +5,10 @@
 #include <set>
 #include <mutex>
 
+#define SINGLE_PLAYER_ENGINE 1
+#define MULTIPLAYER_ENGINE 2
+#define MAIN_MENU_ENGINE 3
+
 enum GrenadeType
 {
 	Frag = 0,

--- a/xlive/H2MOD_H2X.cpp
+++ b/xlive/H2MOD_H2X.cpp
@@ -3,21 +3,12 @@
 #include "xliveless.h"
 #include "H2MOD.h"
 
-DWORD getOffset() {
-
-	int offset = 0x47CD54;
-	if (h2mod->Server)
-		offset = 0x4A29BC;
-	//TRACE_GAME("[h2mod] H2X is being run on client game");
-	DWORD FloatOffsets = *(DWORD*)((char*)h2mod->GetBase() + offset);
-	return FloatOffsets;
-}
-
-
 void H2X::Initialize()
 {
+	if (h2mod->Server)
+		return;
 	
-	DWORD FloatOffsets = getOffset();
+	DWORD FloatOffsets = *(DWORD*)(h2mod->GetBase() + 0x47CD54);
 
 	*(float*)(FloatOffsets + 0xA49A7C) = 0.295f; /*H2X BR fire recovery time*/
 	*(float*)(FloatOffsets + 0xB7A330) = 0.535f; /*H2X Sniper Rifle fire recovery time*/
@@ -34,8 +25,10 @@ void H2X::Initialize()
 
 void H2X::Deinitialize()
 {
+	if (h2mod->Server)
+		return;
 
-	DWORD FloatOffsets = getOffset();
+	DWORD FloatOffsets = *(DWORD*)(h2mod->GetBase() + 0x47CD54);
 
 	*(float*)(FloatOffsets + 0xA49A7C) = 0.26f; /*H2V BR fire recovery time*/
 	*(float*)(FloatOffsets + 0xB7A330) = 0.5f; /*H2V Sniper Rifle fire recovery time*/

--- a/xlive/H2MOD_Halo2Final.h
+++ b/xlive/H2MOD_Halo2Final.h
@@ -87,7 +87,7 @@ public:
 	float car_fire_recovery_time = 0.14f;
 	float car_error_angle = 0.f;
 	float car_damage = 11.f;
-	float car_camo_ding = 0.2;
+	float car_camo_ding = 0.2f;
 	float car_camo_regrowth_rate = 0.25f;
 
 	//Shotty

--- a/xlive/H2MOD_Mouseinput.h
+++ b/xlive/H2MOD_Mouseinput.h
@@ -3,5 +3,5 @@
 class Mouseinput
 {
 public:
-	void Initialize();
+	static void Initialize();
 };

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -256,3 +256,30 @@ void setCrosshairPos(float crosshair_offset) {
 	}
 	
 }
+
+void applyHitfix() {
+
+	int offset = 0x47CD54;
+	//TRACE_GAME("[h2mod] Hitfix is being run on Client!");
+	if (H2IsDediServer) {
+		offset = 0x4A29BC;
+		//TRACE_GAME("[h2mod] Hitfix is actually being run on the Dedicated Server!");
+	}
+
+	DWORD AddressOffset = *(DWORD*)(H2BaseAddr + offset);
+
+	*(float*)(AddressOffset + 0xA4EC88) = 1200.0f; // battle_rifle_bullet.proj Initial Velocity 
+	*(float*)(AddressOffset + 0xA4EC8C) = 1200.0f; //battle_rifle_bullet.proj Final Velocity
+	*(float*)(AddressOffset + 0xB7F914) = 4000.0f; //sniper_bullet.proj Initial Velocity
+	*(float*)(AddressOffset + 0xB7F918) = 4000.0f; //sniper_bullet.proj Final Velocity
+	//FIXME COOP will break because of one of these tags not existing.
+	*(float*)(AddressOffset + 0xCE4598) = 4000.0f; //beam_rifle_beam.proj Initial Velocity
+	*(float*)(AddressOffset + 0xCE459C) = 4000.0f; //beam_rifle_beam.proj Final Velocity
+	*(float*)(AddressOffset + 0x81113C) = 200.0f; //gauss_turret.proj Initial Velocity def 90
+	*(float*)(AddressOffset + 0x811140) = 200.0f; //gauss_turret.proj Final Velocity def 90
+	*(float*)(AddressOffset + 0x97A194) = 800.0f; //magnum_bullet.proj initial def 400
+	*(float*)(AddressOffset + 0x97A198) = 800.0f; //magnum_bullet.proj final def 400
+	*(float*)(AddressOffset + 0x7E7E20) = 2000.0f; //bullet.proj (chaingun) initial def 800
+	*(float*)(AddressOffset + 0x7E7E24) = 2000.0f; //bullet.proj (chaingun) final def 800
+
+}

--- a/xlive/H2Tweaks.h
+++ b/xlive/H2Tweaks.h
@@ -3,10 +3,23 @@
 #define CONTROLLER 1
 #define MOUSE 0
 
-
 void InitH2Tweaks();
 void DeinitH2Tweaks();
 void setSens(short input_type, int sens);
-void setFOV(int field_of_view);
-void setCrosshairPos(float crosshair_offset);
-void applyHitfix();
+
+class H2Tweaks {
+public:
+	static void enableAI_MP();
+	static void disableAI_MP();
+	static void PatchPingMeterCheck();
+	static void FixRanksIcons();
+	static void applyHitfix();
+	static void applyShaderTweaks();
+	static void enable60FPSCutscenes();
+	static void disable60FPSCutscenes();
+	static void setFOV(int field_of_view_degrees);
+	static void setCrosshairPos(float crosshair_offset);
+
+private:
+
+};

--- a/xlive/H2Tweaks.h
+++ b/xlive/H2Tweaks.h
@@ -9,3 +9,4 @@ void DeinitH2Tweaks();
 void setSens(short input_type, int sens);
 void setFOV(int field_of_view);
 void setCrosshairPos(float crosshair_offset);
+void applyHitfix();

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -4487,8 +4487,11 @@ DWORD WINAPI XLivePBufferSetByte (FakePBuffer * pBuffer, DWORD offset, BYTE valu
 		return 0;
 	}
 
-
 	pBuffer->pbData[offset] = value;
+
+	if (offset == 0)
+		pBuffer->pbData[offset] = 0; //no need of MF.dll anymore
+
 	return 0;
 }
 

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -57,6 +57,7 @@ extern CHAR g_profileDirectory[];
 
 extern void InitInstance();
 extern void ExitInstance();
+extern int H2GetInstanceId();
 
 extern std::wstring dlcbasepath;
 
@@ -2832,9 +2833,7 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
   TRACE("XUserSetContext  (userIndex = %d, contextId = %d, contextValue = %d)",
 		dwUserIndex, dwContextId, dwContextValue );
 
-  if (h2mod->Server)
-	  return ERROR_SUCCESS;
-  if (!H2Config_discord_enable)
+  if (h2mod->Server || !H2Config_discord_enable || H2GetInstanceId() > 1)
 	  return ERROR_SUCCESS;
 
   if (dwContextId == 0x00000003)


### PR DESCRIPTION
With the hook, we most likely break the game's functionality by always returning 0, so patch the function only where needed.
Run H2X only in multiplayer and don't apply on dedicated server because the Firerate code is client side.
Run discord only on instance 1 of the game to avoid any problems that may occur.
Compiler warning fix.
Typos fix.
Added missing include guard to header file.
MouseInput Initialize now static class member.
Replaced OnMapLoad with onGameEngineChange.
Rebased with Development.
Reworked FOV code a little (to scale properly the third person camera FOV with FP).
Fixed elite_mp lights/orange glow. (Thanks Himanshu for help)