### PR TITLE
Faster Live server list downloading + misc changes

### DIFF
--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1129,6 +1129,7 @@ void __cdecl OnMapLoad(int a1)
 		H2Tweaks::disableAI_MP();
 		UIRankPatch();
 		H2Tweaks::disable60FPSCutscenes();
+		H2Tweaks::setHz();
 
 		p_set_random_number(a1);
 		return; 
@@ -1194,7 +1195,8 @@ void __cdecl OnMapLoad(int a1)
 	 
 		H2Tweaks::setCrosshairSize(0, false);
 		H2Tweaks::disable60FPSCutscenes(); 
-		
+		H2Tweaks::setSavedSens();
+
 		//H2Tweaks::applyShaderTweaks(); 
 
 		if (GameState == 3)
@@ -1229,6 +1231,7 @@ void __cdecl OnMapLoad(int a1)
 
 		H2Tweaks::setCrosshairPos(H2Config_crosshair_offset);
 		H2Tweaks::enable60FPSCutscenes();
+		H2Tweaks::setSavedSens();
 	}
 
 	p_set_random_number(a1);

--- a/xlive/H2MOD/Modules/Config/Config.cpp
+++ b/xlive/H2MOD/Modules/Config/Config.cpp
@@ -81,10 +81,13 @@ bool H2Config_custom_labels_capture_missing = false;
 bool H2Config_skip_intro = false;
 bool H2Config_raw_input = false;
 bool H2Config_discord_enable = true;
-bool H2Config_controller_aim_assist = true;
+//bool H2Config_controller_aim_assist = true;
 int H2Config_fps_limit = 60;
 int H2Config_static_lod_state = static_lod::disable;
 int H2Config_field_of_view = 0;
+int H2Config_refresh_rate = 60;
+int H2Config_mouse_sens = 0;
+int H2Config_controller_sens = 0;
 float H2Config_crosshair_offset = NAN;
 bool H2Config_disable_ingame_keyboard = false;
 bool H2Config_hide_ingame_chat = false;
