### PR TITLE
Disable Hitmarker

### DIFF
--- a/xlive/H2MOD/Modules/Config/Config.cpp
+++ b/xlive/H2MOD/Modules/Config/Config.cpp
@@ -89,7 +89,7 @@ float H2Config_crosshair_offset = NAN;
 bool H2Config_disable_ingame_keyboard = false;
 bool H2Config_hide_ingame_chat = false;
 bool H2Config_xDelay = true;
-bool H2Config_hitmarker_sound = false;
+//bool H2Config_hitmarker_sound = false;
 bool H2Config_voice_chat = true;
 int H2Config_custom_resolution_x = 0;
 int H2Config_custom_resolution_y = 0;
@@ -281,12 +281,12 @@ void SaveH2Config() {
 		fputs("\n# 0 - Non-host players cannot delay the game start countdown timer.", fileConfig);
 		fputs("\n# 1 - Non-host players can delay the game start countdown timer (native default).", fileConfig);
 		fputs("\n\n", fileConfig);
-		if (!H2IsDediServer) {
-			fputs("# enable_hitmarker_sound Options (Client):", fileConfig);
-			fputs("\n# 0 - Shooting players does not produce a hitmarker sound effect (default).", fileConfig);
-			fputs("\n# 1 - Shooting players plays a hitmarker sound effect.", fileConfig);
-			fputs("\n\n", fileConfig);
-		}
+		//if (!H2IsDediServer) {
+			//fputs("# enable_hitmarker_sound Options (Client):", fileConfig);
+			//fputs("\n# 0 - Shooting players does not produce a hitmarker sound effect (default).", fileConfig);
+			//fputs("\n# 1 - Shooting players plays a hitmarker sound effect.", fileConfig);
+			//fputs("\n\n", fileConfig);
+		//}
 		fputs("# voice_chat Options:", fileConfig);
 		fputs("\n# 0 - Voice chat is not enabled, you cannot host voice servers or connect to them.", fileConfig);
 		fputs("\n# 1 - Voice chat is enabled, you can host voice servers or connect to them (default).", fileConfig);
@@ -430,9 +430,9 @@ void SaveH2Config() {
 			//fputs("\ncustom_resolution = 0x0", fileConfig);
 		}
 		fputs("\nenable_xdelay = ", fileConfig); fputs(H2Config_xDelay ? "1" : "0", fileConfig);
-		if (!H2IsDediServer) {
-			fputs("\nenable_hitmarker_sound = ", fileConfig); fputs(H2Config_hitmarker_sound ? "1" : "0", fileConfig);
-		}
+		//if (!H2IsDediServer) {
+			//fputs("\nenable_hitmarker_sound = ", fileConfig); fputs(H2Config_hitmarker_sound ? "1" : "0", fileConfig);
+		//}
 		fputs("\nvoice_chat = ", fileConfig); fputs(H2Config_voice_chat ? "1" : "0", fileConfig);
 
 		if (H2IsDediServer) {
@@ -617,7 +617,7 @@ static bool est_sens_mouse = false;
 static bool est_disable_ingame_keyboard = false;
 static bool est_hide_ingame_chat = false;
 static bool est_xdelay = false;
-static bool est_hitmarker_sound = false;
+//static bool est_hitmarker_sound = false;
 static bool est_voice_chat = false;
 static bool est_als_mp_explosion_physics = false;
 static bool est_als_mp_sputnik = false;
@@ -692,7 +692,7 @@ static void est_reset_vars() {
 	est_disable_ingame_keyboard = false;
 	est_hide_ingame_chat = false;
 	est_xdelay = false;
-	est_hitmarker_sound = false;
+	//est_hitmarker_sound = false;
 	est_voice_chat = false;
 	est_als_mp_explosion_physics = false;
 	est_als_mp_sputnik = false;
@@ -1362,18 +1362,18 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				est_xdelay = true;
 			}
 		}
-		else if (sscanf(fileLine, "enable_hitmarker_sound =%d", &tempint1) == 1) {
-			if (est_hitmarker_sound) {
-				duplicated = true;
-			}
-			else if (!(tempint1 == 0 || tempint1 == 1)) {
-				incorrect = true;
-			}
-			else {
-				H2Config_hitmarker_sound = (bool)tempint1;
-				est_hitmarker_sound = true;
-			}
-		}
+		//else if (sscanf(fileLine, "enable_hitmarker_sound =%d", &tempint1) == 1) {
+		//	if (est_hitmarker_sound) {
+		//		duplicated = true;
+		//	}
+		//	else if (!(tempint1 == 0 || tempint1 == 1)) {
+		//		incorrect = true;
+		//	}
+		//	else {
+		//		H2Config_hitmarker_sound = (bool)tempint1;
+		//		est_hitmarker_sound = true;
+		//	}
+		//}
 		else if (sscanf(fileLine, "voice_chat =%d", &tempint1) == 1) {
 			if (est_voice_chat) {
 				duplicated = true;

--- a/xlive/H2MOD/Modules/Config/Config.h
+++ b/xlive/H2MOD/Modules/Config/Config.h
@@ -8,7 +8,7 @@ void ReadH2Config();
 #define DLL_VERSION_MAJOR               0
 #define DLL_VERSION_MINOR               5
 #define DLL_VERSION_REVISION            0
-#define DLL_VERSION_BUILD				0
+#define DLL_VERSION_BUILD				1
 
 #define DLL_VERSION            DLL_VERSION_MAJOR, DLL_VERSION_MINOR, DLL_VERSION_REVISION, DLL_VERSION_BUILD
 #define STRINGIZE2(s) #s
@@ -39,7 +39,7 @@ extern float H2Config_crosshair_offset;
 extern bool H2Config_disable_ingame_keyboard;
 extern bool H2Config_hide_ingame_chat;
 extern bool H2Config_xDelay;
-extern bool H2Config_hitmarker_sound;
+//extern bool H2Config_hitmarker_sound;
 extern bool H2Config_voice_chat;
 extern int H2Config_custom_resolution_x;
 extern int H2Config_custom_resolution_y;

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
@@ -2791,9 +2791,9 @@ static bool CMButtonHandler_OtherSettings(int button_id) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_raw_input = !H2Config_raw_input));
 		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0xFFFFF02A, 0xFFFFF02B);
 	}
