### PR TITLE
[Console] Fix crashes on pasting and return correct error code for `XLiveInput`

### DIFF
--- a/xlive/H2MOD/GUI/GUI.cpp
+++ b/xlive/H2MOD/GUI/GUI.cpp
@@ -165,7 +165,7 @@ int WINAPI XLiveInput(XLIVE_INPUT_INFO* pPii)
 		//TODO: fHandled doesn't actually work..need to look into how halo2.exe uses the XLIVE_INPUT_INFO struct after calling xliveinput
 		pPii->fHandled = commands->handleInput(pPii->wParam);
 	}
-	return 1;
+	return S_OK;
 }
 
 // #5030: XLivePreTranslateMessage

--- a/xlive/H2MOD/Modules/Console/ConsoleCommands.cpp
+++ b/xlive/H2MOD/Modules/Console/ConsoleCommands.cpp
@@ -5,6 +5,7 @@
 #include "H2MOD\Modules\Config\Config.h"
 #include "Blam/BlamLibrary.h"
 #include "H2MOD\Modules\CustomMenu\Credits.h"
+#include "Util\ClipboardAPI.h"
 
 
 std::wstring ERROR_OPENING_CLIPBOARD(L"Error opening clipboard");
@@ -73,17 +74,12 @@ BOOL ConsoleCommands::handleInput(WPARAM wp) {
 		{
 			//read 'V' before 'CTRL'
 			if (console && (GetAsyncKeyState(VK_CONTROL) & 0x8000)) {
-				if (!OpenClipboard(NULL)) {
+
+				std::string clipboardContent;
+				if (!ClipboardAPI::read(clipboardContent)) {
 					output(ERROR_OPENING_CLIPBOARD);
 					return false;
 				}
-
-				HANDLE clipboardHandle = GetClipboardData(CF_TEXT);
-				//lock the clipboard
-				std::string clipboardContent = (LPSTR)GlobalLock(clipboardHandle);
-				//unlock  the clipboard
-				GlobalUnlock(clipboardHandle);
-				CloseClipboard();
 				this->command += clipboardContent;
 				this->caretPos = this->command.length();
 			}

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -309,6 +309,7 @@
     <ClCompile Include="H2MOD\Variants\VariantPlayer.cpp" />
     <ClCompile Include="H2MOD\Variants\VariantSystem.cpp" />
     <ClCompile Include="Util\Base64.cpp" />
+    <ClCompile Include="Util\ClipboardAPI.cpp" />
     <ClCompile Include="Util\Debug\Debug.cpp" />
     <ClCompile Include="util\filesys.cpp" />
     <ClCompile Include="Util\hash.cpp" />
@@ -440,6 +441,7 @@
     <ClInclude Include="H2MOD\Variants\VariantSystem.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="Util\Base64.h" />
+    <ClInclude Include="Util\ClipboardAPI.h" />
     <ClInclude Include="Util\Debug\Debug.h" />
     <ClInclude Include="util\filesys.h" />
     <ClInclude Include="Util\hash.h" />

--- a/xlive/Project_Cartographer.vcxproj.filters
+++ b/xlive/Project_Cartographer.vcxproj.filters
@@ -450,6 +450,9 @@
     <ClCompile Include="H2MOD\Modules\MainMenu\Ranks.cpp">
       <Filter>Source Files\H2MOD\Modules\MainMenu</Filter>
     </ClCompile>
+    <ClCompile Include="Util\ClipboardAPI.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="H2MOD.h">
@@ -853,6 +856,9 @@
     </ClInclude>
     <ClInclude Include="H2MOD\Modules\MainMenu\Ranks.h">
       <Filter>Source Files\H2MOD\Modules\MainMenu</Filter>
+    </ClInclude>
+    <ClInclude Include="Util\ClipboardAPI.h">
+      <Filter>Source Files\Util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xlive/Util/ClipboardAPI.cpp
+++ b/xlive/Util/ClipboardAPI.cpp
@@ -1,0 +1,61 @@
+#include "stdafx.h"
+#include "ClipboardAPI.h"
+#include "xliveless.h"
+#include <mutex>
+
+std::mutex clipboard_mutex;
+
+bool ClipboardAPI::set(const std::string &text, HWND owner)
+{
+	std::unique_lock<std::mutex> clipboard_lock(clipboard_mutex);
+	bool success = false;
+	if (LOG_CHECK(OpenClipboard(owner))) {
+		LOG_CHECK(EmptyClipboard() != FALSE);
+
+		size_t len = text.length() + 1;
+		HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, len);
+		if (LOG_CHECK(hMem != NULL)) {
+			char *clipboard_text = LOG_CHECK(static_cast<char*>(GlobalLock(hMem)));
+			if (clipboard_text) {
+				strncpy(clipboard_text, text.c_str(), len);
+				if (LOG_CHECK(GlobalUnlock(hMem) || GetLastError() == NO_ERROR))
+					success = (SetClipboardData(CF_TEXT, hMem) != NULL);
+			}
+		}
+		LOG_CHECK(CloseClipboard());
+	}
+	return success;
+}
+
+bool ClipboardAPI::read(std::string &contents, HWND owner)
+{
+	std::unique_lock<std::mutex> clipboard_lock(clipboard_mutex);
+	if (!IsClipboardFormatAvailable(CF_TEXT))
+		return false;
+	if (LOG_CHECK(OpenClipboard(owner))) {
+		HANDLE data = GetClipboardData(CF_TEXT);
+		if (LOG_CHECK(data != NULL)) {
+			LPSTR text = static_cast<LPSTR>(GlobalLock(data));
+			if (LOG_CHECK(text != NULL)) {
+				bool string_is_good = false;
+				try {
+					contents = text;
+					string_is_good = true;
+				}
+				catch (const std::length_error &e) {
+					TRACE_FUNC_N("clipboard contents too long: \"%s\"", e.what());
+				}
+				catch (const std::exception &e) {
+					TRACE_FUNC_N("%s", e.what());
+				}
+				if (LOG_CHECK(GlobalUnlock(data) || GetLastError() == NO_ERROR) && string_is_good)
+				{
+					LOG_CHECK(CloseClipboard());
+					return true;
+				}
+			}
+		}
+		LOG_CHECK(CloseClipboard());
+	}
+	return false;
+}

--- a/xlive/Util/ClipboardAPI.h
+++ b/xlive/Util/ClipboardAPI.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "stdafx.h"
+#include <string>
+
+namespace ClipboardAPI
+{
+	bool set(const std::string &text, HWND owner = nullptr);
+	bool read(std::string &contents, HWND owner = nullptr);
+}


### PR DESCRIPTION
Fixes crashes when attempting to paste an image, etc.