@@ -233,10 +236,10 @@ void SaveH2Config() {
 			fputs("\n# 1 - Enables Discord Rich Presence.", fileConfig);
 			fputs("\n\n", fileConfig);
 
-			fputs("# controller_aim_assist Options (Client):", fileConfig);
+			/*fputs("# controller_aim_assist Options (Client):", fileConfig);
 			fputs("\n# 0 - Disables aim assist for controllers.", fileConfig);
 			fputs("\n# 1 - Enables aim assist for controllers.", fileConfig);
-			fputs("\n\n", fileConfig);
+			fputs("\n\n", fileConfig);*/
 
 			fputs("# fps_limit Options (Client):", fileConfig);
 			fputs("\n# <uint> - 0 disables the built in frame limiter. >0 is the fps limit of the game.", fileConfig);
@@ -257,6 +260,18 @@ void SaveH2Config() {
 			fputs("\n# <uint 0 to 110> - 0 disables the built in FoV adjustment. >0 is the FoV set value.", fileConfig);
 			fputs("\n\n", fileConfig);
 
+			fputs("# refresh_rates Options (Client):", fileConfig);
+			fputs("\n# <uint 0 to 240> - 0 disables the built in refresh rate adjustment. >0 is the refresh rate set value.", fileConfig);
+			fputs("\n\n", fileConfig);
+
+			fputs("# mouse_sens Options (Client):", fileConfig);
+			fputs("\n# <uint 0 to inf> - 0 uses the default sensitivity.", fileConfig);
+			fputs("\n\n", fileConfig);
+
+			fputs("# controller_sens Options (Client):", fileConfig);
+			fputs("\n# <uint 0 to inf> - 0 uses the default sensitivity.", fileConfig);
+			fputs("\n\n", fileConfig);
+
 			fputs("# crosshair_offset Options (Client):", fileConfig);
 			fputs("\n# <0 to 0.53> - NaN disables the built in Crosshair adjustment.", fileConfig);
 			fputs("\n\n", fileConfig);
@@ -271,22 +286,22 @@ void SaveH2Config() {
 			fputs("\n# 1 - In-game chat is hidden.", fileConfig);
 			fputs("\n\n", fileConfig);
 
-			//fputs("# custom_resolution Options (Client):", fileConfig);
-			//fputs("\n# <width>x<height> - Sets the resolution of the game via the Windows Registry.", fileConfig);
-			//fputs("\n# 0x0, 0x?, ?x0 - these do not do modify anything where ? is >= 0.", fileConfig);
-			//fputs("\n\n", fileConfig);
+			/*fputs("# custom_resolution Options (Client):", fileConfig);
+			fputs("\n# <width>x<height> - Sets the resolution of the game via the Windows Registry.", fileConfig);
+			fputs("\n# 0x0, 0x?, ?x0 - these do not do modify anything where ? is >= 0.", fileConfig);
+			fputs("\n\n", fileConfig);*/
 
 		}
 		fputs("# enable_xdelay Options:", fileConfig);
 		fputs("\n# 0 - Non-host players cannot delay the game start countdown timer.", fileConfig);
 		fputs("\n# 1 - Non-host players can delay the game start countdown timer (native default).", fileConfig);
 		fputs("\n\n", fileConfig);
-//		if (!H2IsDediServer) {
-//			fputs("# enable_hitmarker_sound Options (Client):", fileConfig);
-//			fputs("\n# 0 - Shooting players does not produce a hitmarker sound effect (default).", fileConfig);
-//			fputs("\n# 1 - Shooting players plays a hitmarker sound effect.", fileConfig);
-//			fputs("\n\n", fileConfig);
-//		}
+		/*if (!H2IsDediServer) {
+			fputs("# enable_hitmarker_sound Options (Client):", fileConfig);
+			fputs("\n# 0 - Shooting players does not produce a hitmarker sound effect (default).", fileConfig);
+			fputs("\n# 1 - Shooting players plays a hitmarker sound effect.", fileConfig);
+			fputs("\n\n", fileConfig);
+		}
 		fputs("# voice_chat Options:", fileConfig);
 		fputs("\n# 0 - Voice chat is not enabled, you cannot host voice servers or connect to them.", fileConfig);
 		fputs("\n# 1 - Voice chat is enabled, you can host voice servers or connect to them (default).", fileConfig);
@@ -308,10 +323,10 @@ void SaveH2Config() {
 			fputs("\n# 1 - Grunt Birthday Party skull is on for all players.", fileConfig);
 			fputs("\n\n", fileConfig);
 
-			/*fputs("# grenade_chain_react Options (Server):", fileConfig);
+			fputs("# grenade_chain_react Options (Server):", fileConfig);
 			fputs("\n# 0 - Grenades do not chain react in multiplayer.", fileConfig);
 			fputs("\n# 1 - Grenades chain react in multiplayer.", fileConfig);
-			fputs("\n\n", fileConfig);*/
+			fputs("\n\n", fileConfig);
 
 			fputs("# banshee_bomb Options (Server):", fileConfig);
 			fputs("\n# 0 - Players cannot use the Banshee Bomb in multiplayer.", fileConfig);
@@ -329,7 +344,7 @@ void SaveH2Config() {
 			fputs("\n# 0 - Players cannot use their Flashlight in multiplayer.", fileConfig);
 			fputs("\n# 1 - Players can use their Flashlight in multiplayer.", fileConfig);
 			fputs("\n\n", fileConfig);
-		}
+		}*/
 
 		fputs("# debug_log Options:", fileConfig);
 		fputs("\n# 0 - Disables excess logging.", fileConfig);
@@ -404,7 +419,7 @@ void SaveH2Config() {
 
 			fputs("\ndiscord_enable = ", fileConfig); fputs(H2Config_discord_enable ? "1" : "0", fileConfig);
 
-			fputs("\ncontroller_aim_assist = ", fileConfig); fputs(H2Config_controller_aim_assist ? "1" : "0", fileConfig);
+			//fputs("\ncontroller_aim_assist = ", fileConfig); fputs(H2Config_controller_aim_assist ? "1" : "0", fileConfig);
 
 			sprintf(settingOutBuffer, "\nfps_limit = %d", H2Config_fps_limit);
 			fputs(settingOutBuffer, fileConfig);
@@ -413,6 +428,15 @@ void SaveH2Config() {
 			fputs(settingOutBuffer, fileConfig);
 
 			sprintf(settingOutBuffer, "\nfield_of_view = %d", H2Config_field_of_view);
+			fputs(settingOutBuffer, fileConfig);
+
+			sprintf(settingOutBuffer, "\nrefresh_rate = %d", H2Config_refresh_rate);
+			fputs(settingOutBuffer, fileConfig);
+
+			sprintf(settingOutBuffer, "\nmouse_sens = %d", H2Config_mouse_sens);
+			fputs(settingOutBuffer, fileConfig);
+
+			sprintf(settingOutBuffer, "\ncontroller_sens = %d", H2Config_controller_sens);
 			fputs(settingOutBuffer, fileConfig);
 
 			if (FloatIsNaN(H2Config_crosshair_offset)) {
@@ -430,9 +454,9 @@ void SaveH2Config() {
 			//fputs("\ncustom_resolution = 0x0", fileConfig);
 		}
 		fputs("\nenable_xdelay = ", fileConfig); fputs(H2Config_xDelay ? "1" : "0", fileConfig);
-//		if (!H2IsDediServer) {
-//			fputs("\nenable_hitmarker_sound = ", fileConfig); fputs(H2Config_hitmarker_sound ? "1" : "0", fileConfig);
-//		}
+		/*if (!H2IsDediServer) {
+			fputs("\nenable_hitmarker_sound = ", fileConfig); fputs(H2Config_hitmarker_sound ? "1" : "0", fileConfig);
+		}
 		fputs("\nvoice_chat = ", fileConfig); fputs(H2Config_voice_chat ? "1" : "0", fileConfig);
 
 		if (H2IsDediServer) {
@@ -442,7 +466,7 @@ void SaveH2Config() {
 
 			fputs("\nmp_grunt_bday_party = ", fileConfig); fputs(AdvLobbySettings_mp_grunt_bday_party ? "1" : "0", fileConfig);
 
-			//fputs("\ngrenade_chain_react = ", fileConfig); fputs(AdvLobbySettings_grenade_chain_react ? "1" : "0", fileConfig);
+			fputs("\ngrenade_chain_react = ", fileConfig); fputs(AdvLobbySettings_grenade_chain_react ? "1" : "0", fileConfig);
 
 			fputs("\nbanshee_bomb = ", fileConfig); fputs(AdvLobbySettings_banshee_bomb ? "1" : "0", fileConfig);
 
@@ -450,7 +474,7 @@ void SaveH2Config() {
 			fputs("\nmp_blind = ", fileConfig); fputs(tmpChar, fileConfig);
 
 			fputs("\nflashlight = ", fileConfig); fputs(AdvLobbySettings_flashlight ? "1" : "0", fileConfig);
-		}
+		}*/
 
 		fputs("\ndebug_log = ", fileConfig); fputs(H2Config_debug_log ? "1" : "0", fileConfig);
 
@@ -607,17 +631,20 @@ static bool est_language_label_capture = false;
 static bool est_skip_intro = false;
 static bool est_raw_input = false;
 static bool est_discord_enable = false;
-static bool est_controller_aim_assist = false;
+//static bool est_controller_aim_assist = false;
 static bool est_fps_limit = false;
 static bool est_static_lod_state = false;
 static bool est_field_of_view = false;
+static bool est_refresh_rate = false;
+static bool est_mouse_sens = false;
+static bool est_controller_sens = false;
 static bool est_crosshair_offset = false;
 static bool est_sens_controller = false;
 static bool est_sens_mouse = false;
 static bool est_disable_ingame_keyboard = false;
 static bool est_hide_ingame_chat = false;
 static bool est_xdelay = false;
-//static bool est_hitmarker_sound = false;
+/*static bool est_hitmarker_sound = false;
 static bool est_voice_chat = false;
 static bool est_als_mp_explosion_physics = false;
 static bool est_als_mp_sputnik = false;
@@ -625,7 +652,7 @@ static bool est_als_mp_grunt_bday_party = false;
 static bool est_als_grenade_chain_react = false;
 static bool est_als_banshee_bomb = false;
 static bool est_als_mp_blind = false;
-static bool est_als_flashlight = false;
+static bool est_als_flashlight = false;*/
 static bool est_debug_log = false;
 static bool est_custom_resolution = false;
 static bool est_server_name = false;
@@ -682,7 +709,7 @@ static void est_reset_vars() {
 	est_skip_intro = false;
 	est_raw_input = false;
 	est_discord_enable = false;
-	est_controller_aim_assist = false;
+	//est_controller_aim_assist = false;
 	est_fps_limit = false;
 	est_static_lod_state = false;
 	est_field_of_view = false;
@@ -692,7 +719,7 @@ static void est_reset_vars() {
 	est_disable_ingame_keyboard = false;
 	est_hide_ingame_chat = false;
 	est_xdelay = false;
-	//est_hitmarker_sound = false;
+	/*est_hitmarker_sound = false;
 	est_voice_chat = false;
 	est_als_mp_explosion_physics = false;
 	est_als_mp_sputnik = false;
@@ -700,7 +727,7 @@ static void est_reset_vars() {
 	est_als_grenade_chain_react = false;
 	est_als_banshee_bomb = false;
 	est_als_mp_blind = false;
-	est_als_flashlight = false;
+	est_als_flashlight = false;*/
 	est_debug_log = false;
 	est_custom_resolution = false;
 	est_server_name = false;
@@ -928,7 +955,7 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				est_discord_enable = true;
 			}
 		}
-		else if (!H2IsDediServer && sscanf(fileLine, "controller_aim_assist =%d", &tempint1) == 1) {
+		/*else if (!H2IsDediServer && sscanf(fileLine, "controller_aim_assist =%d", &tempint1) == 1) {
 			if (est_controller_aim_assist) {
 				duplicated = true;
 			}
@@ -939,7 +966,7 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				H2Config_controller_aim_assist = (bool)tempint1;
 				est_controller_aim_assist = true;
 			}
-		}
+		}*/
 		else if (!H2IsDediServer && sscanf(fileLine, "fps_limit =%d", &tempint1) == 1) {
 			if (est_fps_limit) {
 				duplicated = true;
@@ -976,6 +1003,42 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 			else {
 				H2Config_field_of_view = tempint1;
 				est_field_of_view = true;
+			}
+		}
+		else if (!H2IsDediServer && sscanf(fileLine, "refresh_rate =%d", &tempint1) == 1) {
+			if (est_refresh_rate) {
+				duplicated = true;
+			}
+			else if (!(tempint1 >= 0)) {
+				incorrect = true;
+			}
+			else {
+				H2Config_refresh_rate = tempint1;
+				est_refresh_rate = true;
+			}
+		}
+		else if (!H2IsDediServer && sscanf(fileLine, "mouse_sens =%d", &tempint1) == 1) {
+			if (est_mouse_sens) {
+				duplicated = true;
+			}
+			else if (!(tempint1 >= 0)) {
+				incorrect = true;
+			}
+			else {
+				H2Config_mouse_sens = tempint1;
+				est_mouse_sens = true;
+			}
+		}
+		else if (!H2IsDediServer && sscanf(fileLine, "controller_sens =%d", &tempint1) == 1) {
+			if (est_controller_sens) {
+				duplicated = true;
+			}
+			else if (!(tempint1 >= 0)) {
+				incorrect = true;
+			}
+			else {
+				H2Config_controller_sens = tempint1;
+				est_controller_sens = true;
 			}
 		}
 		else if (!H2IsDediServer && sscanf(fileLine, "crosshair_offset =%f", &tempfloat1) == 1) {
@@ -1362,18 +1425,18 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				est_xdelay = true;
 			}
 		}
-//		else if (sscanf(fileLine, "enable_hitmarker_sound =%d", &tempint1) == 1) {
-//			if (est_hitmarker_sound) {
-//				duplicated = true;
-//			}
-//			else if (!(tempint1 == 0 || tempint1 == 1)) {
-//				incorrect = true;
-//			}
-//			else {
-//				H2Config_hitmarker_sound = (bool)tempint1;
-//				est_hitmarker_sound = true;
-//			}
-//		}
+		/*else if (sscanf(fileLine, "enable_hitmarker_sound =%d", &tempint1) == 1) {
+			if (est_hitmarker_sound) {
+				duplicated = true;
+			}
+			else if (!(tempint1 == 0 || tempint1 == 1)) {
+				incorrect = true;
+			}
+			else {
+				H2Config_hitmarker_sound = (bool)tempint1;
+				est_hitmarker_sound = true;
+			}
+		}
 		else if (sscanf(fileLine, "voice_chat =%d", &tempint1) == 1) {
 			if (est_voice_chat) {
 				duplicated = true;
@@ -1422,7 +1485,7 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				est_als_mp_grunt_bday_party = true;
 			}
 		}
-		/*else if (sscanf(fileLine, "grenade_chain_react =%d", &tempint1) == 1) {
+		else if (sscanf(fileLine, "grenade_chain_react =%d", &tempint1) == 1) {
 			if (est_als_grenade_chain_react) {
 				duplicated = true;
 			}
@@ -1433,7 +1496,7 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				AdvLobbySettings_grenade_chain_react = (bool)tempint1;
 				est_als_grenade_chain_react = true;
 			}
-		}*/
+		}
 		else if (sscanf(fileLine, "banshee_bomb =%d", &tempint1) == 1) {
 			if (est_als_banshee_bomb) {
 				duplicated = true;
@@ -1469,7 +1532,7 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				AdvLobbySettings_flashlight = (bool)tempint1;
 				est_als_flashlight = true;
 			}
-		}
+		}*/
 		else if (sscanf(fileLine, "debug_log =%d", &tempint1) == 1) {
 			if (est_debug_log) {
 				duplicated = true;

--- a/xlive/H2MOD/Modules/Config/Config.h
+++ b/xlive/H2MOD/Modules/Config/Config.h
@@ -7,8 +7,8 @@ void ReadH2Config();
 
 #define DLL_VERSION_MAJOR               0
 #define DLL_VERSION_MINOR               5
-#define DLL_VERSION_REVISION            1
-#define DLL_VERSION_BUILD				0
+#define DLL_VERSION_REVISION            2
+#define DLL_VERSION_BUILD				1
 
 #define DLL_VERSION            DLL_VERSION_MAJOR, DLL_VERSION_MINOR, DLL_VERSION_REVISION, DLL_VERSION_BUILD
 #define STRINGIZE2(s) #s
@@ -31,10 +31,13 @@ extern bool H2Config_custom_labels_capture_missing;
 extern bool H2Config_skip_intro;
 extern bool H2Config_raw_input;
 extern bool H2Config_discord_enable;
-extern bool H2Config_controller_aim_assist;
+//extern bool H2Config_controller_aim_assist;
 extern int H2Config_fps_limit;
 extern int H2Config_static_lod_state;
 extern int H2Config_field_of_view;
+extern int H2Config_mouse_sens;
+extern int H2Config_controller_sens;
+extern int H2Config_refresh_rate;
 extern float H2Config_crosshair_offset;
 extern bool H2Config_disable_ingame_keyboard;
 extern bool H2Config_hide_ingame_chat;

--- a/xlive/H2MOD/Modules/Console/ConsoleCommands.cpp
+++ b/xlive/H2MOD/Modules/Console/ConsoleCommands.cpp
@@ -566,6 +566,10 @@ void ConsoleCommands::handle_command(std::string command) {
 			this->checked_for_ids = false;
 		}
 		else if (firstCommand == "$spawnnear") {
+			if (!gameManager->isHost()) {
+				output(L"Only host can spawn objects");
+				return;
+			}
 			if (splitCommands.size() < 3 || splitCommands.size() > 4) {
 				output(L"Invalid command, usage $spawn command_name count");
 				return;
@@ -647,6 +651,10 @@ void ConsoleCommands::handle_command(std::string command) {
 			t1.detach();
 		}
 		else if (firstCommand == "$spawn") {
+			if (!gameManager->isHost()) {
+				output(L"Only host can spawn objects");
+				return;
+			}
 			if (splitCommands.size() != 6) {
 				output(L"Invalid command, usage $spawn command_name count x y z");
 				return;
@@ -690,6 +698,7 @@ void ConsoleCommands::handle_command(std::string command) {
 
 			if (isNum(sensVal.c_str())) {
 				H2Tweaks::setSens(CONTROLLER, stoi(sensVal));
+				H2Config_controller_sens = stoi(sensVal);
 			}
 			else {
 				output(L"Wrong input! Use a number.");
@@ -705,6 +714,7 @@ void ConsoleCommands::handle_command(std::string command) {
 
 			if (isNum(sensVal.c_str())) {
 				H2Tweaks::setSens(MOUSE, stoi(sensVal));
+				H2Config_mouse_sens = stoi(sensVal);
 			}
 			else {
 				output(L"Wrong input! Use a number.");

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
@@ -1524,6 +1524,147 @@ void GSCustomMenuCall_EditFOV() {
 #pragma endregion
 
 
+const int CMLabelMenuId_EditHz = 0xFF000018;
+#pragma region CM_EditHz
+
+static void loadLabelHzNum() {
+	if (H2Config_refresh_rate) {
+		char* lblHzLimitNum = H2CustomLanguageGetLabel(CMLabelMenuId_EditHz, 0xFFFF0003);
+		if (!lblHzLimitNum)
+			return;
+		int buildLimitLabelLen = strlen(lblHzLimitNum) + 20;
+		char* buildLimitLabel = (char*)malloc(sizeof(char) * buildLimitLabelLen);
+		snprintf(buildLimitLabel, buildLimitLabelLen, lblHzLimitNum, H2Config_refresh_rate);
+		add_cartographer_label(CMLabelMenuId_EditHz, 3, buildLimitLabel, true);
+		free(buildLimitLabel);
+	}
+	else {
+		char* lblHzLimitDisabled = H2CustomLanguageGetLabel(CMLabelMenuId_EditHz, 0xFFFF0013);
+		add_cartographer_label(CMLabelMenuId_EditHz, 3, lblHzLimitDisabled, true);
+	}
+}
+
+void __stdcall CMLabelButtons_EditHz(int a1, int a2)
+{
+	int(__thiscall* sub_211909)(int, int, int, int) = (int(__thiscall*)(int, int, int, int))((char*)H2BaseAddr + 0x211909);
+	void(__thiscall* sub_21bf85)(int, int label_id) = (void(__thiscall*)(int, int))((char*)H2BaseAddr + 0x21bf85);
+
+	__int16 button_id = *(WORD*)(a1 + 112);
+	int v3 = sub_211909(a1, 6, 0, 0);
+	if (v3)
+	{
+		sub_21bf85_CMLTD(v3, button_id + 1, CMLabelMenuId_EditHz);
+	}
+}
+
+__declspec(naked) void sub_2111ab_CMLTD_nak_EditHz() {//__thiscall
+	__asm {
+		mov eax, [esp + 4h]
+
+		push ebp
+		push edi
+		push esi
+		push ecx
+		push ebx
+
+		push 0xFFFFFFF1//label_id_description
+		push 0xFFFFFFF0//label_id_title
+		push CMLabelMenuId_EditHz
+		push eax
+		push ecx
+		call sub_2111ab_CMLTD//__stdcall
+
+		pop ebx
+		pop ecx
+		pop esi
+		pop edi
+		pop ebp
+
+		retn 4
+	}
+}
+
+static bool CMButtonHandler_EditHz(int button_id) {
+	const int upper_limit = 240;
+	if (button_id == 0) {
+		if (H2Config_refresh_rate <= upper_limit - 10)
+			H2Config_refresh_rate += 10;
+		else
+			H2Config_refresh_rate = upper_limit;
+	}
+	else if (button_id == 1) {
+		if (H2Config_refresh_rate < upper_limit)
+			H2Config_refresh_rate += 1;
+	}
+	else if (button_id == 3) {
+		if (H2Config_refresh_rate > 0)
+			H2Config_refresh_rate -= 1;
+	}
+	else if (button_id == 4) {
+		if (H2Config_refresh_rate > 10)
+			H2Config_refresh_rate -= 10;
+		else
+			H2Config_refresh_rate = 0;
+	}
+	else if (button_id == 2) {
+		if (H2Config_refresh_rate)
+			H2Config_refresh_rate = 0;
+		else
+			H2Config_refresh_rate = 60;
+	}
+	loadLabelHzNum();
+	H2Tweaks::setHz();
+	return false;
+}
+
+__declspec(naked) void sub_20F790_CM_nak_EditHz() {//__thiscall
+	__asm {
+		push ebp
+		push edi
+		push esi
+		push ecx
+		push ebx
+
+		push 0//selected button id
+		push ecx
+		call sub_20F790_CM//__stdcall
+
+		pop ebx
+		pop ecx
+		pop esi
+		pop edi
+		pop ebp
+
+		retn
+	}
+}
+
+int __cdecl CustomMenu_EditHz(int);
+
+int(__cdecl *CustomMenuFuncPtrHelp_EditHz())(int) {
+	return CustomMenu_EditHz;
+}
+
+DWORD* menu_vftable_1_EditHz = 0;
+DWORD* menu_vftable_2_EditHz = 0;
+
+void CMSetupVFTables_EditHz() {
+	CMSetupVFTables(&menu_vftable_1_EditHz, &menu_vftable_2_EditHz, (DWORD)CMLabelButtons_EditHz, (DWORD)sub_2111ab_CMLTD_nak_EditHz, (DWORD)CustomMenuFuncPtrHelp_EditHz, (DWORD)sub_20F790_CM_nak_EditHz, true, 0);
+}
+
+int __cdecl CustomMenu_EditHz(int a1) {
+	loadLabelHzNum();
+	return CustomMenu_CallHead(a1, menu_vftable_1_EditHz, menu_vftable_2_EditHz, (DWORD)&CMButtonHandler_EditHz, 5, 272);
+}
+
+void GSCustomMenuCall_EditHz() {
+	int WgitScreenfunctionPtr = (int)(CustomMenu_EditHz);
+	CallWgit(WgitScreenfunctionPtr);
+}
+
+#pragma endregion
+
+
 const int CMLabelMenuId_EditFPS = 0xFF00000E;
 #pragma region CM_EditFPS
 
@@ -2334,7 +2475,7 @@ void RefreshToggleIngameKeyboardControls() {
 }
 
 //Reversed from Rainman/Cloud's tool (Credit to him for original hack).
-void RefreshToggleDisableControllerAimAssist() {
+/*void RefreshToggleDisableControllerAimAssist() {
 	//FIXME: Causes the vertical lift on The Armory to kill you and launch Sergeant Johnson.
 	//Probably other weird glitches too.
 	return;
@@ -2414,7 +2555,7 @@ void RefreshToggleDisableControllerAimAssist() {
 		*(DWORD*)(AddressOffset + 0xCD877C) = val18;
 
 	}
-}
+}*/
 
 void RefreshTogglexDelay() {
 	BYTE xDelayJMP[] = { 0x74 };
@@ -2767,33 +2908,36 @@ static bool CMButtonHandler_OtherSettings(int button_id) {
 	else if (button_id == 1) {
 		GSCustomMenuCall_EditStaticLoD();
 	}
-//	else if (button_id == 2) {
-//		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0x8, 0x9);
-//		//loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_controller_aim_assist = !H2Config_controller_aim_assist));
-//		RefreshToggleDisableControllerAimAssist();
-//	}
 	else if (button_id == 2) {
+		GSCustomMenuCall_EditHz();
+	}
+	/*else if (button_id == 2) {
+		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0x8, 0x9);
+		//loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_controller_aim_assist = !H2Config_controller_aim_assist));
+		RefreshToggleDisableControllerAimAssist();
+	}*/
+	else if (button_id == 3) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_discord_enable = !H2Config_discord_enable));
 		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0xFFFFF02A, 0xFFFFF02B);
 	}
-	else if (button_id == 3) {
+	else if (button_id == 4) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_xDelay = !H2Config_xDelay));
 		RefreshTogglexDelay();
 	}
-	else if (button_id == 4) {
+	else if (button_id == 5) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF6, !(H2Config_skip_intro = !H2Config_skip_intro));
 	}
-	else if (button_id == 5) {
+	else if (button_id == 6) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, !(H2Config_disable_ingame_keyboard = !H2Config_disable_ingame_keyboard));
 		RefreshToggleIngameKeyboardControls();
 	}
-	else if (button_id == 6) {
+	else if (button_id == 7) {
 		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_raw_input = !H2Config_raw_input));
 		GSCustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0xFFFFF02A, 0xFFFFF02B);
 	}
-//	else if (button_id == 8) {
-//		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_hitmarker_sound = !H2Config_hitmarker_sound));
-//	}
+	/*else if (button_id == 8) {
+		loadLabelToggle_OtherSettings(button_id + 1, 0xFFFFFFF2, (H2Config_hitmarker_sound = !H2Config_hitmarker_sound));
+	}*/
 	return false;
 }
 
@@ -2834,13 +2978,13 @@ void CMSetupVFTables_OtherSettings() {
 
 int __cdecl CustomMenu_OtherSettings(int a1) {
 //	loadLabelToggle_OtherSettings(3, 0xFFFFFFF2, H2Config_controller_aim_assist);
-	loadLabelToggle_OtherSettings(3, 0xFFFFFFF2, H2Config_discord_enable);
-	loadLabelToggle_OtherSettings(4, 0xFFFFFFF2, H2Config_xDelay);
-	loadLabelToggle_OtherSettings(5, 0xFFFFFFF6, !H2Config_skip_intro);
-	loadLabelToggle_OtherSettings(6, 0xFFFFFFF2, !H2Config_disable_ingame_keyboard);
-	loadLabelToggle_OtherSettings(7, 0xFFFFFFF2, H2Config_raw_input);
+	loadLabelToggle_OtherSettings(4, 0xFFFFFFF2, H2Config_discord_enable);
+	loadLabelToggle_OtherSettings(5, 0xFFFFFFF2, H2Config_xDelay);
+	loadLabelToggle_OtherSettings(6, 0xFFFFFFF6, !H2Config_skip_intro);
+	loadLabelToggle_OtherSettings(7, 0xFFFFFFF2, !H2Config_disable_ingame_keyboard);
+	loadLabelToggle_OtherSettings(8, 0xFFFFFFF2, H2Config_raw_input);
 //	loadLabelToggle_OtherSettings(9, 0xFFFFFFF2, H2Config_hitmarker_sound);
-	return CustomMenu_CallHead(a1, menu_vftable_1_OtherSettings, menu_vftable_2_OtherSettings, (DWORD)&CMButtonHandler_OtherSettings, 7, 272);
+	return CustomMenu_CallHead(a1, menu_vftable_1_OtherSettings, menu_vftable_2_OtherSettings, (DWORD)&CMButtonHandler_OtherSettings, 8, 272);
 }
 
 void GSCustomMenuCall_OtherSettings() {
@@ -4775,6 +4919,16 @@ void initGSCustomMenu() {
 	add_cartographer_label(CMLabelMenuId_EditFPS, 5, "-10");
 
 
+	add_cartographer_label(CMLabelMenuId_EditHz, 0xFFFFFFF0, "Force a refresh rate");
+	add_cartographer_label(CMLabelMenuId_EditHz, 0xFFFFFFF1, "Use the buttons below to force your refresh rate on startup. Requires a restart");
+	add_cartographer_label(CMLabelMenuId_EditHz, 1, "+10");
+	add_cartographer_label(CMLabelMenuId_EditHz, 2, "+1");
+	add_cartographer_label(CMLabelMenuId_EditHz, 0xFFFF0003, "Refresh Rate Value: %d");
+	add_cartographer_label(CMLabelMenuId_EditHz, 0xFFFF0013, "No Refresh Rate Forced");
+	add_cartographer_label(CMLabelMenuId_EditHz, 4, "-1");
+	add_cartographer_label(CMLabelMenuId_EditHz, 5, "-10");
+
+
 	add_cartographer_label(CMLabelMenuId_EditStaticLoD, 0xFFFFFFF0, "Static Model Level of Detail");
 	add_cartographer_label(CMLabelMenuId_EditStaticLoD, 0xFFFFFFF1, "Use the buttons below to set a static level on a model's Level of Detail.");
 	add_cartographer_label(CMLabelMenuId_EditStaticLoD, 1, "Default");
@@ -4869,12 +5023,13 @@ void initGSCustomMenu() {
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFFFFF7, "Skip %s");
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 1, "> FPS Limit");
 	add_cartographer_label(CMLabelMenuId_OtherSettings, 2, "> Static Model LoD");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 3, "> Refresh Rate");
 //	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0003, "Controller Aim-Assist");
-	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0003, "Discord Rich Presence");
-	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0004, "xDelay");
-	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0005, "Game Intro Video");
-	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0006, "In-game Keyb. CTRLs");
-	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0007, "Raw Mouse Input");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0004, "Discord Rich Presence");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0005, "xDelay");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0006, "Game Intro Video");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0007, "In-game Keyb. CTRLs");
+	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0008, "Raw Mouse Input");
 //	add_cartographer_label(CMLabelMenuId_OtherSettings, 0xFFFF0009, "Hitmarker Sound Effect");
 
 
