### PR TITLE
Fix crash caused by renaming the executable.

### DIFF
--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -23,6 +23,7 @@
 #include "H2Config.h"
 #include "H2Tweaks.h"
 #include "Blam\Engine\FileSystem\FiloInterface.h"
+#include "H2Startup.h"
 
 H2MOD *h2mod = new H2MOD();
 GunGame* gunGame = new GunGame();
@@ -1277,14 +1278,14 @@ void H2MOD::Initialize()
 {
 	//HANDLE hThread = CreateThread(NULL, 0, Thread1, NULL, 0, NULL);
 
-	if (GetModuleHandleA("H2Server.exe"))
+	this->Base = (DWORD)game_info.base;
+
+	if (game_info.process_type == H2Types::H2Server)
 	{
-		this->Base = (DWORD)GetModuleHandleA("H2Server.exe");
 		this->Server = TRUE;
 	}
-	else
+	else if (game_info.process_type == H2Types::H2Game)
 	{
-		this->Base = (DWORD)GetModuleHandleA("halo2.exe");
 		this->Server = FALSE;
 		//HANDLE Handle_Of_Sound_Thread = 0;
 		//int Data_Of_Sound_Thread = 1;

--- a/xlive/H2Startup.h
+++ b/xlive/H2Startup.h
@@ -6,6 +6,23 @@ void InitH2Startup2();
 void DeinitH2Startup();
 int H2GetInstanceId();
 
+enum H2Types
+{
+	H2Game,
+	H2Server,
+	Invalid
+};
+
+class ProcessInfo
+{
+
+public:
+	HMODULE base;
+	H2Types process_type = H2Types::Invalid;
+};
+
+extern ProcessInfo game_info;
+
 extern bool H2IsDediServer;
 extern DWORD H2BaseAddr;
 extern wchar_t* H2ProcessFilePath;

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -124,7 +124,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Crypt32.lib;Shlwapi.lib;Dbghelp.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;libprotobuf_release.lib;d3d9.lib;d3dx9.lib;discord/discord-rpc.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>version.lib;Crypt32.lib;Shlwapi.lib;Dbghelp.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;libprotobuf_release.lib;d3d9.lib;d3dx9.lib;discord/discord-rpc.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ModuleDefinitionFile>.\xlive.def</ModuleDefinitionFile>
@@ -174,7 +174,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Crypt32.lib;Shlwapi.lib;Dbghelp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;libprotobuf.lib;d3d9.lib;d3dx9.lib;Winmm.lib;discord/discord-rpc-debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>version.lib;Crypt32.lib;Shlwapi.lib;Dbghelp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;libprotobuf.lib;d3d9.lib;d3dx9.lib;Winmm.lib;discord/discord-rpc-debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ModuleDefinitionFile>.\xlive.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -226,7 +226,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Crypt32.lib;Shlwapi.lib;Dbghelp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;libprotobuf.lib;d3d9.lib;d3dx9.lib;Winmm.lib;discord/discord-rpc-debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>version.lib;Crypt32.lib;Shlwapi.lib;Dbghelp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;libprotobuf.lib;d3d9.lib;d3dx9.lib;Winmm.lib;discord/discord-rpc-debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ModuleDefinitionFile>.\xlive.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
The code for detecting if xlive got loaded into a server or a client now has a fallback that checks the original filename of the executable and will show an error instead of crashing if that fails.