### PR TITLE
Separated Vehicle FOV and Fixed Third Person FOV calculation

### DIFF
--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1769,6 +1769,7 @@ void H2MOD::Initialize()
 		this->Server = FALSE;
 		
 		H2Tweaks::setFOV(H2Config_field_of_view);
+		H2Tweaks::setVehicleFOV(H2Config_vehicle_field_of_view);
 		if (H2Config_raw_input)
 			Mouseinput::Initialize();
 

--- a/xlive/H2MOD/Modules/Config/Config.cpp
+++ b/xlive/H2MOD/Modules/Config/Config.cpp
@@ -87,6 +87,7 @@ bool H2Config_discord_enable = true;
 int H2Config_fps_limit = 60;
 int H2Config_static_lod_state = static_lod::disable;
 int H2Config_field_of_view = 0;
+int H2Config_vehicle_field_of_view = 0;
 int H2Config_refresh_rate = 60;
 int H2Config_mouse_sens = 0;
 int H2Config_controller_sens = 0;
@@ -431,6 +432,9 @@ void SaveH2Config() {
 			sprintf(settingOutBuffer, "\nfield_of_view = %d", H2Config_field_of_view);
 			fputs(settingOutBuffer, fileConfig);
 
+			sprintf(settingOutBuffer, "\nvehicle_field_of_view = %d", H2Config_vehicle_field_of_view);
+			fputs(settingOutBuffer, fileConfig);
+
 			sprintf(settingOutBuffer, "\nrefresh_rate = %d", H2Config_refresh_rate);
 			fputs(settingOutBuffer, fileConfig);
 
@@ -635,6 +639,7 @@ static bool est_discord_enable = false;
 static bool est_fps_limit = false;
 static bool est_static_lod_state = false;
 static bool est_field_of_view = false;
+static bool est_vehicle_field_of_view = false;
 static bool est_refresh_rate = false;
 static bool est_mouse_sens = false;
 static bool est_controller_sens = false;
@@ -712,6 +717,7 @@ static void est_reset_vars() {
 	est_fps_limit = false;
 	est_static_lod_state = false;
 	est_field_of_view = false;
+	est_vehicle_field_of_view = false;
 	est_refresh_rate = false;
 	est_mouse_sens = false;
 	est_controller_sens = false;
@@ -1005,6 +1011,19 @@ static int interpretConfigSetting(char* fileLine, char* version, int lineNumber)
 				H2Config_field_of_view = tempint1;
 				est_field_of_view = true;
 			}
+		}
+		else if (!H2IsDediServer && sscanf(fileLine, "vehicle_field_of_view =%d", &tempint1) == 1) {
+			if (est_vehicle_field_of_view) {
+				duplicated = true;
+			}
+		else if (!(tempint1 >= 0)) {
+			incorrect = true;
+		}
+		else {
+			H2Config_vehicle_field_of_view = tempint1;
+			est_vehicle_field_of_view = true;
+		}
+
 		}
 		else if (!H2IsDediServer && sscanf(fileLine, "refresh_rate =%d", &tempint1) == 1) {
 			if (est_refresh_rate) {

--- a/xlive/H2MOD/Modules/Config/Config.h
+++ b/xlive/H2MOD/Modules/Config/Config.h
@@ -35,6 +35,7 @@ extern bool H2Config_discord_enable;
 extern int H2Config_fps_limit;
 extern int H2Config_static_lod_state;
 extern int H2Config_field_of_view;
+extern int H2Config_vehicle_field_of_view;
 extern int H2Config_mouse_sens;
 extern int H2Config_controller_sens;
 extern int H2Config_refresh_rate;

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
@@ -1516,6 +1516,143 @@ void GSCustomMenuCall_EditFOV() {
 
 #pragma endregion
 
+const int CMLabelMenuId_VehicleEditFOV = 0xFF000020;
+#pragma region CM_EditVehicleFOV
+
+static void loadLabelVehicleFOVNum() {
+	if (H2Config_vehicle_field_of_view != 70) {
+		char* lblFpsLimitNum = H2CustomLanguageGetLabel(CMLabelMenuId_VehicleEditFOV, 0xFFFF0003);
+		if (!lblFpsLimitNum)
+			return;
+		int buildLimitLabelLen = strlen(lblFpsLimitNum) + 20;
+		char* buildLimitLabel = (char*)malloc(sizeof(char) * buildLimitLabelLen);
+		snprintf(buildLimitLabel, buildLimitLabelLen, lblFpsLimitNum, H2Config_vehicle_field_of_view);
+		add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 3, buildLimitLabel, true);
+		free(buildLimitLabel);
+	}
+	else {
+		char* lblFpsLimitDisabled = H2CustomLanguageGetLabel(CMLabelMenuId_VehicleEditFOV, 0xFFFF0013);
+		add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 3, lblFpsLimitDisabled, true);
+	}
+}
+
+void __stdcall CMLabelButtons_EditVehicleFOV(int a1, int a2)
+{
+	int(__thiscall* sub_211909)(int, int, int, int) = (int(__thiscall*)(int, int, int, int))((char*)H2BaseAddr + 0x211909);
+	void(__thiscall* sub_21bf85)(int, int label_id) = (void(__thiscall*)(int, int))((char*)H2BaseAddr + 0x21bf85);
+
+	__int16 button_id = *(WORD*)(a1 + 112);
+	int v3 = sub_211909(a1, 6, 0, 0);
+	if (v3)
+	{
+		sub_21bf85_CMLTD(v3, button_id + 1, CMLabelMenuId_VehicleEditFOV);
+	}
+}
+
+__declspec(naked) void sub_2111ab_CMLTD_nak_EditVehicleFOV() {//__thiscall
+	__asm {
+		mov eax, [esp + 4h]
+
+		push ebp
+		push edi
+		push esi
+		push ecx
+		push ebx
+
+		push 0xFFFFFFF1//label_id_description
+		push 0xFFFFFFF0//label_id_title
+		push CMLabelMenuId_VehicleEditFOV
+		push eax
+		push ecx
+		call sub_2111ab_CMLTD//__stdcall
+
+		pop ebx
+		pop ecx
+		pop esi
+		pop edi
+		pop ebp
+
+		retn 4
+	}
+}
+
+static bool CMButtonHandler_EditVehicleFOV(int button_id) {
+	const int upper_limit = 110;
+	if (button_id == 0) {
+		if (H2Config_vehicle_field_of_view <= upper_limit - 10)
+			H2Config_vehicle_field_of_view += 10;
+		else
+			H2Config_vehicle_field_of_view = upper_limit;
+	}
+	else if (button_id == 1) {
+		if (H2Config_vehicle_field_of_view < upper_limit)
+			H2Config_vehicle_field_of_view += 1;
+	}
+	else if (button_id == 3) {
+		if (H2Config_vehicle_field_of_view > 0)
+			H2Config_vehicle_field_of_view -= 1;
+	}
+	else if (button_id == 4) {
+		if (H2Config_vehicle_field_of_view > 10)
+			H2Config_vehicle_field_of_view -= 10;
+		else
+			H2Config_vehicle_field_of_view = 0;
+	}
+	else if (button_id == 2) {
+			H2Config_vehicle_field_of_view = 70;
+	}
+	loadLabelVehicleFOVNum();
+	H2Tweaks::setVehicleFOV(H2Config_vehicle_field_of_view);
+	return false;
+}
+
+__declspec(naked) void sub_20F790_CM_nak_EditVehicleFOV() {//__thiscall
+	__asm {
+		push ebp
+		push edi
+		push esi
+		push ecx
+		push ebx
+
+		push 0//selected button id
+		push ecx
+		call sub_20F790_CM//__stdcall
+
+		pop ebx
+		pop ecx
+		pop esi
+		pop edi
+		pop ebp
+
+		retn
+	}
+}
+
+int __cdecl CustomMenu_EditVehicleFOV(int);
+
+int(__cdecl *CustomMenuFuncPtrHelp_EditVehicleFOV())(int) {
+	return CustomMenu_EditVehicleFOV;
+}
+
+DWORD* menu_vftable_1_EditVehicleFOV = 0;
+DWORD* menu_vftable_2_EditVehicleFOV = 0;
+
+void CMSetupVFTables_EditVehicleFOV() {
+	CMSetupVFTables(&menu_vftable_1_EditVehicleFOV, &menu_vftable_2_EditVehicleFOV, (DWORD)CMLabelButtons_EditVehicleFOV, (DWORD)sub_2111ab_CMLTD_nak_EditVehicleFOV, (DWORD)CustomMenuFuncPtrHelp_EditVehicleFOV, (DWORD)sub_20F790_CM_nak_EditVehicleFOV, true, 0);
+}
+
+int __cdecl CustomMenu_EditVehicleFOV(int a1) {
+	loadLabelVehicleFOVNum();
+	return CustomMenu_CallHead(a1, menu_vftable_1_EditVehicleFOV, menu_vftable_2_EditVehicleFOV, (DWORD)&CMButtonHandler_EditVehicleFOV, 5, 272);
+}
+
+void GSCustomMenuCall_EditVehicleFOV() {
+	int WgitScreenfunctionPtr = (int)(CustomMenu_EditVehicleFOV);
+	CallWgit(WgitScreenfunctionPtr);
+}
+
+#pragma endregion
+
 
 const int CMLabelMenuId_EditHz = 0xFF000018;
 #pragma region CM_EditHz
@@ -2531,18 +2668,21 @@ static bool CMButtonHandler_EditHudGui(int button_id) {
 		GSCustomMenuCall_EditFOV();
 	}
 	else if (button_id == 1) {
-		GSCustomMenuCall_EditCrosshair();
+		GSCustomMenuCall_EditVehicleFOV();
 	}
 	else if (button_id == 2) {
-		GSCustomMenuCall_EditCrosshairSize();
+		GSCustomMenuCall_EditCrosshair();
 	}
 	else if (button_id == 3) {
-		loadLabelToggle_EditHudGui(button_id + 1, 0xFFFFFFF4, !(H2Config_hide_ingame_chat = !H2Config_hide_ingame_chat));
+		GSCustomMenuCall_EditCrosshairSize();
 	}
 	else if (button_id == 4) {
-		loadLabelToggle_EditHudGui(button_id + 1, 0xFFFFFFF2, !(blind_hud = !blind_hud));
+		loadLabelToggle_EditHudGui(button_id + 1, 0xFFFFFFF4, !(H2Config_hide_ingame_chat = !H2Config_hide_ingame_chat));
 	}
 	else if (button_id == 5) {
+		loadLabelToggle_EditHudGui(button_id + 1, 0xFFFFFFF2, !(blind_hud = !blind_hud));
+	}
+	else if (button_id == 6) {
 		loadLabelToggle_EditHudGui(button_id + 1, 0xFFFFFFF2, !(blind_fp = !blind_fp));
 	}
 	return false;
@@ -2584,10 +2724,10 @@ void CMSetupVFTables_EditHudGui() {
 }
 
 int __cdecl CustomMenu_EditHudGui(int a1) {
-	loadLabelToggle_EditHudGui(4, 0xFFFFFFF4, !H2Config_hide_ingame_chat);
-	loadLabelToggle_EditHudGui(5, 0xFFFFFFF2, !blind_hud);
-	loadLabelToggle_EditHudGui(6, 0xFFFFFFF2, !blind_fp);
-	return CustomMenu_CallHead(a1, menu_vftable_1_EditHudGui, menu_vftable_2_EditHudGui, (DWORD)&CMButtonHandler_EditHudGui, 6, 272);
+	loadLabelToggle_EditHudGui(5, 0xFFFFFFF4, !H2Config_hide_ingame_chat);
+	loadLabelToggle_EditHudGui(6, 0xFFFFFFF2, !blind_hud);
+	loadLabelToggle_EditHudGui(7, 0xFFFFFFF2, !blind_fp);
+	return CustomMenu_CallHead(a1, menu_vftable_1_EditHudGui, menu_vftable_2_EditHudGui, (DWORD)&CMButtonHandler_EditHudGui, 7, 272);
 }
 
 void GSCustomMenuCall_EditHudGui() {
@@ -4810,14 +4950,24 @@ void initGSCustomMenu() {
 	add_cartographer_label(CMLabelMenuId_EditCrosshair, 5, "-0.02");
 
 
-	add_cartographer_label(CMLabelMenuId_EditFOV, 0xFFFFFFF0, "Edit Field of View");
-	add_cartographer_label(CMLabelMenuId_EditFOV, 0xFFFFFFF1, "Use the buttons below to modify the in-game Field of View (FoV).");
+	add_cartographer_label(CMLabelMenuId_EditFOV, 0xFFFFFFF0, "Edit Player Field of View");
+	add_cartographer_label(CMLabelMenuId_EditFOV, 0xFFFFFFF1, "Use the buttons below to modify the in-game first person Field of View (FoV).");
 	add_cartographer_label(CMLabelMenuId_EditFOV, 1, "+10");
 	add_cartographer_label(CMLabelMenuId_EditFOV, 2, "+1");
 	add_cartographer_label(CMLabelMenuId_EditFOV, 0xFFFF0003, "FoV: %d");
 	add_cartographer_label(CMLabelMenuId_EditFOV, 0xFFFF0013, "FoV Alteration Disabled");
 	add_cartographer_label(CMLabelMenuId_EditFOV, 4, "-1");
 	add_cartographer_label(CMLabelMenuId_EditFOV, 5, "-10");
+
+
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 0xFFFFFFF0, "Edit Vehicle Field of View");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 0xFFFFFFF1, "Use the buttons below to modify the Field of View (FoV) of vehicles.");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 1, "+10");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 2, "+1");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 0xFFFF0003, "FoV: %d");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 0xFFFF0013, "FoV Alteration Disabled");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 4, "-1");
+	add_cartographer_label(CMLabelMenuId_VehicleEditFOV, 5, "-10");
 
 
 	add_cartographer_label(CMLabelMenuId_EditFPS, 0xFFFFFFF0, "Edit FPS Limit");