@@ -5033,6 +5188,8 @@ void initGSCustomMenu() {
 	CMSetupVFTables_EditFOV();
 
 	CMSetupVFTables_EditFPS();
+
+	CMSetupVFTables_EditHz();
 
 	CMSetupVFTables_EditStaticLoD();
 

--- a/xlive/H2MOD/Modules/HitFix/HitFix.cpp
+++ b/xlive/H2MOD/Modules/HitFix/HitFix.cpp
@@ -11,20 +11,20 @@ void HitFix::Initialize()
 
 	DWORD AddressOffset = *(DWORD*)((char*)h2mod->GetBase() + offset);
 
-	*(float*)(AddressOffset + 0xA4EC88) = 800.0f;	//battle_rifle_bullet.proj Initial Velocity 400
-	*(float*)(AddressOffset + 0xA4EC8C) = 800.0f;	//battle_rifle_bullet.proj Final Velocity 400
-	*(float*)(AddressOffset + 0xA84DD4) = 800.0f;   //carbine_projectile       Initial Velocity 400
-	*(float*)(AddressOffset + 0xA84DD8) = 800.0f;   //carbine_projectile       Final Velocity 400
-	//*(float*)(AddressOffset + 0xB7F914) = 2400.0f;	//sniper_bullet.proj Initial Velocity 1200
-	//*(float*)(AddressOffset + 0xB7F918) = 2400.0f;	//sniper_bullet.proj Final Velocity 1200
+	*(float*)(AddressOffset + 0xA4EC88) = 1200.0f; // battle_rifle_bullet.proj Initial Velocity 
+	*(float*)(AddressOffset + 0xA4EC8C) = 1200.0f; //battle_rifle_bullet.proj Final Velocity
+	*(float*)(AddressOffset + 0xA84DD4) = 1200.0f; //carbine_projectile Initial Velocity 400
+	*(float*)(AddressOffset + 0xA84DD8) = 1200.0f; //carbine_projectile Final Velocity 400
+	*(float*)(AddressOffset + 0xB7F914) = 4000.0f; //sniper_bullet.proj Initial Velocity
+	*(float*)(AddressOffset + 0xB7F918) = 4000.0f; //sniper_bullet.proj Final Velocity
 	
 	//FIXME COOP will break because of one of these tags not existing.
-	//*(float*)(AddressOffset + 0xCE4598) = 2400.0f;	//beam_rifle_beam.proj Initial Velocity 1200
-	//*(float*)(AddressOffset + 0xCE459C) = 2400.0f;	//beam_rifle_beam.proj Final Velocity 1200
-	//*(float*)(AddressOffset + 0x81113C) = 180.0f;	//gauss_turret.proj Initial Velocity def 90
-	//*(float*)(AddressOffset + 0x811140) = 180.0f;	//gauss_turret.proj Final Velocity def 90
-	*(float*)(AddressOffset + 0x97A194) = 800.0f;	//magnum_bullet.proj initial def 400
-	*(float*)(AddressOffset + 0x97A198) = 800.0f;	//magnum_bullet.proj final def 400
-	*(float*)(AddressOffset + 0x7E7E20) = 1600.0f;	//bullet.proj (chaingun) initial def 800
-	*(float*)(AddressOffset + 0x7E7E24) = 1600.0f;	//bullet.proj (chaingun) final def 800
+	*(float*)(AddressOffset + 0xCE4598) = 4000.0f; //beam_rifle_beam.proj Initial Velocity
+	*(float*)(AddressOffset + 0xCE459C) = 4000.0f; //beam_rifle_beam.proj Final Velocity
+	*(float*)(AddressOffset + 0x81113C) = 200.0f; //gauss_turret.proj Initial Velocity def 90
+	*(float*)(AddressOffset + 0x811140) = 200.0f; //gauss_turret.proj Final Velocity def 90
+	*(float*)(AddressOffset + 0x97A194) = 800.0f; //magnum_bullet.proj initial def 400
+	*(float*)(AddressOffset + 0x97A198) = 800.0f; //magnum_bullet.proj final def 400
+	*(float*)(AddressOffset + 0x7E7E20) = 2000.0f; //bullet.proj (chaingun) initial def 800
+	*(float*)(AddressOffset + 0x7E7E24) = 2000.0f; //bullet.proj (chaingun) final def 800
 }