-	else if (button_id == 8) {
-		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_hitmarker_sound = !H2Config_hitmarker_sound));
-	}
+//	else if (button_id == 8) {
+//		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_hitmarker_sound = !H2Config_hitmarker_sound));
+//	}
 	return false;
 }
 
@@ -2839,8 +2839,8 @@ int __cdecl CustomMenu_OtherSettings(int a1) {
 	loadLabelToggle_OtherSettings(6, 0xFFFFFFF6, !H2Config_skip_intro);
 	loadLabelToggle_OtherSettings(7, 0xFFFFFFF2, !H2Config_disable_ingame_keyboard);
 	loadLabelToggle_OtherSettings(8, 0xFFFFFFF2, H2Config_raw_input);
-	loadLabelToggle_OtherSettings(9, 0xFFFFFFF2, H2Config_hitmarker_sound);
-	return CustomMenu_CallHead(a1, menu_vftable_1_OtherSettings, menu_vftable_2_OtherSettings, (DWORD)&CMButtonHandler_OtherSettings, 9, 272);
+	//loadLabelToggle_OtherSettings(9, 0xFFFFFFF2, H2Config_hitmarker_sound);
+	return CustomMenu_CallHead(a1, menu_vftable_1_OtherSettings, menu_vftable_2_OtherSettings, (DWORD)&CMButtonHandler_OtherSettings, 8, 272);
 }
 
 void GSCustomMenuCall_OtherSettings() {
@@ -4877,7 +4877,7 @@ void initGSCustomMenu() {
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0006, "Game Intro Video");
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0007, "In-game Keyb. CTRLs");
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0008, "Raw Mouse Input");
-	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0009, "Hitmarker Sound Effect");
+	//add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0009, "Hitmarker Sound Effect");
 
 
 	add_cartographer_label(CMLabelMenuId_AdvSettings, 0xFFFFFFF0, "Advanced Settings");

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
@@ -2791,9 +2791,10 @@ static bool CMButtonHandler_OtherSettings(int button_id) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_raw_input = !H2Config_raw_input));
 		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0xFFFFF02A, 0xFFFFF02B);
 	}
