### PR TITLE
disable one of the light_framerate_killer tag changes

### DIFF
--- a/xlive/H2MOD/Modules/TagFixes/TagFixes.cpp
+++ b/xlive/H2MOD/Modules/TagFixes/TagFixes.cpp
@@ -169,7 +169,10 @@ namespace TagFixes
 			for (auto& light_item : lights)
 			{
 				auto light = tags::get_tag_fast<s_light_group_definition>(light_item.first);
-				light->flags |= s_light_group_definition::e_flags::light_framerate_killer;
+				// Disabled since it caused issues where certain lights wouldnt render randomly
+				// TODO figure out why it does this at some other point in time
+				// light->flags |= s_light_group_definition::e_flags::light_framerate_killer;
+
 				light->flags |= s_light_group_definition::e_flags::multiplayer_override;
 			}
 		}


### PR DESCRIPTION
caused issues with lights de-rendering