--- a/xlive/H2MOD/Modules/Startup/Startup.cpp
+++ b/xlive/H2MOD/Modules/Startup/Startup.cpp
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include <string>
 #include <sstream>
+#include <io.h>
 #include "Util\Hooks\Hook.h"
 #include "Util\Debug\Debug.h"
 #include "Util\hash.h"
@@ -83,7 +84,11 @@ void initInstanceNumber() {
 
 wchar_t xinput_path[_MAX_PATH];
 
-void configureXinput() {
+bool configureXinput() {
+	auto report_error = [](const std::string &message) {
+		MessageBoxA(NULL, message.c_str(), "Xinput config error!", MB_OK);
+	};
+
 	if (!H2IsDediServer) {
 		if (H2GetInstanceId() > 1) {
 			swprintf(xinput_path, ARRAYSIZE(xinput_path), L"xinput/p%02d/xinput9_1_0.dll", H2GetInstanceId());
@@ -95,112 +100,107 @@ void configureXinput() {
 			char xinputdir[_MAX_PATH];
 			sprintf(xinputdir, "xinput/p%02d", H2GetInstanceId());
 			sprintf(xinputName, "%s/xinput9_1_0.dll", xinputdir);
-			CreateDirectoryA("xinput", NULL);
-			int fperrno1 = GetLastError();
-			if (!(fperrno1 == ERROR_ALREADY_EXISTS || fperrno1 == ERROR_SUCCESS)) {
-				fileFail(NULL);
-				MessageBoxA(NULL, "Error 7g546.", "Unknown Error", MB_OK);
-				exit(EXIT_FAILURE);
-			}
-			CreateDirectoryA(xinputdir, NULL);
-			int fperrno2 = GetLastError();
-			if (!(fperrno2 == ERROR_ALREADY_EXISTS || fperrno2 == ERROR_SUCCESS)) {
-				fileFail(NULL);
-				MessageBoxA(NULL, "Error 7g547.", "Unknown Error", MB_OK);
-				exit(EXIT_FAILURE);
-			}
-			if (FILE *file = fopen(xinputName, "r")) {
-				fclose(file);
-			}
-			else {
-				int xinput_index = -1;
-				char xinput_md5_durazno_0_6_0_0[] = "6140ae76b26a633ce2255f6fc88fbe34";
-				long xinput_offset_durazno_0_6_0_0 = 0x196de;
-				bool xinput_unicode_durazno_0_6_0_0 = true;
-				char xinput_md5_x360ce_3_3_1_444[] = "8f24e36d5f0a71c8a412cec6323cd781";
-				long xinput_offset_x360ce_3_3_1_444 = 0x1ea54;
-				bool xinput_unicode_x360ce_3_3_1_444 = true;
-				char xinput_md5_x360ce_3_4_1_1357[] = "5236623449893c0e1e98fc95f067fcff";
-				long xinput_offset_x360ce_3_4_1_1357 = 0x16110;
-				bool xinput_unicode_x360ce_3_4_1_1357 = false;
-				const int xinput_array_length = 3;
-				char* xinput_md5[xinput_array_length] = { xinput_md5_durazno_0_6_0_0, xinput_md5_x360ce_3_3_1_444, xinput_md5_x360ce_3_4_1_1357 };
-				long xinput_offset[xinput_array_length] = { xinput_offset_durazno_0_6_0_0, xinput_offset_x360ce_3_3_1_444, xinput_offset_x360ce_3_4_1_1357 };
-				bool xinput_unicode[xinput_array_length] = { xinput_unicode_durazno_0_6_0_0, xinput_unicode_x360ce_3_3_1_444, xinput_unicode_x360ce_3_4_1_1357 };
-				std::string available_xinput_md5;
-				int hasherr = hashes::calc_file_md5("xinput9_1_0.dll", available_xinput_md5);
-				FILE* file1 = NULL;
-				if (hasherr == 0 && (file1 = fopen("xinput9_1_0.dll", "rb"))) {
-					for (int i = 0; i < xinput_array_length; i++) {
-						if (strcmp(xinput_md5[i], available_xinput_md5.c_str()) == 0) {
-							xinput_index = i;
-							break;
-						}
-					}
-					if (xinput_index < 0) {
-						char xinputError[] = "ERROR! For \'Split-screen\' play, a supported xinput9_1_0.dll is required to be installed in the local game directory!\nOr you may install a custom one manually in the xinput/p??/ folders.";
-						addDebugText(xinputError);
-						MessageBoxA(NULL, xinputError, "Incorrect DLL Error", MB_OK);
-						exit(EXIT_FAILURE);
-					}
-					FILE* file2 = fopen(xinputName, "wb");
-					if (!file2) {
-						fileFail(file2);
-						MessageBoxA(NULL, "Error bf58i.", "Unknown Error", MB_OK);
-						exit(EXIT_FAILURE);
-					}
-					char buffer[BUFSIZ];
-					size_t n;
-					while ((n = fread(buffer, sizeof(char), sizeof(buffer), file1)) > 0) {
-						if (fwrite(buffer, sizeof(char), n, file2) != n) {
-							char xinputError[255];
-							sprintf(xinputError, "ERROR! Failed to write copied file: %s", xinputName);
-							addDebugText(xinputError);
-							MessageBoxA(NULL, xinputError, "DLL Copy Error", MB_OK);
-							exit(EXIT_FAILURE);
-						}
-					}
-					fclose(file1);
-					fclose(file2);
 
-					FILE* file3 = fopen(xinputName, "r+b");
-					int len_to_write = 2;
-					BYTE assmXinputDuraznoNameEdit[] = { 0x30 + (H2GetInstanceId() / 10), 0x30 + (H2GetInstanceId() % 10), 0x30 + (H2GetInstanceId() % 10) };
-					if (xinput_unicode[xinput_index]) {
-						assmXinputDuraznoNameEdit[1] = 0x00;
-						len_to_write = 3;
-					}
-					if (fseek(file3, xinput_offset[xinput_index], SEEK_SET) == 0 && fwrite(assmXinputDuraznoNameEdit, sizeof(BYTE), len_to_write, file3) == len_to_write) {
-						addDebugText("Successfully copied and patched original xinput9_1_0.dll");
-					}
-					else {
-						fclose(file3);
-						remove(xinputName);
-						char xinputError[255];
-						sprintf(xinputError, "ERROR! Failed to write hex edit to file: %s", xinputName);
-						addDebugText(xinputError);
-						MessageBoxA(NULL, xinputError, "DLL Edit Error", MB_OK);
-						exit(EXIT_FAILURE);
-					}
-					fclose(file3);
+			/* Creates a directory and displays error if it fails */
+			auto create_dir = [=](const std::string &path) -> bool {
+				if (LOG_CHECK(!CreateDirectoryA(path.c_str(), NULL) && GetLastError() != ERROR_ALREADY_EXISTS))
+				{
+					report_error("Failed to create '" + path + "' directory, check logs!");
+					return false;
 				}
-				else if (hasherr == -1 || !file1) {
-					char xinputError[] = "ERROR! An xinput9_1_0.dll does not exist in the local game directory!\nFor \'Split-screen\' play, any supported .dll is required.";
+				return true;
+			};
+
+			if (!create_dir("xinput") || !create_dir(xinputdir))
+			{
+				return false;
+			}
+
+			TRACE_FUNC_N("xinput path: %s", xinputName);
+			if (_access_s(xinputName, 02))
+			{
+				if (errno == EACCES)
+				{
+					report_error("Can't access the xinput dll for writing");
+					return false;
+				}
+
+				if (_access_s("xinput9_1_0.dll", 04) != 0) {
+					char xinputError[] = "ERROR! An xinput9_1_0.dll does not exist in the local game directory or is inaccessible!\nFor \'Split-screen\' play, any supported .dll is required.";
 					addDebugText(xinputError);
 					MessageBoxA(NULL, xinputError, "DLL Missing Error", MB_OK);
 					exit(EXIT_FAILURE);
 				}
-				else {
-					char xinputError[200];
-					snprintf(xinputError, 200, "Hash Error Num: %x - msg: %s", hasherr, available_xinput_md5.c_str());
+				int xinput_index = -1;
+				constexpr char *xinput_md5_durazno_0_6_0_0 = "6140ae76b26a633ce2255f6fc88fbe34";
+				constexpr long xinput_offset_durazno_0_6_0_0 = 0x196de;
+				constexpr bool xinput_unicode_durazno_0_6_0_0 = true;
+				constexpr char *xinput_md5_x360ce_3_3_1_444 = "8f24e36d5f0a71c8a412cec6323cd781";
+				constexpr long xinput_offset_x360ce_3_3_1_444 = 0x1ea54;
+				constexpr bool xinput_unicode_x360ce_3_3_1_444 = true;
+				constexpr char *xinput_md5_x360ce_3_4_1_1357 = "5236623449893c0e1e98fc95f067fcff";
+				constexpr long xinput_offset_x360ce_3_4_1_1357 = 0x16110;
+				constexpr bool xinput_unicode_x360ce_3_4_1_1357 = false;
+				constexpr int xinput_array_length = 3;
+				static constexpr char* xinput_md5[xinput_array_length] = { xinput_md5_durazno_0_6_0_0, xinput_md5_x360ce_3_3_1_444, xinput_md5_x360ce_3_4_1_1357 };
+				static constexpr long xinput_offset[xinput_array_length] = { xinput_offset_durazno_0_6_0_0, xinput_offset_x360ce_3_3_1_444, xinput_offset_x360ce_3_4_1_1357 };
+				static constexpr bool xinput_unicode[xinput_array_length] = { xinput_unicode_durazno_0_6_0_0, xinput_unicode_x360ce_3_3_1_444, xinput_unicode_x360ce_3_4_1_1357 };
+				std::string available_xinput_md5;
+				if (!hashes::calc_file_md5("xinput9_1_0.dll", available_xinput_md5))
+				{
+					report_error("Failed to hash original xinput9_1_0.dll, file might be missing?");
+					return false;
+				}
+				for (int i = 0; i < xinput_array_length; i++) {
+					if (strcmp(xinput_md5[i], available_xinput_md5.c_str()) == 0) {
+						xinput_index = i;
+						break;
+					}
+				}
+				if (xinput_index < 0) {
+					char xinputError[] = "ERROR! For \'Split-screen\' play, a supported xinput9_1_0.dll is required to be installed in the local game directory!\nOr you may install a custom one manually in the xinput/p??/ folders.";
 					addDebugText(xinputError);
-					MessageBoxA(NULL, xinputError, "MD5 Hash Error", MB_OK);
+					MessageBoxA(NULL, xinputError, "Incorrect DLL Error", MB_OK);
 					exit(EXIT_FAILURE);
 				}
+
+				if (!LOG_CHECK(CopyFileA("xinput9_1_0.dll", xinputName, FALSE)))
+				{
+					report_error("Failed to copy Xinput DLL for patching!");
+					return false;
+				}
+
+				FILE* xinput_patched = fopen(xinputName, "r+b");
+				if (!xinput_patched) {
+					fileFail(xinput_patched);
+					report_error("Can't open xinput file for patching.");
+					exit(EXIT_FAILURE);
+				}
+
+				int len_to_write = 2;
+				BYTE assmXinputDuraznoNameEdit[] = { 0x30 + (H2GetInstanceId() / 10), 0x30 + (H2GetInstanceId() % 10), 0x30 + (H2GetInstanceId() % 10) };
+				if (xinput_unicode[xinput_index]) {
+					assmXinputDuraznoNameEdit[1] = 0x00;
+					len_to_write = 3;
+				}
+				if (fseek(xinput_patched, xinput_offset[xinput_index], SEEK_SET) == 0 && fwrite(assmXinputDuraznoNameEdit, sizeof(BYTE), len_to_write, xinput_patched) == len_to_write) {
+					addDebugText("Successfully copied and patched original xinput9_1_0.dll");
+				}
+				else {
+					fclose(xinput_patched);
+					remove(xinputName);
+					char xinputError[255];
+					sprintf(xinputError, "ERROR! Failed to write hex edit to file: %s", xinputName);
+					addDebugText(xinputError);
+					MessageBoxA(NULL, xinputError, "DLL Edit Error", MB_OK);
+					exit(EXIT_FAILURE);
+				}
+				fclose(xinput_patched);
 			}
 		}
 	}
 	addDebugText("Finished Processing Instance Number.");
+	return true;
 }
 
 void initLocalAppData() {
@@ -408,7 +408,8 @@ void InitH2Startup() {
 #endif
 	InitH2Accounts();
 
-	configureXinput();
+	if (!configureXinput())
+		exit(EXIT_FAILURE);
 
 	//apply any network hooks
 	network->applyNetworkHooks();

--- a/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
+++ b/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
@@ -1136,6 +1136,14 @@ void H2Tweaks::setSens(InputType input_type, int sens) {
 	}
 }
 
+void H2Tweaks::setSavedSens() {
+	if (H2Config_mouse_sens != 0)
+		H2Tweaks::setSens(MOUSE, (H2Config_mouse_sens));
+
+	if (H2Config_controller_sens != 0)
+		H2Tweaks::setSens(CONTROLLER, (H2Config_controller_sens));
+}
+
 void H2Tweaks::setFOV(double field_of_view_degrees) {
 
 	if (H2IsDediServer)
@@ -1154,6 +1162,14 @@ void H2Tweaks::setFOV(double field_of_view_degrees) {
 		WriteValue(H2BaseAddr + 0x41D984, calculated_radians_FOV); // First Person
 		WriteValue(H2BaseAddr + 0x413780, calculated_radians_FOV + 0.22f); // Third Person
 	}
+}
+
+void H2Tweaks::setHz() {
+
+	if (H2IsDediServer)
+		return;
+
+	*(BYTE*)(H2BaseAddr + 0xA3DA08) = (H2Config_refresh_rate);
 }
 
 void H2Tweaks::setCrosshairPos(float crosshair_offset) {

--- a/xlive/H2MOD/Modules/Tweaks/Tweaks.h
+++ b/xlive/H2MOD/Modules/Tweaks/Tweaks.h
@@ -19,8 +19,10 @@ namespace H2Tweaks {
 	void enable60FPSCutscenes();
 	void disable60FPSCutscenes();
 	void setFOV(double field_of_view_degrees);
+	void setHz();
 	void setCrosshairPos(float crosshair_offset);
 	void setCrosshairSize(int size, bool preset);
 	void applyPlayersActionsUpdateRatePatch();
 	void setSens(InputType input_type, int sens);
+	void setSavedSens();
 }

--- a/xlive/XLive/Networking/ServerList.cpp
+++ b/xlive/XLive/Networking/ServerList.cpp
@@ -12,8 +12,8 @@ using namespace rapidjson;
 extern CHAR g_szUserName[4][16];
 extern unsigned short H2Config_base_port;
 
-HANDLE ServerEnum = NULL;
 ServerList LiveManager;
+HANDLE ServerEnum = NULL;
 
 static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
@@ -21,20 +21,18 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 	return size * nmemb;
 }
 
-void BadServer(ULONGLONG xuid, _XLOCATOR_SEARCHRESULT* nResult,const char* log_catch)
+void BadServer(ULONGLONG xuid, _XLOCATOR_SEARCHRESULT* nResult, const char* log_catch)
 {
 	if (H2Config_debug_log)
-		TRACE_GAME_N("BadServer - XUID: %llu - Log Catch: %s", xuid,log_catch);
+		TRACE_GAME_N("BadServer - XUID: %llu - Log Catch: %s", xuid, log_catch);
 
 	ZeroMemory(nResult, sizeof(_XLOCATOR_SEARCHRESULT));
 }
-void QueryServerData(ULONGLONG xuid,_XLOCATOR_SEARCHRESULT* nResult)
-{	
-	CURL *curl;
+void QueryServerData(CURL* curl, ULONGLONG xuid, _XLOCATOR_SEARCHRESULT* nResult)
+{
 	CURLcode res;
 	std::string readBuffer;
 
-	curl = curl_easy_init();
 	if (curl) {
 
 		std::string server_url = std::string("http://cartographer.online/live/servers/");
@@ -44,7 +42,6 @@ void QueryServerData(ULONGLONG xuid,_XLOCATOR_SEARCHRESULT* nResult)
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		res = curl_easy_perform(curl);
-		curl_easy_cleanup(curl);
 
 		rapidjson::Document doc;
 		doc.Parse(readBuffer.c_str());
@@ -125,13 +122,12 @@ void QueryServerData(ULONGLONG xuid,_XLOCATOR_SEARCHRESULT* nResult)
 
 		for (int i = 0; i < 6; i++) {
 			sscanf(&abEnet[i * 2], "%2hhx", &nResult->serverAddress.abEnet[i]);
-		}
-		
+		}	
 
 		if (!doc.HasMember("abonline"))
 		{
 			BadServer(xuid, nResult, "Missing Member: abOnline");
-				return;
+			return;
 		}
 
 		const char* abOnline = doc["abonline"].GetString();
@@ -144,7 +140,7 @@ void QueryServerData(ULONGLONG xuid,_XLOCATOR_SEARCHRESULT* nResult)
 		for (int i = 0; i < 20; i++) {
 			sscanf(&abOnline[i * 2], "%2hhx", &nResult->serverAddress.abOnline[i]);
 		}
-	
+
 		if (!doc.HasMember("xuid"))
 		{
 			BadServer(xuid, nResult, "Missing Member: xuid");
@@ -171,45 +167,45 @@ void QueryServerData(ULONGLONG xuid,_XLOCATOR_SEARCHRESULT* nResult)
 		{
 			nResult->pProperties[current_property].dwPropertyId = property["dwPropertyId"].GetInt();
 			nResult->pProperties[current_property].value.type = property["type"].GetInt();
-			
+
 			const char* data = 0;
 			wchar_t *unicode_data = 0;
 			int str_len = 0;
-			
+
 
 			GenericStringBuffer<UTF16<> > buffer;
 			Writer<GenericStringBuffer<UTF16<> >, UTF8<>, UTF16<> > writer(buffer);
 			std::wstring str;
 			switch (property["type"].GetInt())
 			{
-				case XUSER_DATA_TYPE_INT32:
-					nResult->pProperties[current_property].value.nData = property["value"].GetInt();
+			case XUSER_DATA_TYPE_INT32:
+				nResult->pProperties[current_property].value.nData = property["value"].GetInt();
 				break;
 
-				case XUSER_DATA_TYPE_UNICODE:
-					writer.String(property["value"].GetString());
-					
-					str.append(buffer.GetString());
-					
-					str.erase(std::remove(str.begin(), str.end(), '"'), str.end());
-					str.erase(std::remove(str.begin(), str.end(), '\\'), str.end());
+			case XUSER_DATA_TYPE_UNICODE:
+				writer.String(property["value"].GetString());
 
-					unicode_data = new wchar_t[str.size()+1];
-					ZeroMemory(unicode_data, str.size()+1);
+				str.append(buffer.GetString());
 
-					wcscpy(unicode_data, str.c_str());
-					
-					nResult->pProperties[current_property].value.string.cbData = buffer.GetSize();
-					nResult->pProperties[current_property].value.string.pwszData = unicode_data;
+				str.erase(std::remove(str.begin(), str.end(), '"'), str.end());
+				str.erase(std::remove(str.begin(), str.end(), '\\'), str.end());
+
+				unicode_data = new wchar_t[str.size() + 1];
+				ZeroMemory(unicode_data, str.size() + 1);
+
+				wcscpy(unicode_data, str.c_str());
+
+				nResult->pProperties[current_property].value.string.cbData = buffer.GetSize();
+				nResult->pProperties[current_property].value.string.pwszData = unicode_data;
 
 
 				break;
 
-				case XUSER_DATA_TYPE_INT64:
-					nResult->pProperties[current_property].value.i64Data = property["value"].GetInt64();
+			case XUSER_DATA_TYPE_INT64:
+				nResult->pProperties[current_property].value.i64Data = property["value"].GetInt64();
 				break;
 			}
-			
+
 			current_property++;
 		}
 	}
@@ -217,9 +213,9 @@ void QueryServerData(ULONGLONG xuid,_XLOCATOR_SEARCHRESULT* nResult)
 	++LiveManager.total_servers;
 }
 
-void GetServersFromHttp(ServerList* servptr,PXOVERLAPPED pOverlapped, DWORD cbBuffer, char* pvBuffer)
+void GetServersFromHttp(ServerList* servptr, PXOVERLAPPED pOverlapped, DWORD cbBuffer, char* pvBuffer)
 {
-	servptr->running = true;
+	servptr->server_list_download_running = true;
 	
 	addDebugText("Requesting server list");
 
@@ -233,19 +229,18 @@ void GetServersFromHttp(ServerList* servptr,PXOVERLAPPED pOverlapped, DWORD cbBu
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		res = curl_easy_perform(curl);
-		curl_easy_cleanup(curl);
 
 		rapidjson::Document document;
 		document.Parse(readBuffer.c_str());
-		
+
 		int server_count = document["servers"].Size();
 		servptr->servers_left = server_count;
 
 		if (server_count * sizeof(_XLOCATOR_SEARCHRESULT) > cbBuffer) {
 			
-			servptr->running = false;
+			servptr->server_list_download_running = false;
 			servptr->servers_left = -1;
-			
+
 			pOverlapped->InternalLow = ERROR_INSUFFICIENT_BUFFER;
 			pOverlapped->dwExtendedError = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
 
@@ -257,24 +252,27 @@ void GetServersFromHttp(ServerList* servptr,PXOVERLAPPED pOverlapped, DWORD cbBu
 		for (auto& server : document["servers"].GetArray())
 		{
 			ULONGLONG xuid = std::stoll(server.GetString());
-			QueryServerData(xuid, &server_buffer[servptr->GetTotalServers()]);
-			
+			QueryServerData(curl, xuid, &server_buffer[servptr->GetTotalServers()]);
+
 			servptr->servers_left--;
-			pOverlapped->InternalLow = ERROR_SUCCESS;			
+			pOverlapped->InternalLow = ERROR_SUCCESS;
 			pOverlapped->InternalHigh = servptr->GetTotalServers();
 			pOverlapped->dwExtendedError = HRESULT_FROM_WIN32(ERROR_IO_PENDING);
 		}
-	}
-	std::string debg_1 = "Server Count: " + std::to_string(servptr->total_servers);
-	addDebugText(debg_1.c_str());
 
-	servptr->running = false;
+		std::string debg_1 = "Server Count: " + std::to_string(servptr->GetTotalServers());
+		addDebugText(debg_1.c_str());
+		curl_easy_cleanup(curl);
+	}
+
+	servptr->server_list_download_running = false;
 }
 
 
-bool ServerList::GetServerCounts()
+void ServerList::GetServerCounts()
 {
 
+	this->server_counts_download_running = true;
 	CURL *curl;
 	CURLcode res;
 	std::string readBuffer;
@@ -299,13 +297,11 @@ bool ServerList::GetServerCounts()
 			total_public = document["public_count"].GetInt();
 			total_public_gold = document["public_gold"].GetInt();
 
-			return true;
 		}
 
-		return false;
 	}
 
-	return false;
+	this->server_counts_download_running = false;
 }
 
 int ServerList::GetServersLeft()
@@ -320,7 +316,7 @@ int ServerList::GetTotalServers()
 
 bool ServerList::GetRunning()
 {
-	return running;
+	return server_list_download_running;
 }
 
 void ServerList::GetServers(PXOVERLAPPED pOverlapped, DWORD cbBuffer, char* pvBuffer)
@@ -329,7 +325,7 @@ void ServerList::GetServers(PXOVERLAPPED pOverlapped, DWORD cbBuffer, char* pvBu
 	pOverlapped->InternalHigh = ERROR_IO_INCOMPLETE;
 
 	// check if another thread isn't running and servers_left is in "unitialized state"
-	if (!this->running && this->servers_left == -1)
+	if (!this->server_list_download_running && this->servers_left == -1)
 	{
 		this->total_servers = 0;
 		this->serv_thread = std::thread(GetServersFromHttp, this, pOverlapped, cbBuffer, pvBuffer);
@@ -346,9 +342,7 @@ void ServerList::GetServers(PXOVERLAPPED pOverlapped, DWORD cbBuffer, char* pvBu
 		pOverlapped->InternalHigh = this->GetTotalServers();
 		pOverlapped->dwExtendedError = HRESULT_FROM_WIN32(ERROR_NO_MORE_FILES);
 	}
-
 }
-
 
 void RemoveServer()
 {
@@ -379,7 +373,6 @@ void RemoveServer()
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, buffer.GetString());
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
-
 	}
 }
 
@@ -502,21 +495,14 @@ DWORD WINAPI XLocatorGetServiceProperty(DWORD dwUserIndex, DWORD cNumProperties,
 	// TRACE("XLocatorGetServiceProperty  (*** checkme ***) (dwUserIndex = %X, cNumProperties = %X, pProperties = %X, pOverlapped = %X)",
 	//		dwUserIndex, cNumProperties, pProperties, pOverlapped);
 
-	if (LiveManager.GetServerCounts())
-	{
-		pProperties[0].value.nData = LiveManager.total_count;
-		pProperties[1].value.nData = LiveManager.total_public;
-		pProperties[2].value.nData = LiveManager.total_peer_gold + LiveManager.total_public_gold;
-		pProperties[3].value.nData = LiveManager.total_peer;
-
-		return S_OK;
-	}
+	if (!LiveManager.server_counts_download_running)
+		std::thread(&ServerList::GetServerCounts, &LiveManager).detach();
 
 	//Sets Not Available to display if pProperties fails to get server count.
-	pProperties[0].value.nData = -1;
-	pProperties[1].value.nData = -1;
-	pProperties[2].value.nData = -1;
-	pProperties[3].value.nData = -1;
+	pProperties[0].value.nData = LiveManager.total_count;
+	pProperties[1].value.nData = LiveManager.total_public;
+	pProperties[2].value.nData = LiveManager.total_peer_gold + LiveManager.total_public_gold != -2 ? LiveManager.total_peer_gold + LiveManager.total_public_gold : -1;
+	pProperties[3].value.nData = LiveManager.total_peer;
 
 	return S_OK;
 }
@@ -527,7 +513,7 @@ DWORD WINAPI XLocatorCreateServerEnumerator(int a1, int a2, int a3, int a4, int 
 {
 	TRACE("XLocatorCreateServerEnumerator");
 
-	*pcbBuffer = (DWORD)(sizeof(_XLOCATOR_SEARCHRESULT) * (LiveManager.total_count + 10));
+	*pcbBuffer = (DWORD)(sizeof(_XLOCATOR_SEARCHRESULT) * 200); // 200 is the maximum XLocator could hold per title
 
 	if (phEnum)
 	{

--- a/xlive/XLive/Networking/ServerList.h
+++ b/xlive/XLive/Networking/ServerList.h
@@ -74,22 +74,23 @@ class ServerList
 	std::thread serv_thread;
 
 public:
-	std::atomic<bool> running = false;
+	std::atomic<bool> server_list_download_running = false;
+	std::atomic<bool> server_counts_download_running = false;
 	bool completed = false;
 	int servers_left = -1;
 	int total_servers = 0;
 
-	int total_count = 0;
-	int total_public = 0;
-	int total_public_gold = 0;
-	int total_peer = 0;
-	int total_peer_gold = 0;
+	int total_count = -1;
+	int total_public = -1;
+	int total_peer = -1;
+	int total_peer_gold = -1;
+	int total_public_gold = -1;
 
 	bool GetRunning();
 	void GetServers(PXOVERLAPPED, DWORD, char*);
 	int GetServersLeft();
 	int GetTotalServers();
-	bool GetServerCounts();
+	void GetServerCounts();
 
 
 };

--- a/xlive/xliveless.h
+++ b/xlive/xliveless.h
@@ -44,29 +44,36 @@ extern logger *network_log;
 #define TRACE(msg, ...) CHECK_PTR(xlive_trace_log, xlive_trace_log->write(L ## msg, __VA_ARGS__))
 #define TRACE_N(msg, ...) CHECK_PTR(xlive_trace_log, xlive_trace_log->write( ## msg, __VA_ARGS__))
 
+inline void verify_output_log(const char *expression, const char *func_name, const char* file, const int line)
+{
+	TRACE_GAME_N("'%s' failed in '%s' at '%s:%d'!", func_name, expression, file, line);
+	DWORD last_error = GetLastError();
+	if (last_error)
+	{
+		LPWSTR messageBuffer = NULL;
+		size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+		if (size) {
+			TRACE_GAME_N("Last error: '%ws'", messageBuffer);
+			LocalFree(messageBuffer);
+		}
+		else {
+			TRACE_GAME_N("Converting error %d to string failed!", last_error);
+		}
+		SetLastError(0);
+	}
+}
+
+
 template <typename T>
 inline T verify_output(T output, const char *expression, const char *func_name, const char* file, const int line)
 {
 	if (!output) {
-		TRACE_GAME_N("'%s' failed in '%s' at '%s:%d'!", func_name, expression, file, line);
-		DWORD last_error = GetLastError();
-		if (last_error)
-		{
-			LPWSTR messageBuffer = NULL;
-			size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-				NULL, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
-			if (size) {
-				TRACE_GAME_N("Last error: '%ws'", messageBuffer);
-				LocalFree(messageBuffer);
-			}
-			else {
-				TRACE_GAME_N("Converting error %d to string failed!", last_error);
-			}
-			SetLastError(0);
-}
+		verify_output_log(expression, func_name, file, line);
 	}
 	return output;
 }
+
 #define LOG_CHECK(expression) \
 	verify_output(expression, #expression, __FUNCTION__, __FILE__, __LINE__)
 


### PR DESCRIPTION
-Force Refresh Rate
Saves and forces a selected refresh rate from the Carto settings menu on startup
-Save mouse/controller sens
Saves the value last inputed into the console and pokes it on map load. The default value is zero and the code does nothing if it is zero.
-Fix for console spawn commands
Should only be able to be used by the host now
-Hitfix reverted to 4.0.4 values
-Live server list downloads faster
Original commit by Nuke found here
NukeULater@1d14f0d
-Fix for Xinput copying
This fixes splitscreen. Original commit by num005 found here
num0005@2e761c4

num0005@d23e8f0

num0005@82c6455

num0005@09be95a

-Commented out some unused features