### PR TITLE
Added melee lunge distance patch (player_actions_update now uses h2x ...

### DIFF
--- a/xlive/GSCustomMenu.cpp
+++ b/xlive/GSCustomMenu.cpp
@@ -2949,7 +2949,7 @@ void CMSetupVFTables_AdvSettings() {
 }
 
 int __cdecl CustomMenu_AdvSettings(int a1) {
-	return CustomMenu_CallHead(a1, menu_vftable_1_AdvSettings, menu_vftable_2_AdvSettings, (DWORD)&CMButtonHandler_AdvSettings, gameManager->isHost() && h2mod->get_engine_type() == EngineType::MULTIPLAYER_ENGINE ? 5 : 4, 272);
+	return CustomMenu_CallHead(a1, menu_vftable_1_AdvSettings, menu_vftable_2_AdvSettings, (DWORD)&CMButtonHandler_AdvSettings, gameManager->isHost() && h2mod->GetEngineType() == EngineType::MULTIPLAYER_ENGINE ? 5 : 4, 272);
 }
 
 void GSCustomMenuCall_AdvSettings() {
@@ -3018,7 +3018,7 @@ static bool CMButtonHandler_AdvLobbySettings(int button_id) {
 	}
 	else if (button_id == 2) {
 		loadLabelToggle_AdvLobbySettings(button_id + 1, 0xFFFFFFF2, !(AdvLobbySettings_disable_kill_volumes = !AdvLobbySettings_disable_kill_volumes));
-		if (gameManager->isHost() && h2mod->get_engine_type() == EngineType::MULTIPLAYER_ENGINE && !AdvLobbySettings_disable_kill_volumes) {
+		if (gameManager->isHost() && h2mod->GetEngineType() == EngineType::MULTIPLAYER_ENGINE && !AdvLobbySettings_disable_kill_volumes) {
 			GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0x8, 0x9);
 		}
 		H2Tweaks::toggleKillVolumes(!AdvLobbySettings_disable_kill_volumes);
@@ -3083,7 +3083,7 @@ void* __stdcall sub_248beb_deconstructor_AdvLobbySettings(LPVOID lpMem, char a2)
 	}
 	wcsncpy(ServerLobbyName, bufferLobbyName, 32);
 
-	if (gameManager->isHost() && h2mod->get_engine_type() == EngineType::MULTIPLAYER_ENGINE) {
+	if (gameManager->isHost() && h2mod->GetEngineType() == EngineType::MULTIPLAYER_ENGINE) {
 		advLobbySettings->sendLobbySettingsPacket();
 	}
 	

--- a/xlive/GSUtils.cpp
+++ b/xlive/GSUtils.cpp
@@ -233,7 +233,7 @@ void pushHostLobby() {
 
 	addDebugText("Pushing open lobby.");
 
-	int socketDescriptor;
+	SOCKET socketDescriptor;
 	struct sockaddr_in serverAddress;
 	if ((socketDescriptor = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
 		addDebugText("ERROR: Could not create socket.");
@@ -246,6 +246,8 @@ void pushHostLobby() {
 		//returns -1 if it wasn't successful. Note that it doesn't return -1 if the connection couldn't be established (UDP)
 		addDebugText("ERROR: Failed to push open lobby.");
 	}
+
+	closesocket(socketDescriptor);
 }
 
 char* custom_label_literal(char* label_escaped) {

--- a/xlive/GUI.cpp
+++ b/xlive/GUI.cpp
@@ -97,7 +97,7 @@ LPD3DXSPRITE pSprite;
 
 std::chrono::system_clock::time_point nextFrame = std::chrono::system_clock::now();
 std::chrono::system_clock::duration desiredRenderTime = std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::duration<double>(1.0 / (double)H2Config_fps_limit));
-void frameTimeManagement()
+inline void frameTimeManagement()
 {
 	std::this_thread::sleep_until(nextFrame);
 	do {
@@ -134,10 +134,10 @@ void GUI::Initialize()
 
 }
 
-static bool has_initialised_input = false;
 // #5001
 int WINAPI XLiveInput(XLIVE_INPUT_INFO* pPii)
 {
+	static bool has_initialised_input = false;
 	if (!has_initialised_input) {
 		extern HWND H2hWnd;
 		extern RECT rectScreenOriginal;
@@ -145,6 +145,7 @@ int WINAPI XLiveInput(XLIVE_INPUT_INFO* pPii)
 		GetWindowRect(H2hWnd, &rectScreenOriginal);
 		has_initialised_input = true;
 	}
+
 	if ((GetKeyState(pPii->wParam) & 0x8000) && (pPii->uMSG == WM_KEYDOWN || pPii->uMSG == WM_SYSKEYDOWN)) {
 		//TODO: fHandled doesn't actually work..need to look into how halo2.exe uses the XLIVE_INPUT_INFO struct after calling xliveinput
 		pPii->fHandled = commands->handleInput(pPii->wParam);

--- a/xlive/GUI.cpp
+++ b/xlive/GUI.cpp
@@ -1,8 +1,6 @@
 //#include <windows.h>
 #include <d3d9.h>
 #include <d3dx9.h>
-#include <iostream>
-#include <memory>
 
 //#include <OSHGui.hpp>
 //#include <Drawing/Direct3D9/Direct3D9Renderer.hpp>
@@ -10,12 +8,10 @@
 #include "GUI.h"
 #include "H2MOD.h"
 #include "xliveless.h"
-#include "cartographer_main.hpp"
 #include "H2MOD_MapManager.h"
 #include "H2OnscreenDebugLog.h"
 #include "H2ConsoleCommands.h"
 #include "H2Config.h"
-#include <time.h>
 
 
 extern ConsoleCommands* commands;

--- a/xlive/H2Config.cpp
+++ b/xlive/H2Config.cpp
@@ -84,8 +84,6 @@ int H2Config_fps_limit = 60;
 int H2Config_static_lod_state = static_lod::cinematic;
 int H2Config_field_of_view = 0;
 float H2Config_crosshair_offset = NAN;
-int H2Config_sens_controller = 0;
-int H2Config_sens_mouse = 0;
 bool H2Config_disable_ingame_keyboard = false;
 bool H2Config_hide_ingame_chat = false;
 bool H2Config_xDelay = true;
@@ -261,14 +259,6 @@ void SaveH2Config() {
 			fputs("\n# <0 to 0.53> - NaN disables the built in Crosshair adjustment.", fileConfig);
 			fputs("\n\n", fileConfig);
 
-			fputs("# controller_sensitivity Option (Client):", fileConfig);
-			fputs("\n# <value> Change controller sensitivity to your preference.", fileConfig);
-			fputs("\n\n", fileConfig);
-
-			fputs("# mouse_sensitivity Option (Client):", fileConfig);
-			fputs("\n# <value> Change mouse sensitivity to your preference.", fileConfig);
-			fputs("\n\n", fileConfig);
-
 			fputs("# disable_ingame_keyboard Options (Client):", fileConfig);
 			fputs("\n# 0 - Normal Game Controls.", fileConfig);
 			fputs("\n# 1 - Disables ONLY Keyboard when in-game & allows controllers when game is not in focus.", fileConfig);
@@ -430,12 +420,6 @@ void SaveH2Config() {
 				sprintf(settingOutBuffer, "\ncrosshair_offset = %f", H2Config_crosshair_offset);
 				fputs(settingOutBuffer, fileConfig);
 			}
-			sprintf(settingOutBuffer, "\ncontroller_sensitivity = %d", H2Config_sens_controller);
-			fputs(settingOutBuffer, fileConfig);
-
-			sprintf(settingOutBuffer, "\nmouse_sensitivity = %d", H2Config_sens_mouse);
-			fputs(settingOutBuffer, fileConfig);
-
 			fputs("\ndisable_ingame_keyboard = ", fileConfig); fputs(H2Config_disable_ingame_keyboard ? "1" : "0", fileConfig);
 
 			fputs("\nhide_ingame_chat = ", fileConfig); fputs(H2Config_hide_ingame_chat ? "1" : "0", fileConfig);
@@ -1002,30 +986,6 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 			else {
 				H2Config_crosshair_offset = tempfloat1;
 				est_crosshair_offset = true;
-			}
-		}
-		else if (!H2IsDediServer && sscanf(fileLine, "controller_sensitivity =%d", &tempint1) == 1) {
-			if (est_sens_controller) {
-				duplicated = true;
-			}
-			else if (!(tempint1 >= 0)) {
-				incorrect = true;
-			}
-			else {
-				H2Config_sens_controller = tempint1;
-				est_sens_controller = true;
-			}
-		}
-		else if (!H2IsDediServer && sscanf(fileLine, "mouse_sensitivity =%d", &tempint1) == 1) {
-			if (est_sens_mouse) {
-				duplicated = true;
-			}
-			else if (!(tempint1 >= 0)) {
-				incorrect = true;
-			}
-			else {
-				H2Config_sens_mouse = tempint1;
-				est_sens_mouse = true;
 			}
 		}
 		else if (!H2IsDediServer && ownsConfigFile && sscanf(fileLine, "disable_ingame_keyboard =%d", &tempint1) == 1) {

--- a/xlive/H2Config.h
+++ b/xlive/H2Config.h
@@ -36,8 +36,6 @@ extern int H2Config_fps_limit;
 extern int H2Config_static_lod_state;
 extern int H2Config_field_of_view;
 extern float H2Config_crosshair_offset;
-extern int H2Config_sens_controller;
-extern int H2Config_sens_mouse;
 extern bool H2Config_disable_ingame_keyboard;
 extern bool H2Config_hide_ingame_chat;
 extern bool H2Config_xDelay;

--- a/xlive/H2ConsoleCommands.cpp
+++ b/xlive/H2ConsoleCommands.cpp
@@ -1,9 +1,5 @@
 #include "Globals.h"
-#include <Shlwapi.h>
 #include <fstream>
-#include <sstream>
-#include <string>
-#include <h2mod.pb.h>
 #include "H2Startup.h"
 #include "H2Tweaks.h"
 #include "H2Config.h"

--- a/xlive/H2ConsoleCommands.cpp
+++ b/xlive/H2ConsoleCommands.cpp
@@ -457,7 +457,7 @@ void ConsoleCommands::handle_command(std::string command) {
 			strcpy(cstr, sensVal.c_str());
 
 			if (isNum(cstr)) {
-				setSens(CONTROLLER, stoi(sensVal)); 
+				H2Tweaks::setSens(CONTROLLER, stoi(sensVal));
 				H2Config_sens_controller = stoi(sensVal);
 			}
 			else {
@@ -475,7 +475,7 @@ void ConsoleCommands::handle_command(std::string command) {
 			strcpy(cstr, sensVal.c_str());
 
 			if (isNum(cstr)) {
-				setSens(MOUSE, stoi(sensVal));
+				H2Tweaks::setSens(MOUSE, stoi(sensVal));
 				H2Config_sens_mouse = stoi(sensVal);
 			}
 			else {

--- a/xlive/H2ConsoleCommands.cpp
+++ b/xlive/H2ConsoleCommands.cpp
@@ -458,7 +458,6 @@ void ConsoleCommands::handle_command(std::string command) {
 
 			if (isNum(cstr)) {
 				H2Tweaks::setSens(CONTROLLER, stoi(sensVal));
-				H2Config_sens_controller = stoi(sensVal);
 			}
 			else {
 				output(L"Wrong input! Use a number.");
@@ -476,7 +475,6 @@ void ConsoleCommands::handle_command(std::string command) {
 
 			if (isNum(cstr)) {
 				H2Tweaks::setSens(MOUSE, stoi(sensVal));
-				H2Config_sens_mouse = stoi(sensVal);
 			}
 			else {
 				output(L"Wrong input! Use a number.");

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1165,11 +1165,13 @@ std::string JOIN_GAME_OF_HALO2 = "Join a game of Halo 2.";
 
 BYTE* __cdecl unicodeStringConversion(BYTE* nonUnicodeStr, BYTE* unicodeStr, int size) {
 	char* str = (char*)(nonUnicodeStr);
-	if (strcmp(str, CREATE_NEW_NETWORK_GAME_STR.c_str()) == 0 && replacedNetworkNormalTextWidget != NULL) {
-		return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget, unicodeStr, size);
-	}
-	if (strcmp(str, JOIN_GAME_OF_HALO2.c_str()) == 0 && replacedNetworkNormalTextWidget2 != NULL) {
-		return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget2, unicodeStr, size);
+	if (*(DWORD*)(h2mod->GetBase() + 0x96743C) + (0xAA8 * 0)) {
+		if (strcmp(str, CREATE_NEW_NETWORK_GAME_STR.c_str()) == 0 && replacedNetworkNormalTextWidget != NULL) {
+			return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget, unicodeStr, size);
+		}
+		if (strcmp(str, JOIN_GAME_OF_HALO2.c_str()) == 0 && replacedNetworkNormalTextWidget2 != NULL) {
+			return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget2, unicodeStr, size);
+		}
 	}
 	return unicode_string_conversion_method(nonUnicodeStr, unicodeStr, size);
 }

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1,30 +1,17 @@
 #include <stdafx.h>
-#include <windows.h>
 #include <Wincrypt.h>
-#include <iostream>
-#include <sstream>
-#include <codecvt>
 #include "H2MOD.h"
 #include "H2MOD_Mouseinput.h"
 #include "H2MOD_H2X.h"
 #include "H2MOD_GunGame.h"
-#include "H2MOD_Infection.h"
-#include "H2MOD_Halo2Final.h"
-#include "Network.h"
-#include "xliveless.h"
 #include "CUser.h"
 #include <Mmsystem.h>
-#include <thread>
-#include "Globals.h"
 #include "H2OnscreenDebugLog.h"
-#include "GSUtils.h"
-#include <Mmsystem.h>
 #include "discord/DiscordInterface.h"
 #include "H2Config.h"
 #include "H2Tweaks.h"
 #include "Blam\Engine\FileSystem\FiloInterface.h"
 #include "H2Startup.h"
-#include "GSCustomMenu.h"
 #include "MapChecksumSync.h"
 
 H2MOD *h2mod = new H2MOD();

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -679,7 +679,7 @@ void __stdcall OnPlayerScore(void* thisptr, unsigned short a2, int a3, int a4, i
 
 void PatchGameDetailsCheck()
 {
-	NopFill(h2mod->GetBase() + 0x219D6D, 2);
+	NopFill<2>(h2mod->GetBase() + 0x219D6D);
 }
 
 void H2MOD::PatchWeaponsInteraction(bool b_Enable)
@@ -1236,7 +1236,7 @@ void H2MOD::ApplyHooks() {
 		VirtualProtect(calls_session_boot_method, 4, PAGE_EXECUTE_READWRITE, &dwBack);
 
 		// disable part of custom map tag verification
-		NopFill(GetBase() + 0x4FA0A, 6);
+		NopFill<6>(GetBase() + 0x4FA0A);
 
 		pjoin_game = (tjoin_game)DetourClassFunc((BYTE*)this->GetBase() + 0x1CDADE, (BYTE*)join_game, 13);
 		VirtualProtect(pjoin_game, 4, PAGE_EXECUTE_READWRITE, &dwBack);
@@ -1294,9 +1294,9 @@ void H2MOD::ApplyHooks() {
 
 		// Patch out the code that displays the "Invalid Checkpoint" error
 		// Start
-		NopFill(GetBase() + 0x30857, 0x41);
+		NopFill<0x41>(GetBase() + 0x30857);
 		// Respawn
-		NopFill(GetBase() + 0x8BB98, 0x2b);
+		NopFill<0x2b>(GetBase() + 0x8BB98);
 
 		change_team_method = (change_team)DetourFunc((BYTE*)this->GetBase() + 0x2068F2, (BYTE*)changeTeam, 8);
 		VirtualProtect(change_team_method, 4, PAGE_EXECUTE_READWRITE, &dwBack);
@@ -1319,11 +1319,6 @@ void H2MOD::ApplyHooks() {
 		PatchCall(Base + 0x00182d6d, GrenadeChainReactIsEngineMPCheck);
 		PatchCall(Base + 0x00092C05, BansheeBombIsEngineMPCheck);
 		PatchCall(Base + 0x0013ff75, FlashlightIsEngineSPCheck);
-		
-		// Fixes issue #118
-		/* g_depth_bias always NULL rather than taking any value from 
-		   shader tag before calling g_D3DDevice->SetRenderStatus(D3DRS_DEPTHBIAS, g_depth_bias); */
-		NopFill(GetBase() + 0x269FD5, 0x8);
 	}
 	else {
 
@@ -1349,7 +1344,7 @@ void H2MOD::ApplyHooks() {
 		VirtualProtect(pupdate_player_score, 4, PAGE_EXECUTE_READWRITE, &dwBack);//
 		
 		// disable part of custom map tag verification
-		NopFill(GetBase() + 0x56C0A, 6);
+		NopFill<6>(GetBase() + 0x56C0A);
 
 		pplayer_death = (player_death)DetourFunc((BYTE*)this->GetBase() + 0x152ED4, (BYTE*)OnPlayerDeath, 9);
 		VirtualProtect(pplayer_death, 4, PAGE_EXECUTE_READWRITE, &dwBack);

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -793,6 +793,7 @@ void __cdecl onGameEngineChange(int a1)
 		H2Tweaks::setCrosshairPos(H2Config_crosshair_offset);
 	 
 		H2Tweaks::setCrosshairSize(0, false);
+		H2Tweaks::disable60FPSCutscenes(); 
 		
 		//H2Tweaks::applyShaderTweaks(); 
 

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -215,7 +215,7 @@ bool __stdcall create_unit_hook(void* pCreationData, int a2, int a3, void* pObje
 	return pcreate_unit_hook(pCreationData, a2, a3, pObject);
 }
 
-EngineType H2MOD::get_engine_type()
+EngineType H2MOD::GetEngineType()
 {
 	DWORD GameGlobals = *(DWORD*)(h2mod->GetBase() + ((h2mod->Server) ? 0x4CB520 : 0x482D3C));
 

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1165,13 +1165,11 @@ std::string JOIN_GAME_OF_HALO2 = "Join a game of Halo 2.";
 
 BYTE* __cdecl unicodeStringConversion(BYTE* nonUnicodeStr, BYTE* unicodeStr, int size) {
 	char* str = (char*)(nonUnicodeStr);
-	if (*(DWORD*)(h2mod->GetBase() + 0x96743C) + (0xAA8 * 0)) {
-		if (strcmp(str, CREATE_NEW_NETWORK_GAME_STR.c_str()) == 0 && replacedNetworkNormalTextWidget != NULL) {
-			return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget, unicodeStr, size);
-		}
-		if (strcmp(str, JOIN_GAME_OF_HALO2.c_str()) == 0 && replacedNetworkNormalTextWidget2 != NULL) {
-			return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget2, unicodeStr, size);
-		}
+	if (strcmp(str, CREATE_NEW_NETWORK_GAME_STR.c_str()) == 0 && replacedNetworkNormalTextWidget != NULL) {
+		return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget, unicodeStr, size);
+	}
+	if (strcmp(str, JOIN_GAME_OF_HALO2.c_str()) == 0 && replacedNetworkNormalTextWidget2 != NULL) {
+		return unicode_string_conversion_method((BYTE*)replacedNetworkNormalTextWidget2, unicodeStr, size);
 	}
 	return unicode_string_conversion_method(nonUnicodeStr, unicodeStr, size);
 }

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -135,6 +135,7 @@ public:
 		void DisableSound(int sound);
 		void PatchWeaponsInteraction(bool b_Enable);		
 		void securityPacketProcessing();
+		void ApplyUnitHooks();
 		EngineType GetEngineType();
 		wchar_t* GetLobbyGameVariantName();
 		void exit_game();

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -132,7 +132,8 @@ public:
 		void DisableSound(int sound);
 		void PatchWeaponsInteraction(bool b_Enable);		
 		void securityPacketProcessing();
-		EngineType get_engine_type();
+		EngineType GetEngineType();
+		wchar_t* GetLobbyGameVariantName();
 		void exit_game();
 		BOOL Server;
 		std::unordered_map<wchar_t*, int> SoundMap;

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -6,6 +6,9 @@
 #include <mutex>
 #include "Blam\Enums\Game\GameEngine.h"
 
+constexpr int XLIVE_VERSION = 4; // I don't recommend changing this
+constexpr int GAME_BUILD = 11122;
+
 enum GrenadeType
 {
 	Frag = 0,

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -9,6 +9,8 @@
 constexpr int XLIVE_VERSION = 4; // I don't recommend changing this
 constexpr int GAME_BUILD = 11122;
 
+constexpr signed int NONE = -1;
+
 enum GrenadeType
 {
 	Frag = 0,

--- a/xlive/H2MOD_AdvLobbySettings.cpp
+++ b/xlive/H2MOD_AdvLobbySettings.cpp
@@ -1,9 +1,6 @@
 #include "H2MOD_AdvLobbySettings.h"
-#include <h2mod.pb.h>
 #include "Globals.h"
 #include "H2OnscreenDebugLog.h"
-#include "GSCustomMenu.h"
-#include "H2Tweaks.h"
 
 bool AdvLobbySettings_mp_explosion_physics = false;
 bool AdvLobbySettings_mp_sputnik = false;

--- a/xlive/H2MOD_AdvLobbySettings.cpp
+++ b/xlive/H2MOD_AdvLobbySettings.cpp
@@ -26,7 +26,7 @@ static std::chrono::time_point<std::chrono::system_clock> lastReq;
 static std::chrono::time_point<std::chrono::system_clock> firstReq;
 
 static void actuallySendPacket() {
-	if (!gameManager->isHost() || h2mod->get_engine_type() != EngineType::MULTIPLAYER_ENGINE)
+	if (!gameManager->isHost() || h2mod->GetEngineType() != EngineType::MULTIPLAYER_ENGINE)
 		return;
 
 	TRACE_GAME("[h2mod] Sending AdvLobbySettings.");
@@ -63,7 +63,7 @@ static void actuallySendPacket() {
 
 void AdvLobbySettings::sendLobbySettingsPacket()
 {
-	if (!gameManager->isHost() || h2mod->get_engine_type() != EngineType::MULTIPLAYER_ENGINE)
+	if (!gameManager->isHost() || h2mod->GetEngineType() != EngineType::MULTIPLAYER_ENGINE)
 		return;
 	
 	lastReq = std::chrono::system_clock::now() + std::chrono::milliseconds(4000);

--- a/xlive/H2MOD_GunGame.cpp
+++ b/xlive/H2MOD_GunGame.cpp
@@ -1,22 +1,22 @@
 #include "Globals.h"
 #include <h2mod.pb.h>
 
-extern int weapon_one;
-extern int weapon_two;
-extern int weapon_three;
-extern int weapon_four;
-extern int weapon_five;
-extern int weapon_six;
-extern int weapon_seven;
-extern int weapon_eight;
-extern int weapon_nine;
-extern int weapon_ten;
-extern int weapon_eleven;
-extern int weapon_tweleve;
-extern int weapon_thirteen;
-extern int weapon_fourteen;
-extern int weapon_fiffteen;
-extern int weapon_sixteen;
+static int weapon_one = 0;
+static int weapon_two = 0;
+static int weapon_three = 0;
+static int weapon_four = 0;
+static int weapon_five = 0;
+static int weapon_six = 0;
+static int weapon_seven = 0;
+static int weapon_eight = 0;
+static int weapon_nine = 0;
+static int weapon_ten = 0;
+static int weapon_eleven = 0;
+static int weapon_tweleve = 0;
+static int weapon_thirteen = 0;
+static int weapon_fourteen = 0;
+static int weapon_fiffteen = 0;
+static int weapon_sixteen = 0;
 
 std::unordered_map<int, int> GunGame::level_weapon;
 std::unordered_map<std::wstring, int> GunGame::gungamePlayers;
@@ -41,6 +41,51 @@ GunGame::GunGame()
 	this->spawnPlayer = new GunGameSpawnHandler();
 	this->playerDeath = new GunGameDeathHandler();
 	this->playerKill = new GunGameKillHandler();
+}
+
+void GunGame::readWeaponLevels()
+{
+	FILE* gfp;
+	gfp = fopen("gungame.ini", "r");
+
+	if (gfp)
+	{
+		TRACE("[GunGame Enabled] - Opened GunGame.ini!");
+		while (!feof(gfp))
+		{
+			char gstr[256];
+
+			fgets(gstr, 256, gfp);
+
+			gCHECK_ARG("weapon_one =", weapon_one);
+			gCHECK_ARG("weapon_two =", weapon_two);
+			gCHECK_ARG("weapon_three =", weapon_three);
+			gCHECK_ARG("weapon_four =", weapon_four);
+			gCHECK_ARG("weapon_five =", weapon_five);
+			gCHECK_ARG("weapon_six =", weapon_six);
+			gCHECK_ARG("weapon_seven =", weapon_seven);
+			gCHECK_ARG("weapon_eight =", weapon_eight);
+			gCHECK_ARG("weapon_nine =", weapon_nine);
+			gCHECK_ARG("weapon_ten =", weapon_ten);
+			gCHECK_ARG("weapon_eleven =", weapon_eleven);
+			gCHECK_ARG("weapon_tweleve =", weapon_tweleve);
+			gCHECK_ARG("weapon_thirteen =", weapon_thirteen);
+			gCHECK_ARG("weapon_fourteen =", weapon_fourteen);
+			gCHECK_ARG("weapon_fifteen =", weapon_fiffteen);
+			gCHECK_ARG("weapon_sixteen =", weapon_sixteen);
+
+		}
+
+#ifdef __DEBUG
+		TRACE("[GunGame] : %i", b_GunGame);
+
+		TRACE("[GunGame] - weapon_one: %i", weapon_one);
+		TRACE("[GunGame] - weapon_two: %i", weapon_two);
+		TRACE("[GunGame] - weapon_three: %i", weapon_three);
+#endif
+
+		fclose(gfp);
+	}
 }
 
 void GunGame::initWeaponLevels() {
@@ -198,8 +243,6 @@ void GunGame::sendGrenadePacket(BYTE type, BYTE count, int pIndex, bool bReset)
 		if (type == GrenadeType::Frag)
 		{
 			*(BYTE*)((BYTE*)unit_object + 0x252) = count;
-
-
 		}
 		if (type == GrenadeType::Plasma)
 		{

--- a/xlive/H2MOD_GunGame.h
+++ b/xlive/H2MOD_GunGame.h
@@ -62,6 +62,7 @@ class GunGame : public GameType<GunGameHandler>
 {
 public:
 	GunGame();
+	static void readWeaponLevels();
 	static void initWeaponLevels();
 	static void spawnPlayerServer(int playerIndex);
 	static void playerDiedServer(int unit_datum_index); // We need to start using PlayerIndex here for sanity.
@@ -71,4 +72,6 @@ public:
 
 	static std::unordered_map<int, int> level_weapon;
 	static std::unordered_map<std::wstring, int> gungamePlayers;
+
+	~GunGame() {  };
 };

--- a/xlive/H2MOD_H2X.cpp
+++ b/xlive/H2MOD_H2X.cpp
@@ -1,6 +1,5 @@
 #include <Windows.h>
 #include "H2MOD_H2X.h"
-#include "xliveless.h"
 #include "H2MOD.h"
 
 void H2X::Initialize()

--- a/xlive/H2MOD_Mouseinput.cpp
+++ b/xlive/H2MOD_Mouseinput.cpp
@@ -1,8 +1,6 @@
 #include "H2MOD_Mouseinput.h"
 #include <Windows.h>
 #include "H2MOD.h"
-#include "xliveless.h"
-#include "Hook.h"
 
 typedef struct DIMOUSESTATE {
 	LONG lX;

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -975,7 +975,6 @@ void InitH2Tweaks() {
 	}	
   
 	// Both server and client
-	}
 	WriteJmpTo(GetAddress(0x1467, 0x12E2), is_supported_build);
 	PatchCall(GetAddress(0x1E49A2, 0x1EDF0), validate_and_add_custom_map);
 	PatchCall(GetAddress(0x4D3BA, 0x417FE), validate_and_add_custom_map);

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -1143,7 +1143,7 @@ void H2Tweaks::setCrosshairSize(int size, bool preset) {
 		
 		for (int i = 0; i < 28; i++) {
 			if (configArray[i] == 0) {
-				*(int*)WEAPONS[i] = disabled[i];
+				*reinterpret_cast<short*>(WEAPONS[i]) = disabled[i];
 			}
 			else if (*configArray[i] == 1 || *configArray[i] < 0 || *configArray[i] > 65535) {
 				*reinterpret_cast<short*>(WEAPONS[i]) = defaultSize[i];

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -259,7 +259,7 @@ enum flags : int
 	unk11, // some tag thing?
 	unk12, // seen near xlive init code
 	unk13,
-	xbox_live_silver_account, // if true, disables 'gold-only' features, like quickmath etc
+	xbox_live_silver_account, // if true, disables 'gold-only' features, like quickmatch etc
 	unk15, // fuzzer/automated testing? (sapien)
 	ui_fast_test_no_start, // same as below but doesn't start a game
 	ui_fast_test, // auto navigates the UI selecting the default option

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -1138,7 +1138,7 @@ void H2Tweaks::setCrosshairSize(int size, bool preset) {
 	}
 
 
-	if (h2mod->get_engine_type() == EngineType::MULTIPLAYER_ENGINE) {
+	if (h2mod->GetEngineType() == EngineType::MULTIPLAYER_ENGINE) {
 
 		
 		for (int i = 0; i < 28; i++) {
@@ -1322,7 +1322,7 @@ void H2Tweaks::FixRanksIcons() {
 	const WORD height_value = 0x0020;			//Value : 32 (decimal)
 
 
-	if (h2mod->get_engine_type() == EngineType::MAIN_MENU_ENGINE) {
+	if (h2mod->GetEngineType() == EngineType::MAIN_MENU_ENGINE) {
 		//Sets Pregame Lobby 
 		WriteValue(shared_Meta_Data_ptr + tag_offset_pre + (index_number * index_offset_p) + x_pos_off, x_pos_pre);
 		WriteValue(shared_Meta_Data_ptr + tag_offset_pre + (index_number * index_offset_p) + y_pos_off, y_pos_pre);

--- a/xlive/H2Tweaks.cpp
+++ b/xlive/H2Tweaks.cpp
@@ -259,7 +259,7 @@ enum flags : int
 	unk11, // some tag thing?
 	unk12, // seen near xlive init code
 	unk13,
-	unk14, // maybe UI?
+	xbox_live_silver_account, // if true, disables 'gold-only' features, like quickmath etc
 	unk15, // fuzzer/automated testing? (sapien)
 	ui_fast_test_no_start, // same as below but doesn't start a game
 	ui_fast_test, // auto navigates the UI selecting the default option
@@ -1388,6 +1388,5 @@ __declspec(naked) void calculate_delta_time(void)
 void H2Tweaks::applyPlayersActionsUpdateRatePatch()
 {
 	xb_tickrate_flt = GetAddress<float>(0x3BBEB4, 0x378C84);
-
 	PatchCall(GetAddress(0x1E12FB, 0x1C8327), calculate_delta_time); // inside update_player_actions()
 }

--- a/xlive/H2Tweaks.h
+++ b/xlive/H2Tweaks.h
@@ -8,7 +8,7 @@ enum InputType
 
 void InitH2Tweaks();
 void DeinitH2Tweaks();
-void setSens(short input_type, int sens);
+
 
 namespace H2Tweaks {
 	void toggleKillVolumes(bool enable);
@@ -24,4 +24,6 @@ namespace H2Tweaks {
 	void setCrosshairPos(float crosshair_offset);
 	void setCrosshairSize(int size, bool preset);
 	void RadarPatch();
+	void applyPlayersActionsUpdateRatePatch();
+	void setSens(InputType input_type, int sens);
 }

--- a/xlive/Hook.h
+++ b/xlive/Hook.h
@@ -45,13 +45,6 @@ inline void WriteValue(DWORD offset, value_type data)
 	WriteBytes(offset, &data, sizeof(data));
 }
 
-#define J( symbol1, symbol2 ) _DO_JOIN( symbol1, symbol2 )
-#define _DO_JOIN( symbol1, symbol2 ) symbol1##symbol2
-#define NopFill(Address, len)                       \
-	BYTE J(NopFIll_, __LINE__ )[len];               \
-	std::fill_n(J(NopFIll_, __LINE__ ), len, 0x90); \
-	WriteBytes(Address, J(NopFIll_, __LINE__ ), len)
-
 inline void WriteJmpTo(DWORD call_addr, DWORD new_function_ptr)
 {
 	BYTE call_patch[1] = { 0xE9 };
@@ -67,4 +60,12 @@ inline void WriteJmpTo(DWORD call_addr, void *new_function_ptr)
 inline void WriteJmpTo(void *call_addr, void *new_function_ptr)
 {
 	WriteJmpTo(reinterpret_cast<DWORD>(call_addr), reinterpret_cast<DWORD>(new_function_ptr));
+}
+
+template<int len>
+inline void NopFill(DWORD address)
+{
+	BYTE bytesArray[len];
+	memset(bytesArray, 0x90, len);
+	WriteBytes(address, bytesArray, len);
 }

--- a/xlive/MapChecksumSync.cpp
+++ b/xlive/MapChecksumSync.cpp
@@ -231,7 +231,7 @@ void MapChecksumSync::RuntimeError(error_id type)
 void MapChecksumSync::SendState()
 {
 	TRACE_FUNC_N("gameManager->isHost() %d", gameManager->isHost());
-	TRACE_FUNC_N("h2mod->get_engine_type() %d", h2mod->get_engine_type());
+	TRACE_FUNC_N("h2mod->GetEngineType() %d", h2mod->GetEngineType());
 	if (!gameManager->isHost())
 		return;
 	H2ModPacket packet;

--- a/xlive/MapChecksumSync.cpp
+++ b/xlive/MapChecksumSync.cpp
@@ -1,14 +1,6 @@
 #include "MapChecksumSync.h"
-#include "stdafx.h"
-#include "Hook.h"
-#include "Util/hash.h"
-#include <string>
-#include <unordered_map>
 #include <unordered_set>
-#include <mutex>
 #include "Globals.h"
-#include <iomanip>
-#include "Util/filesys.h"
 
 extern bool H2IsDediServer;
 extern DWORD H2BaseAddr;

--- a/xlive/Project_Cartographer.vcxproj.user
+++ b/xlive/Project_Cartographer.vcxproj.user
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LocalDebuggerDebuggerType>NativeOnly</LocalDebuggerDebuggerType>

--- a/xlive/dllmain.cpp
+++ b/xlive/dllmain.cpp
@@ -4,6 +4,7 @@
 #include "H2ConsoleCommands.h"
 #include "ReadIniArguments.h"
 #include "Detour.h"
+#include "H2MOD_GunGame.h"
 
 extern ConsoleCommands* commands;
 
@@ -20,26 +21,6 @@ XUID xFakeXuid[4] = { 0xEE100000DEADC0DE, 0xEE200000DEADC0DE, 0xEE300000DEADC0DE
 //CHAR g_profileDirectory[512] = "Profiles";
 
 std::wstring dlcbasepath;
-
-#pragma region H2 GunGame Variables
-	bool b_GunGame = 0;
-	int weapon_one = 0;
-	int weapon_two = 0;
-	int weapon_three = 0;
-	int weapon_four = 0;
-	int weapon_five = 0;
-	int weapon_six = 0;
-	int weapon_seven = 0;
-	int weapon_eight = 0;
-	int weapon_nine = 0;
-	int weapon_ten = 0;
-	int weapon_eleven = 0;
-	int weapon_tweleve = 0;
-	int weapon_thirteen = 0;
-	int weapon_fourteen = 0;
-	int weapon_fiffteen = 0;
-	int weapon_sixteen = 0;
-#pragma endregion
 
 std::string ModulePathA(HMODULE hModule = NULL)
 {
@@ -77,63 +58,13 @@ void InitInstance()
 
 		dlcbasepath = L"DLC";
 
-#pragma region GunGame Levels
-		if (b_GunGame == 1)
-		{
-			FILE* gfp;
-			gfp = fopen("gungame.ini", "r");
-
-			if (gfp)
-			{
-				TRACE("[GunGame Enabled] - Opened GunGame.ini!");
-				while (!feof(gfp))
-				{
-					char gstr[256];
-
-					fgets(gstr, 256, gfp);
-
-					gCHECK_ARG("weapon_one =", weapon_one);
-					gCHECK_ARG("weapon_two =", weapon_two);
-					gCHECK_ARG("weapon_three =", weapon_three);
-					gCHECK_ARG("weapon_four =", weapon_four);
-					gCHECK_ARG("weapon_five =", weapon_five);
-					gCHECK_ARG("weapon_six =", weapon_six);
-					gCHECK_ARG("weapon_seven =", weapon_seven);
-					gCHECK_ARG("weapon_eight =", weapon_eight);
-					gCHECK_ARG("weapon_nine =", weapon_nine);
-					gCHECK_ARG("weapon_ten =", weapon_ten);
-					gCHECK_ARG("weapon_eleven =", weapon_eleven);
-					gCHECK_ARG("weapon_tweleve =", weapon_tweleve);
-					gCHECK_ARG("weapon_thirteen =", weapon_thirteen);
-					gCHECK_ARG("weapon_fourteen =", weapon_fourteen);
-					gCHECK_ARG("weapon_fifteen =", weapon_fiffteen);
-					gCHECK_ARG("weapon_sixteen =", weapon_sixteen);
-
-				}
-
-				fclose(gfp);
-			}
-		}
-
-#pragma endregion
-
 		if (h2mod)
 			h2mod->Initialize();
 		else
 			TRACE("H2MOD Failed to intialize");
 
-		TRACE("[GunGame] : %i", b_GunGame);
-		if (b_GunGame == 1)
-		{
-			TRACE("[GunGame] - weapon_one: %i", weapon_one);
-			TRACE("[GunGame] - weapon_two: %i", weapon_two);
-			TRACE("[GunGame] - weapon_three: %i", weapon_three);
-		}
-
-		WCHAR gameName[256];
-
-		GetModuleFileNameW(NULL, (LPWCH)&gameName, sizeof(gameName));
-		TRACE("%s", gameName);
+		extern GunGame* gunGame;
+		gunGame->readWeaponLevels();
 
 		//extern void LoadAchievements();
 		//LoadAchievements();

--- a/xlive/dllmain.cpp
+++ b/xlive/dllmain.cpp
@@ -1,22 +1,11 @@
 #include "stdafx.h"
-#include <io.h>
-#include <fcntl.h>
 #include "H2MOD.h"
-#include <iostream>
-#include <Shellapi.h>
 #include "H2Startup.h"
-#include "H2OnscreenDebugLog.h"
-#include "GSRunLoop.h"
 #include "H2ConsoleCommands.h"
-#include "H2Config.h"
-#include <sstream>
 #include "ReadIniArguments.h"
+#include "Detour.h"
 
 extern ConsoleCommands* commands;
-
-using namespace std;
-
-#include "Detour.h"
 
 HMODULE hThis = NULL;
 

--- a/xlive/xlive.def
+++ b/xlive/xlive.def
@@ -106,7 +106,7 @@ EXPORTS
 	XLiveUpdateSystem						@5024	
 	XLiveGetLiveIdError						@5025
 	XLiveSetSponsorToken					@5026	
-	XLiveSecureLoadLibraryW					@5028	
+	XLiveLoadLibraryEx					    @5028	
 	XLiveSecureFreeLibrary					@5029	
 	XLivePreTranslateMessage				@5030	
 	XLiveSetDebugLevel						@5031	

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -2941,8 +2941,8 @@ enum class ContextPresence {
 	lobby,
 	results,
 	live_in_game,
-	public_game, /* Not sure about this.. */
-	invite_only_game, /* and this one. */
+	public_game, 
+	invite_only_game, 
 	network_in_game
 };
 

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -2997,26 +2997,13 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
 		case ContextPresence::public_game:
 		case ContextPresence::invite_only_game:
 		case ContextPresence::network_in_game:
-		{
-			int game_engine_type = *reinterpret_cast<BYTE*>(GameEngineGlobals + 0xC54);
-
-			DiscordInterface::SetGameState(
-				map_name,
-				"Multiplayer - LAN",
-				getEnglishMapName(),
-				gamemode_id_to_string(game_engine_type),
-				getVariantName()
-			);
-			update_player_count();
-			break;
-		}
 		case ContextPresence::live_in_game:
 		{
 			int game_engine_type = *reinterpret_cast<BYTE*>(GameEngineGlobals + 0xC54);
 
 			DiscordInterface::SetGameState(
 				map_name,
-				"Multiplayer - LIVE",
+				"Multiplayer",
 				getEnglishMapName(),
 				gamemode_id_to_string(game_engine_type),
 				getVariantName()

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -918,10 +918,6 @@ int WINAPI XNetDnsRelease (void * pxndns)
 PBYTE pb_data;
 UINT cb_data;
 
-//if (comm_socket == INVALID_SOCKET)
-//{
-//	comm_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-
 // #69: XNetQosListen
 DWORD WINAPI XNetQosListen( XNKID *pxnkid, PBYTE pb, UINT cb, DWORD dwBitsPerSec, DWORD dwFlags )
 {
@@ -4687,9 +4683,6 @@ DWORD WINAPI XLivePBufferSetByte (FakePBuffer * pBuffer, DWORD offset, BYTE valu
 	}
 
 	pBuffer->pbData[offset] = value;
-
-	if (offset == 0)
-		pBuffer->pbData[offset] = 0; //no need of MF.dll anymore
 
 	return 0;
 }

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -2994,6 +2994,8 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
 			);
 			break;
 		}
+		case ContextPresence::public_game:
+		case ContextPresence::invite_only_game:
 		case ContextPresence::network_in_game:
 		{
 			int game_engine_type = *reinterpret_cast<BYTE*>(GameEngineGlobals + 0xC54);
@@ -3041,14 +3043,6 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
 		case ContextPresence::results:
 		{
 			DiscordInterface::SetGameState("default", "Reading carnage report", true);
-			break;
-		}
-		case ContextPresence::public_game:
-		{
-			break;
-		}
-		case ContextPresence::invite_only_game:
-		{
 			break;
 		}
 	}

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -5322,20 +5322,19 @@ DWORD WINAPI XMarketplaceGetImageUrl( char *a1, DWORD a2, DWORD a3, DWORD a4, WC
 
 
 // 5028: ??
-DWORD WINAPI XLiveSecureLoadLibraryW( LPCWSTR libFileName, DWORD a2, DWORD dwFlags )
+DWORD WINAPI XLiveLoadLibraryEx(LPCWSTR libFileName, HINSTANCE *a2, DWORD dwFlags)
 {
-  TRACE("XLiveSecureLoadLibraryW  (?? - FIXME)  (libFileName = %s, a2 = %X, flags = %X)",
-		libFileName, a2, dwFlags );
+	TRACE("XLiveSecureLoadLibraryEx (?? - FIXME)  (libFileName = %s, a2 = %X, flags = %X)",
+		libFileName, a2, dwFlags);
 
+	HINSTANCE hInstance = LoadLibraryExW(libFileName, NULL, dwFlags);
 
-	// not done - error now
-  return 0x80070032;
+	if (!hInstance)
+		return 0x80070057;
+
+	*a2 = hInstance;
+	return 0;
 }
-
-
-// 5230: ??
-
-
 
 // 5231: ??
 DWORD WINAPI XLocatorServerUnAdvertise( DWORD a1, DWORD a2 )

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -5324,7 +5324,7 @@ DWORD WINAPI XMarketplaceGetImageUrl( char *a1, DWORD a2, DWORD a3, DWORD a4, WC
 // 5028: ??
 DWORD WINAPI XLiveLoadLibraryEx(LPCWSTR libFileName, HINSTANCE *a2, DWORD dwFlags)
 {
-	TRACE("XLiveSecureLoadLibraryEx (?? - FIXME)  (libFileName = %s, a2 = %X, flags = %X)",
+	TRACE("XLiveLoadLibraryEx (?? - FIXME)  (libFileName = %s, a2 = %X, flags = %X)",
 		libFileName, a2, dwFlags);
 
 	HINSTANCE hInstance = LoadLibraryExW(libFileName, NULL, dwFlags);

--- a/xlive/xliveless.cpp
+++ b/xlive/xliveless.cpp
@@ -2940,9 +2940,10 @@ enum class ContextPresence {
 	singleplayer,
 	lobby,
 	results,
-	public_game = 7,
-	invite_only_game,
-	closed_game
+	live_in_game,
+	public_game, /* Not sure about this.. */
+	invite_only_game, /* and this one. */
+	network_in_game
 };
 
 DWORD diff_level;
@@ -2993,15 +2994,27 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
 			);
 			break;
 		}
-		case ContextPresence::public_game:
-		case ContextPresence::invite_only_game:
-		case ContextPresence::closed_game:
+		case ContextPresence::network_in_game:
 		{
 			int game_engine_type = *reinterpret_cast<BYTE*>(GameEngineGlobals + 0xC54);
 
 			DiscordInterface::SetGameState(
 				map_name,
-				"Multiplayer",
+				"Multiplayer - LAN",
+				getEnglishMapName(),
+				gamemode_id_to_string(game_engine_type),
+				getVariantName()
+			);
+			update_player_count();
+			break;
+		}
+		case ContextPresence::live_in_game:
+		{
+			int game_engine_type = *reinterpret_cast<BYTE*>(GameEngineGlobals + 0xC54);
+
+			DiscordInterface::SetGameState(
+				map_name,
+				"Multiplayer - LIVE",
 				getEnglishMapName(),
 				gamemode_id_to_string(game_engine_type),
 				getVariantName()
@@ -3028,6 +3041,14 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
 		case ContextPresence::results:
 		{
 			DiscordInterface::SetGameState("default", "Reading carnage report", true);
+			break;
+		}
+		case ContextPresence::public_game:
+		{
+			break;
+		}
+		case ContextPresence::invite_only_game:
+		{
 			break;
 		}
 	}


### PR DESCRIPTION
…float to calculate time delta)

Moved NopFill in it's own function rather than using macros because it was causing compilation issues.
Depth-bias fix now as an optional thing (command line argument "-depthbiasfix").
Some misc code changes.
Make use of different game version screen for dev preview/general testing.
Implemented XLiveLoadLibraryEx.
Cleaned code by removing unused includes from various cpp files.
Leave higher sensitivity options optional.
Fixed issue where gungame levels wouldn't be read from ini file.
Fixed issue where rich presence wouldn't update details inside LIVE game (in-game).
Added missing dedi offsets for unit hooks.