### PR TITLE
Event Fixes and first run updating

### DIFF
--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -43,6 +43,7 @@
 #include "Util\Hooks\Hook.h"
 
 #include <float.h>
+
 #if (!defined(_M_FP_FAST)) || !_M_FP_FAST
 #pragma fenv_access (on)
 #endif

--- a/xlive/H2MOD/Modules/Config/Config.cpp
+++ b/xlive/H2MOD/Modules/Config/Config.cpp
@@ -1,4 +1,7 @@
 #include "Config.h"
+
+#include "H2MOD/Modules/CustomMenu/CustomMenu.h"
+#include "H2MOD/Modules/Updater/Updater.h"
 #include "H2MOD\Modules\OnScreenDebug\OnscreenDebug.h"
 #include "H2MOD\Modules\Startup\Startup.h"
 #include "H2MOD\Modules\Utils\Utils.h"
@@ -645,6 +648,7 @@ void ReadH2Config() {
 
 	if (err) {
 		addDebugText("ERROR: No H2Configuration Files Could Be Found!");
+		CMForce_Update = true;
 		H2Config_isConfigFileAppDataLocal = true;
 	}
 	else {

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
@@ -47,6 +47,8 @@ int __cdecl CustomMenu_CallHead(int a1, DWORD* menu_vftable_1, DWORD* menu_vftab
 void __stdcall sub_21bf85_CMLTD(int thisptr, int label_id, int label_menu_id);
 void __stdcall sub_28870B_CM(int a1, int a2, int a3, void*(__stdcall* a4)(int), int a5);
 
+bool CMForce_Update = false;
+
 void GSCustomMenuCall_AccountList();
 
 
@@ -3598,6 +3600,14 @@ void xbox_live_task_progress_callback(DWORD a1)
 				return;
 			}
 			else {
+				if(CMForce_Update)
+				{
+					//Just in case save the config to prevent a high iq individual from getting themsevles in an update loop.
+					SaveH2Config();
+					CMForce_Update = false;
+					GSCustomMenuCall_Update_Note();
+					return;
+				}
 				imgui_handler::ToggleWindow("motd");
 				//extern int notify_xlive_ui;
 				//notify_xlive_ui = 0;

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.h
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.h
@@ -20,6 +20,8 @@ extern const int CMLabelMenuId_AccountEdit;
 extern const int CMLabelMenuId_AccountCreate;
 extern const int CMLabelMenuId_Update;
 
+extern bool CMForce_Update;
+
 void RefreshTogglexDelay();
 
 void GSCustomMenuCall_Obscure();

--- a/xlive/H2MOD/Modules/RunLoop/RunLoop.cpp
+++ b/xlive/H2MOD/Modules/RunLoop/RunLoop.cpp
@@ -653,7 +653,9 @@ void alt_main_game_loop_hook()
 	}
 	else
 	{
+		EventHandler::GameLoopEventExecute(EventExecutionType::execute_before);
 		game_main_loop();
+		EventHandler::GameLoopEventExecute(EventExecutionType::execute_after);
 	}
 	
 }


### PR DESCRIPTION
Fixed some events not firing under certain conditions.

Added some logic to force an update if no config exists, this is under the assumption that when someone doesn't have a config they are most likely a first run user. This is used to make sure they have all the content downloaded and not just the latest xlive.dll