-//	else if (button_id == 8) {
-//		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_hitmarker_sound = !H2Config_hitmarker_sound));
-//	}
+	else if (button_id == 8) {
+		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_voice_chat = !H2Config_voice_chat));
+		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0xFFFFF02A, 0xFFFFF02B);
+	}
 	return false;
 }
 
@@ -2840,7 +2841,8 @@ int __cdecl CustomMenu_OtherSettings(int a1) {
 	loadLabelToggle_OtherSettings(7, 0xFFFFFFF2, !H2Config_disable_ingame_keyboard);
 	loadLabelToggle_OtherSettings(8, 0xFFFFFFF2, H2Config_raw_input);
 	//loadLabelToggle_OtherSettings(9, 0xFFFFFFF2, H2Config_hitmarker_sound);
-	return CustomMenu_CallHead(a1, menu_vftable_1_OtherSettings, menu_vftable_2_OtherSettings, (DWORD)&CMButtonHandler_OtherSettings, 8, 272);
+	loadLabelToggle_OtherSettings(9, 0xFFFFFFF2, H2Config_voice_chat);
+	return CustomMenu_CallHead(a1, menu_vftable_1_OtherSettings, menu_vftable_2_OtherSettings, (DWORD)&CMButtonHandler_OtherSettings, 9, 272);
 }
 
 void GSCustomMenuCall_OtherSettings() {
@@ -4878,6 +4880,7 @@ void initGSCustomMenu() {
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0007, "In-game Keyb. CTRLs");
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0008, "Raw Mouse Input");
 	//add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0009, "Hitmarker Sound Effect");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0009, "Voice Chat");
 
 
 	add_cartographer_label(CMLabelMenuId_AdvSettings, 0xFFFFFFF0, "Advanced Settings");

--- a/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
+++ b/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
@@ -721,44 +721,44 @@ bool __cdecl is_supported_build(char *build)
 
 #pragma endregion
 
