### PR TITLE
Enable live menus only if person has Dev account.

### DIFF
--- a/xlive/GSAccountLogin.cpp
+++ b/xlive/GSAccountLogin.cpp
@@ -344,6 +344,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 				extern char* ServerStatus;
 				if (result == 4) {
 					snprintf(ServerStatus, 250, "Status: Developer");
+					extern void enableLiveMenus();
+					enableLiveMenus();
 				}
 				else if (result == 3 || result == 7) {
 					snprintf(ServerStatus, 250, "Status: CHEATER");

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -140,6 +140,14 @@ EngineType H2MOD::get_engine_type()
 	} 
 }
 
+void enableLiveMenus() {
+	*(int*)(h2mod->GetBase() + 0x422450) = 1; 
+}
+
+void disableLiveMenus() {
+	*(int*)(h2mod->GetBase() + 0x422450) = -1;
+}
+
 #pragma endregion
 
 //sub_1cce9b
@@ -1255,7 +1263,7 @@ void H2MOD::Initialize()
 
 		PatchGameDetailsCheck();
 		//H2Tweaks::PatchPingMeterCheck();
-		*(int*)(h2mod->GetBase() + 0x422450) = 1; //allows for all live menus to be accessed
+		void disableLiveMenus(); //until ready
 
 		if (H2Config_discord_enable && H2GetInstanceId() == 1) {
 			// Discord init

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -90,6 +90,8 @@ bool __cdecl call_assign_equipment_to_unit(int uint, int object_index, short unk
 int __cdecl call_object_placement_data_new(void*, int, int, int);
 signed int __cdecl call_object_new(void*);
 void GivePlayerWeapon(int PlayerIndex, int WeaponId, bool bReset);
+void enableLiveMenus();
+void disableLiveMenus();
 
 class H2MOD
 {
@@ -134,7 +136,7 @@ public:
 		std::set<int> hookedObjectDefs;
 		bool isChatBoxCommand = false;
 
-		DWORD H2MOD::GetBase() { return this->Base; }
+		DWORD GetBase() { return this->Base; }
 
 private:
 		DWORD Base;


### PR DESCRIPTION
To prevent people from accessing the live servers until they are ready. 