### PR TITLE
Miscellaneous code improvements and fixes 

### DIFF
--- a/xlive/Blam/Cache/DataTypes/DatumIndex.h
+++ b/xlive/Blam/Cache/DataTypes/DatumIndex.h
@@ -42,6 +42,10 @@ struct datum
 
 	inline signed short ToAbsoluteIndex() const { return Index; };
 
+	inline void operator=(const datum &other)
+	{
+		this->data = other.data;
+	}
 	inline bool operator == (const datum &other) const
 	{
 		return this->data == other.data;

--- a/xlive/H2MOD/Modules/HitFix/HitFix.cpp
+++ b/xlive/H2MOD/Modules/HitFix/HitFix.cpp
@@ -1,95 +1,94 @@
-#include "Hitfix.h"
+#include "HitFix.h"
 
 #include "H2MOD.h"
 #include "H2MOD\Tags\TagInterface.h"
 
 #include "Util/Hooks/Hook.h"
 
+#include "Blam/Engine/Objects/Objects.h"
+
 #include "Globals.h"
 
 // TODO: move the struct time_globals in here somewhere else
-#include "Blam/Engine/Game/GameTimeGlobals.h"
+#include "Blam\Engine\Game\GameTimeGlobals.h"
 
-float HitFix_Projectile_Tick_Rate = 30.0f;
+#define DEFAULT_PROJECTILE_OBJECT_DATA_SIZE 428
+
+// h3 gets the projectile collision data from somewhere else
+#define ENABLE_H3_COLLISION_DATA_SOURCE 0
+#define INCREASED_PROJECTILE_OBJECT_DATA_SIZE (DEFAULT_PROJECTILE_OBJECT_DATA_SIZE + sizeof(int) + (ENABLE_H3_COLLISION_DATA_SOURCE ? sizeof(real_point3d) : 0))
 
 // game logic is updated synchronously, this shouldn't cause any issues
-// TODO: find if there is any way to add function arguments in a compiled function lol
-datum projectileToBeUpdated;
-bool updateInstantaneousProjectile = false;
-
-
-typedef void(__cdecl* projectile_update_def)(datum projectile_object_index, real_point3d *a2);
-projectile_update_def p_projectile_update;
+static float tick_length;
+float HitFix_Projectile_Tick_Rate = 30.f;
 
 typedef char(__cdecl* projectile_new_def)(unsigned __int16 projectile_object_index, int a2);
 projectile_new_def p_projectile_new;
 
-char __cdecl projectile_new(unsigned __int16 projectile_object_index, int a2)
+typedef void(__cdecl* projectile_update_def)(datum projectile_object_index, real_point3d *a2);
+projectile_update_def p_projectile_update;
+
+// determines whether the projectile should be updated in a 30hz context or not
+void projectile_set_tick_length_context(datum projectile_datum_index, bool projectile_instant_update)
+{
+	ObjectHeader* objects_header = (ObjectHeader*)game_state_objects_header->datum;
+	char* object_data = objects_header[projectile_datum_index.ToAbsoluteIndex()].object;
+	char* proj_tag_data = tags::get_tag_fast<char>(*((datum*)object_data));
+
+	if (*(DWORD*)(proj_tag_data + 0xBC) & FLAG(5) // check if travels instantaneously flag is set in the projectile flags
+		&& (projectile_instant_update || *(DWORD*)(object_data + 428) == time_globals::get()->tick_count)) // also check if the projectile is updated twice in the same tick
+	{
+		//LOG_TRACE_GAME("projectile: {} will be updated at 30 hz context", projectile_datum_index.ToAbsoluteIndex());
+		tick_length = time_globals::get_seconds_per_tick() * ((float)time_globals::get()->ticks_per_second / HitFix_Projectile_Tick_Rate);
+	}
+	else
+	{
+		//LOG_TRACE_GAME("projectile: {} will not be updated at 30 hz context", projectile_datum_index.ToAbsoluteIndex());
+		tick_length = time_globals::get_seconds_per_tick();
+	}
+}
+
+// sets the tick when the projectile has been created
+inline void projectile_set_creation_tick(datum projectile_datum_index)
+{
+	ObjectHeader* objects_header = (ObjectHeader*)game_state_objects_header->datum;
+	char* object_data = objects_header[projectile_datum_index.ToAbsoluteIndex()].object;
+	*(DWORD*)(object_data + 428) = time_globals::get()->tick_count; // store the projectile creation tick count
+}
+
+bool __cdecl projectile_new(unsigned __int16 projectile_object_index, int a2)
 {
 	char ret = p_projectile_new(projectile_object_index, a2);
 
-	ObjectHeader* objects_header = (ObjectHeader*)game_state_objects_header->datum;
-	char* object_data = objects_header[projectile_object_index].object;
-	*(DWORD*)(object_data + 428) = time_globals::get()->tick_count; // store the projectile creation tick count
+	projectile_set_creation_tick(projectile_object_index);
 
 	return ret;
 }
 
 void __cdecl projectile_update_instantaneous(datum projectile_object_index, real_point3d *a2)
 {
-	updateInstantaneousProjectile = true;
-	projectileToBeUpdated = projectile_object_index;
+	projectile_set_tick_length_context(projectile_object_index, true);
 	//LOG_TRACE_GAME("projectile_update_instantaneous() - projectile obj index: {}, just making sure: {}", projectileToBeUpdated.ToAbsoluteIndex(), *(int*)&projectile_object_index & 0xFFFF);
 	p_projectile_update(projectile_object_index, a2);
 }
 
 void __cdecl projectile_update_regular(datum projectile_object_index, real_point3d *a2)
 {
-	updateInstantaneousProjectile = false;
-	projectileToBeUpdated = projectile_object_index;
+	projectile_set_tick_length_context(projectile_object_index, false);
 	//LOG_TRACE_GAME("projectile_update_regular() - projectile obj index: {}, just making sure: {}", projectileToBeUpdated.ToAbsoluteIndex(), *(int*)&projectile_object_index & 0xFFFF);
 	p_projectile_update(projectile_object_index, a2);
 }
 
-// this will get executed when p_projectile_update is called
-float __cdecl get_seconds_per_tick_internal_patch()
+float __cdecl get_tick_length_hook()
 {
-	ObjectHeader* objects_header = (ObjectHeader*)game_state_objects_header->datum;
-	char* object_data = objects_header[projectileToBeUpdated.ToAbsoluteIndex()].object;
-	char* proj_tag_data = tags::get_tag_fast<char>(*((datum*)object_data));
-	time_globals* p_time_globals = time_globals::get();
-
-	float timeDelta = p_time_globals->seconds_per_tick;
-	if (*(DWORD*)(proj_tag_data + 0xBC) & FLAG(5) // check if travels instantaneously flag is set in the projectile flags
-		&& (updateInstantaneousProjectile || *(DWORD*)(object_data + 428) == p_time_globals->tick_count))
-	{
-		//LOG_TRACE_GAME("get_time_delta_internal() - projectile obj index: {}, projectile creation tick: {}, current tick count {}", projectileToBeUpdated.ToAbsoluteIndex(), *(DWORD*)(object_data + 428), p_time_globals->tick_count);
-		timeDelta = timeDelta * (float)((float)p_time_globals->ticks_per_second / HitFix_Projectile_Tick_Rate);
-	}
-
-	return timeDelta;
-}
-
-__declspec(naked) void get_seconds_per_tick()
-{
-	__asm
-	{
-		PUSHAD
-		PUSHFD
-
-		call get_seconds_per_tick_internal_patch
-
-		POPFD
-		POPAD
-		ret
-	}
+	return tick_length;
 }
 
 // we still keep this because the fix above doen't fully fix it
 // object string, initial bullet speed, final bullet speed
 std::vector<std::tuple<std::string, float, float>> weapon_projectiles =
 {
-	//td::make_tuple("objects\\weapons\\rifle\\battle_rifle\\projectiles\\battle_rifle_bullet", 400.f * 2, 400.f * 2),
+	//std::make_tuple("objects\\weapons\\rifle\\battle_rifle\\projectiles\\battle_rifle_bullet", 400.f * 2, 400.f * 2),
 	//std::make_tuple("objects\\weapons\\rifle\\covenant_carbine\\projectiles\\carbine_slug\\carbine_slug", 400.f * 2, 400.f * 2),
 	std::make_tuple("objects\\weapons\\rifle\\sniper_rifle\\projectiles\\sniper_bullet", 1200.0f * 2, 1200.0f * 2),
 	std::make_tuple("objects\\weapons\\rifle\\beam_rifle\\projectiles\\beam_rifle_beam", 1200.0f * 2, 1200.0f * 2),
@@ -97,6 +96,62 @@ std::vector<std::tuple<std::string, float, float>> weapon_projectiles =
 	//std::make_tuple("objects\\weapons\\pistol\\magnum\\projectiles\\magnum_bullet", 400.f * 2, 400.f * 2),
 	//std::make_tuple("objects\\vehicles\\warthog\\turrets\\chaingun\\weapon\\bullet", 2000.0f, 2000.0f)
 };
+
+datum trigger_projectile_datum_index = datum::Null;
+
+#pragma region H3 collision data research
+__declspec(naked) void update_projectile_collision_data()
+{
+	__asm
+	{
+		mov ax, [esi + 0x46]
+		mov [ebx + 0x154], ax
+		mov eax, [esi + 8]
+		mov [ebx + 432], eax
+		mov eax, [esi + 12]
+		mov [ebx + 436], eax
+		mov eax, [esi + 16]
+		mov [ebx + 440], eax
+
+		retn
+	}
+}
+
+__declspec(naked) void matrix4x3_transform_point_parameter_replacement()
+{
+	__asm
+	{
+		lea edx, dword ptr[esi + 432]
+		retn
+	}
+}
+
+void __cdecl object_get_origin(unsigned __int16 unit_index, real_point3d *a3)
+{
+	auto p_object_get_origin = Memory::GetAddressRelative<void(__cdecl*)(unsigned __int16, real_point3d*)>(0x5329B8);
+
+	trigger_projectile_datum_index = unit_index;
+
+	return p_object_get_origin(unit_index, a3);
+}
+
+void __cdecl matrix4x3_transform_point(void* matrix, real_vector3d* v1, real_vector3d* out)
+{
+	auto p_matrix4x3_transform_point = Memory::GetAddressRelative<void(__cdecl*)(void*, real_vector3d*, real_vector3d*)>(0x47795A);
+
+	DatumIterator<ObjectHeader> objectIt(game_state_objects_header);
+
+	BYTE* projectile = (BYTE*)objectIt.get_data_at_index(trigger_projectile_datum_index.ToAbsoluteIndex())->object;
+
+	LOG_TRACE_GAME(L" projectile matrix4x3_transform_point() - original values v1: i: {}, j: {}, k: {}", v1->i, v1->j, v1->k);
+
+	v1 = (real_vector3d*)(projectile + 432);
+
+	LOG_TRACE_GAME(L" projectile matrix4x3_transform_point() - new values v1: i: {}, j: {}, k: {}", v1->i, v1->j, v1->k);
+
+	p_matrix4x3_transform_point(matrix, v1, out);
+}
+#pragma endregion
 
 void HitFix::ApplyProjectileVelocity()
 {
@@ -115,15 +170,23 @@ void HitFix::ApplyProjectileVelocity()
 void HitFix::ApplyPatches()
 {
 	// increase projectile game object data size to store the elapsed tick time when created
-	WriteValue<unsigned short>(h2mod->GetAddress(0x41EE58, 0x3C2368) + 0x8, 428 + 4);
+	WriteValue<unsigned short>(Memory::GetAddress(0x41EE58, 0x3C2368) + 0x8, INCREASED_PROJECTILE_OBJECT_DATA_SIZE);
 
 	// hook projectile_create
-	p_projectile_new = (projectile_new_def)DetourFunc(h2mod->GetAddress<BYTE*>(0x146ECE, 0x171E6B), (BYTE*)projectile_new, 5);
+	p_projectile_new = (projectile_new_def)DetourFunc(Memory::GetAddress<BYTE*>(0x146ECE, 0x171E6B), (BYTE*)projectile_new, 5);
 
 	// replace update_projectile
-	p_projectile_update = (projectile_update_def)(h2mod->GetAddress(0x1493F2, 0x174392));
-	PatchCall(h2mod->GetAddress(0x14A30D, 0x1752AD), projectile_update_regular);
-	PatchCall(h2mod->GetAddress(0x14A25B, 0x1751FB), projectile_update_instantaneous);
+	p_projectile_update = (projectile_update_def)(Memory::GetAddress(0x1493F2, 0x174392));
+	PatchCall(Memory::GetAddress(0x14A30D, 0x1752AD), projectile_update_regular);
+	PatchCall(Memory::GetAddress(0x14A25B, 0x1751FB), projectile_update_instantaneous);
 
-	PatchCall(h2mod->GetAddress(0x149442, 0x1743E2), get_seconds_per_tick);
+	PatchCall(Memory::GetAddress(0x149442, 0x1743E2), get_tick_length_hook);
+
+#if	ENABLE_H3_COLLISION_DATA_SOURCE
+	Codecave(Memory::GetAddressRelative(0x547BDA, 0x572B77), update_projectile_collision_data, 6);
+	Codecave(Memory::GetAddressRelative(0x55D66E, 0x54192E), matrix4x3_transform_point_parameter_replacement, 2);
+#endif
+
+	//PatchCall(Memory::GetAddressRelative(0x55D653), object_get_origin);
+	//PatchCall(Memory::GetAddressRelative(0x55D67E), matrix4x3_transform_point);
 }

--- a/xlive/H2MOD/Variants/Infection/Infection.cpp
+++ b/xlive/H2MOD/Variants/Infection/Infection.cpp
@@ -238,9 +238,6 @@ void Infection::preSpawnServerSetup() {
 void Infection::setPlayerAsHuman(int playerIndex) {
 	Player::setUnitBipedType(playerIndex, Player::Biped::Spartan);
 	Player::setBipedSpeed(playerIndex, 1.0f);
-
-	call_give_player_weapon(playerIndex, Weapon::shotgun, 1);
-	call_give_player_weapon(playerIndex, Weapon::magnum, 0);
 }
 
 void Infection::setPlayerAsZombie(int playerIndex) {

--- a/xlive/H2MOD/Variants/XboxTick/XboxTick.cpp
+++ b/xlive/H2MOD/Variants/XboxTick/XboxTick.cpp
@@ -8,28 +8,10 @@ int XboxTick::setTickRate(bool enable)
 	if (enable) 
 	{
 		tickrate = 30;
-
-		BYTE mov_al_1_retn[] = { 0xB0, 0x01, 0xC3 };
-		if (!h2mod->Server)
-			WriteBytes(h2mod->GetAddress(0x3A938, 0x8DCE5), mov_al_1_retn, sizeof(mov_al_1_retn));
-
-		BYTE jne[] = { 0x85 };
-		if (!h2mod->Server)
-			WriteBytes(h2mod->GetAddress(0x288BD, 0x249CB), jne, sizeof(jne));
-
 		LOG_TRACE_GAME("[h2mod] Set the game tickrate to 30");
 	}
 	else
 	{
-		// disables
-		BYTE push_ebp_xor_bl_bl[] = { 0x53, 0x32, 0xDB };
-		if (!h2mod->Server)
-			WriteBytes(h2mod->GetAddress(0x3A938, 0x8DCE5), push_ebp_xor_bl_bl, sizeof(push_ebp_xor_bl_bl));
-
-		BYTE je[] = { 0x84 };
-		if (!h2mod->Server)
-			WriteBytes(h2mod->GetAddress(0x288BD, 0x249CB), je, sizeof(je));
-
 		LOG_TRACE_GAME("[h2mod] Set the game tickrate to 60");
 	}
 

--- a/xlive/XLive/ServerList/ServerList.cpp
+++ b/xlive/XLive/ServerList/ServerList.cpp
@@ -40,7 +40,7 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
 
 void BadServer(ULONGLONG xuid, const char* log_catch)
 {
-	LOG_TRACE_GAME("{} - XUID: {0} - Log Catch: {1}", __FUNCTION__, xuid, log_catch);
+	LOG_ERROR_XLIVE("{} - XUID: {} - Log Catch: {}", __FUNCTION__, xuid, log_catch);
 }
 
 DWORD ComputeXLocatorServerEnumeratorBufferSize(DWORD cItems, DWORD cRequiredPropertyIDs, DWORD* pRequredPropertiesIDs, DWORD* outStringBufferSize)
@@ -64,7 +64,7 @@ DWORD ComputeXLocatorServerEnumeratorBufferSize(DWORD cItems, DWORD cRequiredPro
 	if (outStringBufferSize)
 	{
 		*outStringBufferSize = (X_PROPERTY_UNICODE_BUFFER_SIZE * cItems * stringProperties);
-		LOG_ERROR_XLIVE("{} : stringBufferSize: {}, stringBufferSize2: {}, cItems: {}, stringCount: {}", __FUNCTION__, *outStringBufferSize, (X_PROPERTY_UNICODE_BUFFER_SIZE * cItems * stringProperties), cItems, stringProperties);
+		LOG_INFO_XLIVE("{} : stringBufferSize: {}, stringBufferSize2: {}, cItems: {}, stringCount: {}", __FUNCTION__, *outStringBufferSize, (X_PROPERTY_UNICODE_BUFFER_SIZE * cItems * stringProperties), cItems, stringProperties);
 	}
 
 	return result;

--- a/xlive/XLive/xnet/IpManagement/XnIp.cpp
+++ b/xlive/XLive/xnet/IpManagement/XnIp.cpp
@@ -264,7 +264,7 @@ void CXnIp::HandleConnectionPacket(XSocket* xsocket, XNetRequestPacket* connectR
 	else
 	{
 		LogConnectionsDetails(recvAddr); // TODO: disable after connection bug is fixed
-		LOG_TRACE_NETWORK("{} - secure connection cannot be established!, __FUNCTION__");
+		LOG_TRACE_NETWORK("{} - secure connection cannot be established!", __FUNCTION__);
 		// TODO: send back the connection cannot be established
 	}
 }

--- a/xlive/XLive/xnet/Sockets/XSocket.cpp
+++ b/xlive/XLive/xnet/Sockets/XSocket.cpp
@@ -421,7 +421,6 @@ int WINAPI XSocketWSASendTo(SOCKET s, LPWSABUF lpBuffers, DWORD dwBufferCount, L
 			xnIp->pckSent++;
 			xnIp->bytesSent += result;
 #endif
-			gXnIp.setTimeConnectionInteractionHappened(xnIp->connectionIdentifier);
 			updateSendToStatistics(packetsSent, *lpNumberOfBytesSent);
 		}
 


### PR DESCRIPTION
More info here https://randomascii.wordpress.com/2020/10/04/windows-timer-resolution-the-great-rule-change/
Applies to Windows 10 v2004 and above (maybe bellow as well, if other applications set the global resolution timer)

Fixed serverlist buffer size calculation and a memory leak when handling strings.

Fixed fall damage patch.

todo other changes info:
