### PR TITLE
Updater changes for new certificates

### DIFF
--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenu.cpp
@@ -1004,6 +1004,7 @@ void xbox_live_task_progress_callback(DWORD a1)
 
 			case ERROR_CODE_CURL_EASY_PERF:
 				CustomMenuCall_Error_Inner(CMLabelMenuId_Error, 0xFFFFF030, 0xFFFFF031);
+				GSCustomMenuCall_Update_Note(); // add this to prompt for an update when it errors out due to a certificate mismatch
 				return;
 
 			case ERROR_CODE_INVALID_VERSION:

--- a/xlive/H2MOD/Modules/Shell/Config.cpp
+++ b/xlive/H2MOD/Modules/Shell/Config.cpp
@@ -24,6 +24,7 @@ unsigned short H2Config_master_port_relay = 1001;
 bool H2Portable = false;//TODO
 
 std::string cartographerURL = "https://cartographer.online";
+std::string unSecureCartographerURL = "http://cartographer.online";
 std::string cartographerMapRepoURL = "http://www.h2maps.net/Cartographer/CustomMaps";
 
 unsigned short H2Config_base_port = 2000;

--- a/xlive/H2MOD/Modules/Shell/Config.h
+++ b/xlive/H2MOD/Modules/Shell/Config.h
@@ -15,7 +15,7 @@ void ReadH2Config();
 
 #define DLL_VERSION_MAJOR               0
 #define DLL_VERSION_MINOR               6
-#define DLL_VERSION_REVISION            6
+#define DLL_VERSION_REVISION            7
 #define DLL_VERSION_BUILD				2
 
 #define DLL_VERSION            DLL_VERSION_MAJOR, DLL_VERSION_MINOR, DLL_VERSION_REVISION, DLL_VERSION_BUILD
@@ -53,6 +53,7 @@ enum H2Config_Experimental_Rendering_Mode : byte
 };
 
 extern std::string cartographerURL;
+extern std::string unSecureCartographerURL;
 extern std::string cartographerMapRepoURL;
 
 extern unsigned long H2Config_master_ip;

--- a/xlive/H2MOD/Modules/Updater/Updater.cpp
+++ b/xlive/H2MOD/Modules/Updater/Updater.cpp
@@ -278,7 +278,7 @@ static void FetchUpdateDetails() {
 
 	addDebugText("Fetching Update Details.");
 	char* rtn_result = 0;
-	int rtn_code = MasterHttpResponse(std::string(cartographerURL + "/update1.ini"), "", &rtn_result);
+	int rtn_code = MasterHttpResponse(std::string(unSecureCartographerURL + "/update1.ini"), "", &rtn_result);
 	if (rtn_code == 0) {
 		addDebugText("Got Update Details.");
 


### PR DESCRIPTION
In custom menu, added a line to prompt for an update when it errors out after log in due to a certificate mismatch. Previous behavior just errored out after logging in, requiring a manual dll update.

Additionally, change the updater code to download from insecure http site, instead of https. Also related to certificate mismatches.