### PR TITLE
Implement universal fire rate calculation

### DIFF
--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -70,7 +70,7 @@ void H2X::Initialize(bool enable)
 
 				// Go through all barrel blocks and apply the fix.
 				for (int i = 0; i < barrel_data_block->block_count; i++) {
-					barrel_block = barrel_block + barrel_data_block_size * i;
+					auto barrel_block = barrel_block + barrel_data_block_size * i;
 
 					float* firerate_lower = (float*)(barrel_block + 4);
 					float* firerate_upper = (float*)(barrel_block + 8);

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -72,9 +72,9 @@ void H2X::Initialize(bool enable)
 				for (int i = 0; i < barrel_data_block->block_count; i++) {
 					barrel_block = barrel_block + barrel_data_block_size * i;
 
-					float* firerate_lower = reinterpret_cast<float*>(barrel_block + 4);
-					float* firerate_upper = reinterpret_cast<float*>(barrel_block + 8);
-					float* recovery_time = reinterpret_cast<float*>(barrel_block + 32);
+					float* firerate_lower = (float*)(barrel_block + 4);
+					float* firerate_upper = (float*)(barrel_block + 8);
+					float* recovery_time = (float*)(barrel_block + 32);
 
 					if (*firerate_lower == *firerate_upper) {
 						/* Reason for this comparison is because in cases

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -93,7 +93,7 @@ void H2X::Initialize(bool enable)
 						float factor = new_difference / old_difference;
 
 						*acceleration_time = *acceleration_time * factor;
-						*deceleration_time = *acceleration_time * factor;
+						*deceleration_time = *deceleration_time * factor;
 					}
 
 					*firerate_lower = new_lower;

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -79,40 +79,25 @@ void H2X::Initialize(bool enable)
 					float* deceleration_time = (float*)(barrel_block + 16);
 					float* recovery_time = (float*)(barrel_block + 32);
 
-					if (*firerate_lower == *firerate_upper) {
-						/* Reason for this comparison is because in cases
-						   where firing rates climb it is more accurate to use
-						   the supplied ones during the climb. Because this
-						   calculation would essentially have to be done on
-						   the output of the mathematical function that
-						   determines the exact firing rate the game will use.
-						   Not the input.
+					float new_upper = calculate_h2x_firerate(*firerate_upper);
+					float new_lower = calculate_h2x_firerate(*firerate_lower);
 
-						   Thus, we only do it like this for weapons with
-						   constant firerates */
-						*firerate_lower = calculate_h2x_firerate(*firerate_lower);
-						*firerate_upper = calculate_h2x_firerate(*firerate_upper);
-					} else {
-						float new_upper = calculate_h2x_firerate(*firerate_upper);
-
+					if (*firerate_lower != *firerate_upper) {
 						/* To simulate the most correct between speeds we
-						   need to make the climb shorter. Otherwise they will
-						   be too slow. */
+						   might need to make the climb shorter.
+						   Otherwise the rates will be too slow. */
 
 						float old_difference = *firerate_upper - *firerate_lower;
-						float new_difference = new_upper - *firerate_lower;
+						float new_difference = new_upper - new_lower;
 
 						float factor = new_difference / old_difference;
 
 						*acceleration_time = *acceleration_time * factor;
 						*deceleration_time = *acceleration_time * factor;
-
-						/* The final fire rate cannot be skipped in edits
-						   because otherwise the gun might be too fast when it
-						   is done climbing. */
-
-						*firerate_upper = new_upper;
 					}
+
+					*firerate_lower = new_lower;
+					*firerate_upper = new_upper;
 
 					*recovery_time = calculate_h2x_recovery_time(*recovery_time);
 				}

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -1,3 +1,9 @@
+/*
+	gbMichelle: 2020-04-14  -  2020-04-15
+	 - Added universal firing rate and acceleration calculations for
+	   Xbox behavior emulation.
+*/
+
 #include <math.h>
 
 #include "stdafx.h"

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -52,6 +52,9 @@ float calculate_h2x_recovery_time(float h2v_recovery_time) {
 
 void H2X::Initialize(bool enable)
 {
+	// Why even execute any of this if we're not enabled?
+	if (!enable) return;
+
 	for (auto& weapon : weapons)
 	{
 		/* With the value calculation being made universal we should consider
@@ -104,8 +107,8 @@ void H2X::Initialize(bool enable)
 			}
 		}
 	}
-	
-	if (!h2mod->Server && enable && h2mod->GetMapType() == MULTIPLAYER_MAP)
+
+	if (!h2mod->Server && h2mod->GetMapType() == MULTIPLAYER_MAP)
 	{
 		// H2X Sound_Classes
 		*(float*)(&tags::get_tag_data()[0x4821C]) = 0.0f; /*H2X projectile_impact Index 0 Gains Bounds lower*/

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -30,7 +30,7 @@ float calculate_h2x_firerate(float h2v_firerate) {
 
 	   We simulate it using this formula */
 
-	if (firerate < 0.0001) {
+	if (h2v_firerate < 0.0001) {
 		// Do not divide by 0.
 		return h2v_firerate;
 	}

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -70,7 +70,7 @@ void H2X::Initialize(bool enable)
 
 				// Go through all barrel blocks and apply the fix.
 				for (int i = 0; i < barrel_data_block->block_count; i++) {
-					auto barrel_block = barrel_block + barrel_data_block_size * i;
+					auto barrel_block = barrel_blocks + barrel_data_block_size * i;
 
 					float* firerate_lower = (float*)(barrel_block + 4);
 					float* firerate_upper = (float*)(barrel_block + 8);

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -23,7 +23,7 @@ std::vector<H2X::h2x_mod_info> weapons =
 
 /* A 100th of an Xbox tick to avoid firing rates getting round down
    because of floating point limitations */
-static const FLOAT_IMPRECISSION_SENTINEL = 30/1000/100;
+static const float FLOAT_IMPRECISSION_SENTINEL = 30/1000/100;
 
 float calculate_h2x_firerate(float h2v_firerate) {
 	// Calculate the effective firerate per seconds.

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -43,9 +43,12 @@ float calculate_h2x_firerate(float h2v_firerate) {
 		/* Firing rates above 30 are not possible at 30fps and below. */
 		return 30.0;
 	}
-	/* - 0.1 to avoid a really pesky floating point rounding error
-	   This error and rounding hack only affects higher values above 10.*/
-	return 30.0 / ceil(1 / h2v_firerate * 30.0 - 0.1);
+
+	/* Convert to double to avoid rounding errors that show up all too often
+	   with floats. */
+	double h2v_firerate_dbl = static_cast<double>(h2v_firerate);
+	// -0.01 to avoid a potential rounding error.
+	return static_cast<float>(30.0 / ceil(1 / h2v_firerate_dbl * 30.0 - 0.01));
 }
 
 float calculate_h2x_recovery_time(float h2v_recovery_time) {
@@ -105,13 +108,13 @@ void H2X::Initialize(bool enable)
 						   might need to make the climb shorter.
 						   Otherwise the rates will be too slow. */
 
-						float old_difference = *firerate_upper - *firerate_lower;
-						float new_difference = new_upper - new_lower;
+						double old_difference = static_cast<double>(*firerate_upper) - static_cast<double>(*firerate_lower);
+						double new_difference = static_cast<double>(new_upper) - static_cast<double>(new_lower);
 
-						float factor = new_difference / old_difference;
+						double factor = new_difference / old_difference;
 
-						*acceleration_time = *acceleration_time * factor;
-						*deceleration_time = *deceleration_time * factor;
+						*acceleration_time = static_cast<float>(*acceleration_time * factor);
+						*deceleration_time = static_cast<float>(*deceleration_time * factor);
 					}
 
 					*firerate_lower = new_lower;

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -49,9 +49,9 @@ float calculate_h2x_firerate(float h2v_firerate) {
 }
 
 float calculate_h2x_recovery_time(float h2v_recovery_time) {
-	if (h2v_firerate < 0.0001) {
+	if (h2v_recovery_time < 0.0001) {
 		// Our math always adds one tick. So, don't do anything if 0.
-		return h2v_firerate;
+		return h2v_recovery_time;
 	}
 
 	/* The + hack is done because all of the brute forced values

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -21,10 +21,6 @@ std::vector<H2X::h2x_mod_info> weapons =
 	{ "objects\\weapons\\rifle\\brute_plasma_rifle\\brute_plasma_rifle", 10.0f, 11.0f, 0, true }
 };
 
-/* Half of an Xbox tick to avoid firing rates getting round down
-   because of floating point limitations */
-static const float FLOAT_IMPRECISSION_SENTINEL = 30/1000/2;
-
 float calculate_h2x_firerate(float h2v_firerate) {
 	// Calculate the effective firerate per seconds.
 	/* This works because every frame Halo 2 checks to see if enough time has
@@ -38,7 +34,8 @@ float calculate_h2x_firerate(float h2v_firerate) {
 		// Do not divide by 0.
 		return h2v_firerate;
 	}
-	return 30.0 / ceil(1 / h2v_firerate * 30.0 - FLOAT_IMPRECISSION_SENTINEL);
+	// - 0.06 to avoid a really pesky floating point rounding error
+	return 30.0 / ceil(1 / h2v_firerate * 30.0 - 0.06);
 }
 
 float calculate_h2x_recovery_time(float h2v_recovery_time) {

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -39,9 +39,13 @@ float calculate_h2x_firerate(float h2v_firerate) {
 	if (h2v_firerate < 0.0001) {
 		// Do not divide by 0.
 		return h2v_firerate;
+	} else if (h2v_firerate > 30.0) {
+		/* Firing rates above 30 are not possible at 30fps and below. */
+		return 30.0;
 	}
-	// - 0.06 to avoid a really pesky floating point rounding error
-	return 30.0 / ceil(1 / h2v_firerate * 30.0 - 0.06);
+	/* - 0.1 to avoid a really pesky floating point rounding error
+	   This error and rounding hack only affects higher values above 10.*/
+	return 30.0 / ceil(1 / h2v_firerate * 30.0 - 0.1);
 }
 
 float calculate_h2x_recovery_time(float h2v_recovery_time) {

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -49,6 +49,11 @@ float calculate_h2x_firerate(float h2v_firerate) {
 }
 
 float calculate_h2x_recovery_time(float h2v_recovery_time) {
+	if (h2v_firerate < 0.0001) {
+		// Our math always adds one tick. So, don't do anything if 0.
+		return h2v_firerate;
+	}
+
 	/* The + hack is done because all of the brute forced values
 	   I find here seem to add an extra tick. This should be wrong.
 	   Please double check if that is actually right.

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -21,9 +21,9 @@ std::vector<H2X::h2x_mod_info> weapons =
 	{ "objects\\weapons\\rifle\\brute_plasma_rifle\\brute_plasma_rifle", 10.0f, 11.0f, 0, true }
 };
 
-/* A 100th of an Xbox tick to avoid firing rates getting round down
+/* Half of an Xbox tick to avoid firing rates getting round down
    because of floating point limitations */
-static const float FLOAT_IMPRECISSION_SENTINEL = 30/1000/100;
+static const float FLOAT_IMPRECISSION_SENTINEL = 30/1000/2;
 
 float calculate_h2x_firerate(float h2v_firerate) {
 	// Calculate the effective firerate per seconds.

--- a/xlive/H2MOD/Variants/H2X/H2X.cpp
+++ b/xlive/H2MOD/Variants/H2X/H2X.cpp
@@ -21,6 +21,10 @@ std::vector<H2X::h2x_mod_info> weapons =
 	{ "objects\\weapons\\rifle\\brute_plasma_rifle\\brute_plasma_rifle", 10.0f, 11.0f, 0, true }
 };
 
+/* A 100th of an Xbox tick to avoid firing rates getting round down
+   because of floating point limitations */
+static const FLOAT_IMPRECISSION_SENTINEL = 30/1000/100;
+
 float calculate_h2x_firerate(float h2v_firerate) {
 	// Calculate the effective firerate per seconds.
 	/* This works because every frame Halo 2 checks to see if enough time has
@@ -34,7 +38,7 @@ float calculate_h2x_firerate(float h2v_firerate) {
 		// Do not divide by 0.
 		return h2v_firerate;
 	}
-	return 30.0 / ceil(1 / h2v_firerate * 30.0);
+	return 30.0 / ceil(1 / h2v_firerate * 30.0 - FLOAT_IMPRECISSION_SENTINEL);
 }
 
 float calculate_h2x_recovery_time(float h2v_recovery_time) {


### PR DESCRIPTION
This was sparked from a discussion involving me and General_101. I've dealt with the opposite problem before in CE as that game's tickrate IS locked. So instead of firerates being higher, they are correct to Xbox, which can make them slower than intended for user mods.

What this does is it implements the universal calculation of the effective firing rates on Xbox and applies those fire rates to the tags.

I did have to add a small hack to make my recovery rates match what you guys had put in. And I am convinced that while it alligns with your values, it may be wrong compared to Xbox. Please test and if the guns are a little too slow, do what the comment tells you to do.

Finally, I don't have visual studio and am not even on Windows right now. So, you may have small missing details like semicolons and stuff. I've set the pullrequest to be editable by maintainers.

Here if some extra reading material for if the changes don't really make sense to you https://gist.github.com/gbMichelle/927384281567e43e413fda761fb846fc

I can answer any questions you may have. Have a nice day!