### PR TITLE
fix rounding error in melee lunge code when converting floating point value to tick count

### DIFF
--- a/xlive/H2MOD/Modules/HitFix/MeleeFix.cpp
+++ b/xlive/H2MOD/Modules/HitFix/MeleeFix.cpp
@@ -10,8 +10,14 @@ namespace MeleeFix
 {
 	void MeleePatch(bool toggle)
 	{
-		WriteValue<BYTE>(Memory::GetAddress(0x10B408, 0xFDA38) + 2, toggle ? 5 : 6); // sword
-		WriteValue<BYTE>(Memory::GetAddress(0x10B40B, 0xFDA3B) + 2, toggle ? 2 : 1); // generic weapon
+		// replace cvttss2si instruction which is the convert to int by truncation (> .5 decimal values don't mean anything, truncation rounding always towards 0) 
+		// with cvtss2si instruction which reads the MXCSR register that holds the flags of the conversion rounding setting
+		// that the game sets, which is Round Control Near (if decimal part > .5, convert to upper value)
+		// when converting the tick count from float to int
+		// otherwise the game will convert to tick count off by 1 tick
+		// to note this in H3 is handled by adding .5, which does the same thing
+		BYTE cvtss2si[] = { 0xF3, 0x0F, 0x2D };
+		WriteBytes(Memory::GetAddressRelative(0x50B419, 0x4FDA49), cvtss2si, sizeof(cvtss2si));
 	}
 
 	void MeleeCollisionPatch()


### PR DESCRIPTION
should improve melee without sacrificing really close melee battles