@@ -4893,12 +5043,13 @@ void initGSCustomMenu() {
 	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFFFFF3, "Disable %s");
 	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFFFFF4, "Show %s");
 	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFFFFF5, "Hide %s");
-	add_cartographer_label(CMLabelMenuId_EditHudGui, 1, "> Field of View (FOV)");
-	add_cartographer_label(CMLabelMenuId_EditHudGui, 2, "> Crosshair Offset");
-	add_cartographer_label(CMLabelMenuId_EditHudGui, 3, "> Crosshair Size");
-	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFF0004, "Ingame Chat");
-	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFF0005, "HUD");
-	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFF0006, "First Person Model");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 1, "> Player FOV");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 2, "> Vehicle FOV");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 3, "> Crosshair Offset");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 4, "> Crosshair Size");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFF0005, "Ingame Chat");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFF0006, "HUD");
+	add_cartographer_label(CMLabelMenuId_EditHudGui, 0xFFFF0007, "First Person Model");
 
 
 	add_cartographer_label(CMLabelMenuId_ToggleSkulls, 0xFFFFFFF0, "Toggle Skulls");
@@ -5096,6 +5247,8 @@ void initGSCustomMenu() {
 	CMSetupVFTables_EditCrosshair();
 
 	CMSetupVFTables_EditFOV();
+
+	CMSetupVFTables_EditVehicleFOV();
 
 	CMSetupVFTables_EditFPS();
 

--- a/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
+++ b/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
@@ -1160,7 +1160,20 @@ void H2Tweaks::setFOV(double field_of_view_degrees) {
 
 		float calculated_radians_FOV = ((float)field_of_view_degrees * M_PI / 180.0f) / default_radians_FOV;
 		WriteValue(H2BaseAddr + 0x41D984, calculated_radians_FOV); // First Person
-		WriteValue(H2BaseAddr + 0x413780, calculated_radians_FOV + 0.22f); // Third Person
+	}
+}
+
+void H2Tweaks::setVehicleFOV(double field_of_view_degrees) {
+
+	if (H2IsDediServer)
+		return;
+
+	if (field_of_view_degrees > 0 && field_of_view_degrees <= 110)
+	{
+		float current_FOV = *reinterpret_cast<float*>(H2BaseAddr + 0x413780);
+
+		float calculated_radians_FOV = ((float)field_of_view_degrees * M_PI / 180.0f);
+		WriteValue(H2BaseAddr + 0x413780, calculated_radians_FOV); // Third Person
 	}
 }
 