-typedef int(__cdecl *tfn_c0017a25d)(DWORD, DWORD*);
-tfn_c0017a25d pfn_c0017a25d;
-int __cdecl fn_c0017a25d(DWORD a1, DWORD* a2)
-{
-	if (H2Config_hitmarker_sound) {
-		typedef unsigned long long QWORD;
-		QWORD xuid_p1 = *(QWORD*)((BYTE*)H2BaseAddr + 0x51A629);
-
-		int i = 0;
-		for (; i < 16; i++) {
-			QWORD xuid_list_ele = *(QWORD*)((BYTE*)H2BaseAddr + 0x968F68 + (8 * i));
-			if (xuid_list_ele == xuid_p1) {
-				break;
-			}
-		}
-
-		int local_player_datum = i < 16 ? h2mod->get_unit_datum_from_player_index(i) : -1;
-
-		//if (local_player_datum != -1 && a1 == local_player_datum && a2[4] != -1) {
-		if (local_player_datum != -1 && a2[4] == local_player_datum && a1 != -1 && a1 != local_player_datum) {
-			for (i = 0; i < 16; i++) {
-				int other_datum = h2mod->get_unit_datum_from_player_index(i);
-				if (a1 == other_datum) {
-					if (h2mod->get_unit_team_index(local_player_datum) != h2mod->get_unit_team_index(other_datum)) {
-						std::unique_lock<std::mutex> lck(h2mod->sound_mutex);
-						h2mod->SoundMap[L"sounds/Halo1PCHitSound.wav"] = 0;
-						//unlock immediately after modifying sound map
-						lck.unlock();
-						h2mod->sound_cv.notify_one();
-					}
-					break;
-				}
-			}
-		}
-	}
-	int result = pfn_c0017a25d(a1, a2);
-	return result;
-}
+//typedef int(__cdecl *tfn_c0017a25d)(DWORD, DWORD*);
+//tfn_c0017a25d pfn_c0017a25d;
+//int __cdecl fn_c0017a25d(DWORD a1, DWORD* a2)
+//{
+//	if (H2Config_hitmarker_sound) {
+//		typedef unsigned long long QWORD;
+//		QWORD xuid_p1 = *(QWORD*)((BYTE*)H2BaseAddr + 0x51A629);
+//
+//		int i = 0;
+//		for (; i < 16; i++) {
+//			QWORD xuid_list_ele = *(QWORD*)((BYTE*)H2BaseAddr + 0x968F68 + (8 * i));
+//			if (xuid_list_ele == xuid_p1) {
+//				break;
+//			}
+//		}
+//
+//		int local_player_datum = i < 16 ? h2mod->get_unit_datum_from_player_index(i) : -1;
+//
+//		//if (local_player_datum != -1 && a1 == local_player_datum && a2[4] != -1) {
+//		if (local_player_datum != -1 && a2[4] == local_player_datum && a1 != -1 && a1 != local_player_datum) {
+//			for (i = 0; i < 16; i++) {
+//				int other_datum = h2mod->get_unit_datum_from_player_index(i);
+//				if (a1 == other_datum) {
+//					if (h2mod->get_unit_team_index(local_player_datum) != h2mod->get_unit_team_index(other_datum)) {
+//						std::unique_lock<std::mutex> lck(h2mod->sound_mutex);
+//						h2mod->SoundMap[L"sounds/Halo1PCHitSound.wav"] = 0;
+//						//unlock immediately after modifying sound map
+//						lck.unlock();
+//						h2mod->sound_cv.notify_one();
+//					}
+//					break;
+//				}
+//			}
+//		}
+//	}
+//	int result = pfn_c0017a25d(a1, a2);
+//	return result;
+//}
 
 
 typedef char(__stdcall *tfn_c0024eeef)(DWORD*, int, int);
@@ -1052,8 +1052,8 @@ void InitH2Tweaks() {
 		PatchCall(H2BaseAddr + 0x21754C, &sub_20E1D8_boot);
 
 		//Hook for Hitmarker sound effect.
-		pfn_c0017a25d = (tfn_c0017a25d)DetourFunc((BYTE*)H2BaseAddr + 0x0017a25d, (BYTE*)fn_c0017a25d, 10);
-		VirtualProtect(pfn_c0017a25d, 4, PAGE_EXECUTE_READWRITE, &dwBack);
+//		pfn_c0017a25d = (tfn_c0017a25d)DetourFunc((BYTE*)H2BaseAddr + 0x0017a25d, (BYTE*)fn_c0017a25d, 10);
+//		VirtualProtect(pfn_c0017a25d, 4, PAGE_EXECUTE_READWRITE, &dwBack);
 
 		//Hook for advanced lobby options.
 		pfn_c0024eeef = (tfn_c0024eeef)DetourClassFunc((BYTE*)H2BaseAddr + 0x0024eeef, (BYTE*)fn_c0024eeef, 9);


### PR DESCRIPTION
This should disable the functionality for the hitmarker effect and remove the option from the other settings menu. My opinion is that this should be disabled since it has an issue with it playing the sound on the wrong player due to player datum stuff. It has been like this since it's inception and I'm not sure if KC has any time at the moment to fix it. Best left disabled until it can be completed.