--- a/xlive/H2MOD/Modules/Tweaks/Tweaks.h
+++ b/xlive/H2MOD/Modules/Tweaks/Tweaks.h
@@ -19,6 +19,7 @@ namespace H2Tweaks {
 	void enable60FPSCutscenes();
 	void disable60FPSCutscenes();
 	void setFOV(double field_of_view_degrees);
+	void setVehicleFOV(double field_of_view_degrees);
 	void setHz();
 	void setCrosshairPos(float crosshair_offset);
 	void setCrosshairSize(int size, bool preset);


### PR DESCRIPTION
Split first person player FOV and third person vehicle FOV into two different custom menus. For instance, players might not want to necessarily change both at the same time. A player might prefer to play an a lower first person FOV and a higher third person FOV when in vehicles. Now players are able to make this choice. 

Additionally, fixed the calculation for third person FOV. Previously, setting FOV to 110 degrees in the custom menu would result in a maximum value of 1.57 radians. However, based on float values in memory, third person FOV has a maximum observable value of 1.91 radians. Now, setting the FOV to 110 degrees in the vehicle FOV menu will correspond with that maximum value. 

![FOV menu](https://user-images.githubusercontent.com/34045130/58768405-b0c05b00-8568-11e9-87a0-64a97e206011.PNG)
