### PR TITLE
fix crash with crosshair scale + other changes

### DIFF
--- a/xlive/Blam/Engine/game/cheats.cpp
+++ b/xlive/Blam/Engine/game/cheats.cpp
@@ -56,18 +56,17 @@ void __cdecl ice_cream_flavor_stock(const e_skull_type skull)
 	typedef int(__cdecl* unspatialized_impulse_sound_new_t)(datum sound_datum, float scale);
 	auto p_unspatialized_impulse_sound_new = Memory::GetAddress<unspatialized_impulse_sound_new_t>(0x8836C, 0x7F173);
 
-	int user_index;
 	s_globals_group_definition* g_globals_tag = tags::get_matg_globals_ptr();
-	const s_globals_group_definition::s_player_information_block* player_information_tagblock;
-	datum sound_datum;
-	string_id skull_string_id;
+	const s_globals_group_definition::s_player_information_block* player_information = g_globals_tag->player_information[0];
 
 	if (skull < k_skull_count && !skull_enabled[skull])
 	{
 		skull_enabled[skull] = true;
 		p_hud_clear_messages();
-		skull_string_id = skull_string_ids[skull];
-		user_index = p_players_first_active_user();
+		
+		string_id skull_string_id = skull_string_ids[skull];
+		int user_index = p_players_first_active_user();
+
 		p_display_generic_hud_string(user_index, skull_string_id);
 		p_scripted_player_effect_screen_fade_in(1.0, 1.0, 1.0, 20);
 
@@ -78,7 +77,7 @@ void __cdecl ice_cream_flavor_stock(const e_skull_type skull)
 			return; 
 		}
 
-		sound_datum = g_globals_tag->player_information[0]->ice_cream.TagIndex;
+		datum sound_datum = player_information->ice_cream.TagIndex;
 		if (sound_datum != DATUM_INDEX_NONE)
 		{
 			p_unspatialized_impulse_sound_new(sound_datum, 1.0);

--- a/xlive/Blam/Engine/interface/new_hud.cpp
+++ b/xlive/Blam/Engine/interface/new_hud.cpp
@@ -70,7 +70,7 @@ void __cdecl ui_get_hud_elemet_bounds_hook(e_hud_anchor anchor, real_bounds* bou
 
 
 // We scale crosshairs by adjusting the bitmap data size in the bitmap tag
-// It dosen't seem to actually downscale the bitmap since the data loaded still remains the same
+// It doesn't seem to actually downscale the bitmap since the data loaded still remains the same
 void set_crosshair_scale(float scale)
 {
 	size_t bitmap_size_vector_index = 0;
@@ -101,8 +101,6 @@ void set_crosshair_scale(float scale)
 // Stores the bitmap width and height in crosshair_original_bitmap_sizes for use when scaling the crosshair bitmaps
 void initialize_crosshair_bitmap_data()
 {
-	crosshair_original_bitmap_sizes.clear();
-
 	for (size_t i = 0; i < crosshair_bitmap_datums.size(); ++i)
 	{
 		bitmap_group* bitm_definition = tags::get_tag_fast<bitmap_group>(crosshair_bitmap_datums[i]);
@@ -133,9 +131,6 @@ bool crosshair_bitmap_vector_contains_datum(datum tag_datum)
 // Intended to grab all bitmaps referenced as crosshairs rather than just the original ones
 void get_crosshair_bitmap_datums()
 {
-	// Clear all datums from previous map file
-	crosshair_bitmap_datums.clear();
-
 	// Get all nhdt tags
 	std::map<datum, std::string> new_hud_definition_tags = tags::find_tags(blam_tag::tag_group_type::newhuddefinition);
 	for each (auto nhdt_tag in new_hud_definition_tags)
@@ -158,8 +153,14 @@ void get_crosshair_bitmap_datums()
 
 }
 
-void initialize_crosshair_scale()
+void initialize_crosshair_scale(bool game_mode_ui_shell)
 {
+	// Clear data from previous map file
+	crosshair_bitmap_datums.clear();
+	crosshair_original_bitmap_sizes.clear();
+
+	if (game_mode_ui_shell) { return; }
+
 	get_crosshair_bitmap_datums();
 	initialize_crosshair_bitmap_data();
 	set_crosshair_scale(H2Config_crosshair_scale);
@@ -183,7 +184,9 @@ void new_hud_apply_patches()
 	PatchCall(Memory::GetAddress(0x22D25A), ui_get_hud_elemet_bounds_hook);
 }
 
-void new_hud_patches_on_map_load()
+void new_hud_patches_on_map_load(bool game_mode_ui_shell)
 {
-	initialize_crosshair_scale();
+	if (Memory::IsDedicatedServer()) { return; }
+
+	initialize_crosshair_scale(game_mode_ui_shell);
 }

--- a/xlive/Blam/Engine/interface/new_hud.h
+++ b/xlive/Blam/Engine/interface/new_hud.h
@@ -37,4 +37,4 @@ s_new_hud_engine_globals* get_new_hud_engine_globals();
 
 void set_crosshair_scale(float scale);
 void new_hud_apply_patches();
-void new_hud_patches_on_map_load();
+void new_hud_patches_on_map_load(bool game_mode_ui_shell);

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -556,7 +556,10 @@ bool __cdecl OnMapLoad(s_game_options* options)
 	for (auto& gametype_it : GametypesMap)
 		gametype_it.second = false;
 
-	if (options->game_mode == _game_mode_ui_shell)
+	bool game_mode_ui_shell = options->game_mode == _game_mode_ui_shell;
+	new_hud_patches_on_map_load(game_mode_ui_shell);
+
+	if (game_mode_ui_shell)
 	{
 		addDebugText("Engine type: Main-Menu");
 		if (!Memory::IsDedicatedServer())
@@ -576,7 +579,6 @@ bool __cdecl OnMapLoad(s_game_options* options)
 		ControllerInput::SetSensitiviy(H2Config_controller_sens);
 		MouseInput::SetSensitivity(H2Config_mouse_sens);
 		hud_patches_on_map_load();
-		new_hud_patches_on_map_load();
 
 		if (h2mod->GetEngineType() == _game_mode_multiplayer)
 		{

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -55,16 +55,11 @@ public:
 	void disable_weapon_pickup(bool enable);
 	void set_local_rank(BYTE rank);
 
-	e_game_mode GetEngineType() { return engineType; }
-	void SetCurrentEngineType(e_game_mode value) { engineType = value; }
 
 	void toggle_ai_multiplayer(bool toggle);
 	void toggle_xbox_tickrate(s_game_options* options, bool toggle);
 
 	bool drawTeamIndicators = true;
-
-private:
-	e_game_mode engineType;
 };
 
 extern std::unique_ptr<H2MOD> h2mod;

--- a/xlive/H2MOD/GUI/XLiveRendering.cpp
+++ b/xlive/H2MOD/GUI/XLiveRendering.cpp
@@ -666,7 +666,7 @@ int WINAPI XLiveRender()
 			}
 #pragma endregion achievement rendering
 
-			if (displayXyz && (NetworkSession::LocalPeerIsSessionHost() || h2mod->GetEngineType() == _game_mode_campaign)) {
+			if (displayXyz && (NetworkSession::LocalPeerIsSessionHost() || s_game_globals::game_is_campaign())) {
 				int text_y_coord = 60;
 				PlayerIterator playerIt;
 				while (playerIt.get_next_active_player()) 

--- a/xlive/H2MOD/GUI/imgui_integration/AdvancedSettings.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/AdvancedSettings.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "Blam/Engine/game/cheats.h"
+#include "Blam/Engine/game/game_globals.h"
 #include "Blam/Engine/interface/hud.h"
 #include "Blam/Engine/interface/new_hud.h"
 #include "Blam/Engine/interface/first_person_camera.h"
@@ -660,7 +661,7 @@ namespace ImGuiHandler {
 			}
 			void HostSettings()
 			{
-				if (NetworkSession::LocalPeerIsSessionHost() || h2mod->GetEngineType() == _game_mode_campaign) {
+				if (NetworkSession::LocalPeerIsSessionHost() || s_game_globals::game_is_campaign()) {
 					if (ImGui::CollapsingHeader(GetString(host_campagin_settings)))
 					{
 						ImGui::Columns(2, NULL, false);
@@ -943,7 +944,7 @@ namespace ImGuiHandler {
 			//ImGui::PushFont(font2);
 			ImGui::SetNextWindowSize(ImVec2(650, 530), ImGuiCond_Appearing);
 			ImGui::SetNextWindowSizeConstraints(ImVec2(610, 530), ImVec2(1920, 1080));
-			if (h2mod->GetEngineType() == _game_mode_ui_shell)
+			if (s_game_globals::game_is_mainmenu())
 				ImGui::SetNextWindowBgAlpha(1);
 			if (ImGui::Begin(GetString(e_advanced_string::title), &open, window_flags))
 			{

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "ImGui_ConsoleImpl.h"
 
+#include "Blam/Engine/game/game_globals.h"
 #include "Blam/Engine/Networking/NetworkMessageTypeCollection.h"
 #include "Blam/Engine/Networking/Session/NetworkSession.h"
 
@@ -138,7 +139,7 @@ int CommandCollection::DisplayXyzCmd(const std::vector<std::string>& tokens, Con
 {
 	ConsoleLog* output = (ConsoleLog*)cbData.strOutput;
 	
-	if (h2mod->GetEngineType() == _game_mode_multiplayer 
+	if (s_game_globals::game_is_multiplayer()
 		&& !NetworkSession::LocalPeerIsSessionHost()) 
 	{
 		output->Output(StringFlag_None, "# only host can see xyz for now...");
@@ -565,7 +566,7 @@ int CommandCollection::SpawnCmd(const std::vector<std::string>& tokens, ConsoleC
 
 	std::string objectName = tokens[tokenArgPos++];
 
-	if (h2mod->GetEngineType() == _game_mode_ui_shell) {
+	if (s_game_globals::game_is_mainmenu()) {
 		output->Output(StringFlag_None, "# can only be used ingame");
 		return 0;
 	}
@@ -662,7 +663,7 @@ int CommandCollection::InjectTagCmd(const std::vector<std::string>& tokens, Cons
 	ConsoleLog* output = cbData.strOutput;
 
 	if (!NetworkSession::LocalPeerIsSessionHost() 
-		&& h2mod->GetEngineType() != _game_mode_campaign)
+		&& !s_game_globals::game_is_campaign())
 	{
 		output->Output(StringFlag_None, "# can only be used by the session host");
 		return 0;

--- a/xlive/H2MOD/GUI/imgui_integration/MessageBox.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/MessageBox.cpp
@@ -1,10 +1,10 @@
 #include "stdafx.h"
 
-#include "Blam/Common/Common.h"
-#include "H2MOD.h"
-#include "H2MOD/Modules/Input/PlayerControl.h"
 #include "imgui.h"
 #include "imgui_handler.h"
+
+#include "Blam/Engine/game/game_globals.h"
+#include "H2MOD/Modules/Input/PlayerControl.h"
 #include "Util/Hooks/Hook.h"
 
 namespace ImGuiHandler
@@ -31,7 +31,7 @@ namespace ImGuiHandler
 			//ImGui::PushFont(font2);
 			ImGui::SetNextWindowSize(ImVec2(650, 250), ImGuiCond_Appearing);
 			ImGui::SetNextWindowSizeConstraints(ImVec2(610, 250), ImVec2(1920, 1080));
-			if (h2mod->GetEngineType() == _game_mode_ui_shell)
+			if (s_game_globals::game_is_mainmenu())
 				ImGui::SetNextWindowBgAlpha(1);
 			if (ImGui::Begin("Message", NULL, window_flags))
 			{

--- a/xlive/H2MOD/Modules/KantTesting/KantTesting.cpp
+++ b/xlive/H2MOD/Modules/KantTesting/KantTesting.cpp
@@ -1,35 +1,11 @@
 #include "stdafx.h"
-
 #include "KantTesting.h"
-#include "Blam/Cache/DataTypes/BlamPrimitiveType.h"
-#include "Blam/Cache/TagGroups/biped_definition.hpp"
-#include "Blam/Cache/TagGroups/globals_definition.hpp"
-#include "Blam/Cache/TagGroups/model_definition.hpp"
-#include "Blam/Cache/TagGroups/scenario_definition.hpp"
-#include "Blam/Cache/TagGroups/scenario_lightmap_definition.hpp"
-#include "Blam/Cache/TagGroups/scenario_structure_bsp_definition.hpp"
-#include "Blam/Cache/TagGroups/weapon_definition.hpp"
-#include "Blam/Engine/game/game_engine.h"
-#include "Blam/Engine/game/game_globals.h"
-#include "Blam/Engine/game/players.h"
-#include "Blam/LazyBlam/LazyBlam.hpp"
-#include "H2MOD/Modules/Shell/Config.h"
-#include "H2MOD/Modules/EventHandler/EventHandler.hpp"
-#include "Blam/Engine/memory/bitstream.h"
-#include "Blam/Engine/memory/bitstream.h"
-#include "H2MOD/Modules/PlayerRepresentation/PlayerRepresentation.h"
-#include "H2MOD/Tags/MetaExtender.h"
-#include "H2MOD/Tags/MetaLoader/tag_loader.h"
-#include "Util/Hooks/Hook.h"
 
 
 namespace KantTesting
 {
 	void MapLoad()
 	{
-		if (h2mod->GetEngineType() == _game_mode_multiplayer)
-		{
-		}
 	}
 	
 	void Initialize()

--- a/xlive/H2MOD/Modules/MainLoopPatches/RunLoop/RunLoop.cpp
+++ b/xlive/H2MOD/Modules/MainLoopPatches/RunLoop/RunLoop.cpp
@@ -265,7 +265,7 @@ bool __cdecl cinematic_in_progress_hook()
 bool __cdecl cinematics_in_progress_disable_framerate_cap_hook()
 {
 	// don't limit the game framerate if we're single player and playing cinematics
-	if (h2mod->GetEngineType() == _game_mode_campaign)
+	if (s_game_globals::game_is_campaign())
 		return false;
 
 	return p_cinematic_is_running();

--- a/xlive/H2MOD/Modules/MainMenu/MapSlots.h
+++ b/xlive/H2MOD/Modules/MainMenu/MapSlots.h
@@ -2,6 +2,6 @@
 namespace MapSlots
 {
 	void OnMapLoad();
-	void ApplyHooks();
+	void map_slots_apply_dedi_hooks();
 	void Initialize();
 }

--- a/xlive/H2MOD/Modules/PlayerRepresentation/PlayerRepresentation.cpp
+++ b/xlive/H2MOD/Modules/PlayerRepresentation/PlayerRepresentation.cpp
@@ -6,7 +6,6 @@
 #include "Blam/Cache/TagGroups/scenario_definition.hpp"
 #include "Blam/Engine/game/game_engine.h"
 #include "Blam/Engine/game/game_engine_util.h"
-#include "Blam/Engine/game/game_globals.h"
 #include "Blam/Engine/game/players.h"
 #include "Blam/Engine/Networking/Session/NetworkSession.h"
 #include "Blam/Engine/tag_files/global_string_ids.h"
@@ -208,11 +207,11 @@ namespace PlayerRepresentation
 		}
 	}
 
-	void OnMapLoad()
+	void OnMapLoad(s_game_options* options)
 	{
 		current_representation_count = 4;
 
-		if (h2mod->GetEngineType() == _game_mode_multiplayer) 
+		if (options->game_mode == _game_mode_multiplayer)
 		{
 			if (H2Config_spooky_boy && get_current_special_event() == e_special_event_type::_halloween && !Memory::IsDedicatedServer())
 			{
@@ -330,7 +329,6 @@ namespace PlayerRepresentation
 	void Initialize()
 	{
 		ApplyHooks();
-		tags::on_map_load(OnMapLoad);
 	}
 
 }

--- a/xlive/H2MOD/Modules/PlayerRepresentation/PlayerRepresentation.h
+++ b/xlive/H2MOD/Modules/PlayerRepresentation/PlayerRepresentation.h
@@ -1,7 +1,8 @@
 #include "Blam/Cache/DataTypes/BlamPrimitiveType.h"
-#include "Blam/Engine/tag_files/string_id.h"
 #include "Blam/Cache/TagGroups/globals_definition.hpp"
+#include "Blam/Engine/game/game_globals.h"
 #include "Blam/Engine/game/players.h"
+#include "Blam/Engine/tag_files/string_id.h"
 
 namespace PlayerRepresentation
 {
@@ -24,5 +25,6 @@ namespace PlayerRepresentation
 	s_globals_group_definition::s_player_representation_block* clone_representation(int index, e_character_type newType);
 
 	datum get_object_datum_from_representation(e_character_type representation_index);
+	void OnMapLoad(s_game_options* options);
 	void Initialize();
 }

--- a/xlive/H2MOD/Modules/WeaponOffsets/WeaponOffsets.cpp
+++ b/xlive/H2MOD/Modules/WeaponOffsets/WeaponOffsets.cpp
@@ -1,11 +1,11 @@
 #include "stdafx.h"
 
-#include "H2MOD.h"
+#include "Blam/Engine/game/game_globals.h"
 #include "H2MOD/Modules/Input/PlayerControl.h"
 #include "H2MOD/GUI/ImGui_Integration/ImGui_Handler.h"
-#include "Util/Hooks/Hook.h"
 #include "H2MOD/Tags/MetaLoader/tag_loader.h"
 #include "H2MOD/Modules/WeaponOffsets/WeaponOffsetConfig.h"
+#include "Util/Hooks/Hook.h"
 
 namespace ImGuiHandler {
 	namespace WeaponOffsets {
@@ -118,7 +118,7 @@ namespace ImGuiHandler {
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(4, 8));
 			ImGui::SetNextWindowSize(ImVec2(450, 320), ImGuiCond_Appearing);
 			ImGui::SetNextWindowSizeConstraints(ImVec2(410, 320), ImVec2(1920, 1080));
-			if (h2mod->GetEngineType() == _game_mode_ui_shell)
+			if (s_game_globals::game_is_mainmenu())
 				ImGui::SetNextWindowBgAlpha(1);
 			if (ImGui::Begin(GetString(e_weapon_offsets_string::title), &open, window_flags))
 			{

--- a/xlive/H2MOD/Variants/FireFight/FireFight.cpp
+++ b/xlive/H2MOD/Variants/FireFight/FireFight.cpp
@@ -76,7 +76,7 @@ void FireFight::OnObjectDamage(ExecTime execTime, datum unitDatumIdx, int a2, bo
 	}
 }
 
-void FireFight::OnMapLoad(ExecTime execTime, s_game_options* gameOptions)
+void FireFight::OnMapLoad(ExecTime execTime, s_game_options* options)
 {
 	switch (execTime)
 	{
@@ -84,7 +84,7 @@ void FireFight::OnMapLoad(ExecTime execTime, s_game_options* gameOptions)
 		break;
 
 	case ExecTime::_postEventExec:
-		switch (h2mod->GetEngineType())
+		switch (options->game_mode)
 		{
 			// cleanup when loading main menu
 		case _game_mode_multiplayer:

--- a/xlive/H2MOD/Variants/FireFight/FireFight.h
+++ b/xlive/H2MOD/Variants/FireFight/FireFight.h
@@ -15,7 +15,7 @@ public:
 	virtual CustomVariantId GetVariantId();
 	
 	// on map load can be used as Initialize
-	virtual void OnMapLoad(ExecTime execTime, s_game_options* gameOptions) override;
+	virtual void OnMapLoad(ExecTime execTime, s_game_options* options) override;
 	virtual void OnPlayerSpawn(ExecTime execTime, datum playerIdx) override;
 	virtual void OnPlayerDeath(ExecTime execTime, datum playerIdx) override;
 	virtual void OnObjectDamage(ExecTime execTime, datum unitDatumIdx, int a2, bool a3, bool a4) override;

--- a/xlive/H2MOD/Variants/GraveRobber/GraveRobber.cpp
+++ b/xlive/H2MOD/Variants/GraveRobber/GraveRobber.cpp
@@ -121,7 +121,7 @@ CustomVariantId GraveRobber::GetVariantId()
 	return CustomVariantId::_id_graverobber;
 }
 
-void GraveRobber::OnMapLoad(ExecTime execTime, s_game_options* gameOptions)
+void GraveRobber::OnMapLoad(ExecTime execTime, s_game_options* options)
 {
 	switch (execTime)
 	{
@@ -129,7 +129,7 @@ void GraveRobber::OnMapLoad(ExecTime execTime, s_game_options* gameOptions)
 		break;
 
 	case ExecTime::_postEventExec:
-		switch (h2mod->GetEngineType())
+		switch (options->game_mode)
 		{
 		case _game_mode_multiplayer:
 			this->Initialize();

--- a/xlive/H2MOD/Variants/GraveRobber/GraveRobber.h
+++ b/xlive/H2MOD/Variants/GraveRobber/GraveRobber.h
@@ -35,7 +35,7 @@ public:
 	CustomVariantId GetVariantId();
 
 	// on map load can be used as Initialize
-	virtual void OnMapLoad(ExecTime execTime, s_game_options* gameOptions) override;
+	virtual void OnMapLoad(ExecTime execTime, s_game_options* options) override;
 	virtual void OnPlayerSpawn(ExecTime execTime, datum playerIdx) override;
 	virtual void OnObjectDamage(ExecTime execTime, datum unitDatumIdx, int a2, bool a3, bool a4) override {/*Unused*/ };
 	virtual void OnPlayerDeath(ExecTime execTime, datum playerIdx) override;

--- a/xlive/H2MOD/Variants/Infection/Infection.cpp
+++ b/xlive/H2MOD/Variants/Infection/Infection.cpp
@@ -320,7 +320,7 @@ CustomVariantId Infection::GetVariantId()
 	return CustomVariantId::_id_infection;
 }
 
-void Infection::OnMapLoad(ExecTime execTime, s_game_options* gameOptions)
+void Infection::OnMapLoad(ExecTime execTime, s_game_options* options)
 {
 	switch (execTime)
 	{
@@ -328,7 +328,7 @@ void Infection::OnMapLoad(ExecTime execTime, s_game_options* gameOptions)
 		break;
 
 	case ExecTime::_postEventExec:
-		switch (h2mod->GetEngineType())
+		switch (options->game_mode)
 		{
 			// cleanup when loading main menu
 		case _game_mode_multiplayer:

--- a/xlive/H2MOD/Variants/Infection/Infection.h
+++ b/xlive/H2MOD/Variants/Infection/Infection.h
@@ -52,7 +52,7 @@ public:
 	virtual CustomVariantId GetVariantId() override;
 
 	// on map load can be used as Initialize
-	virtual void OnMapLoad(ExecTime execTime, s_game_options* gameOptions) override;
+	virtual void OnMapLoad(ExecTime execTime, s_game_options* options) override;
 	virtual void OnPlayerSpawn(ExecTime execTime, datum playerIdx) override;
 	virtual void OnPlayerDeath(ExecTime execTime, datum playerIdx) override;
 

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -309,8 +309,6 @@
     <ClCompile Include="Blam\Engine\text\font_cache.cpp" />
     <ClCompile Include="Blam\Engine\text\unicode.cpp" />
     <ClCompile Include="Blam\Engine\units\units.cpp" />
-    <ClCompile Include="Blam\LazyBlam\LazyBlamLoader.cpp" />
-    <ClCompile Include="Blam\LazyBlam\LazyBlamRebase.cpp" />
     <ClCompile Include="Blam\Math\real_matrix4x3.cpp" />
     <ClCompile Include="Blam\Math\real_vector3d.cpp" />
     <ClCompile Include="Blam\Engine\objects\objects.cpp" />
@@ -383,7 +381,6 @@
     <ClCompile Include="H2MOD\Tags\MetaLoader\meta_struct.cpp" />
     <ClCompile Include="H2MOD\Tags\MetaLoader\tag_loader.cpp" />
     <ClCompile Include="H2MOD\Modules\Shell\ServerConsole.cpp" />
-    <ClCompile Include="Blam\LazyBlam\LazyBlam.cpp" />
     <ClCompile Include="H2MOD\Variants\GraveRobber\GraveRobber.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -634,7 +631,6 @@
     <ClInclude Include="Blam\Engine\units\units.h" />
     <ClInclude Include="Blam\Engine\tag_files\global_string_ids.h" />
     <ClInclude Include="Blam\Engine\camera\camera.h" />
-    <ClInclude Include="Blam\LazyBlam\TagTable.h" />
     <ClInclude Include="Blam\Cache\DataTypes\DataRef.h" />
     <ClInclude Include="Blam\Math\integer_math.h" />
     <ClInclude Include="Blam\Math\real_math.h" />
@@ -713,7 +709,6 @@
     <ClInclude Include="H2MOD\Tags\MetaLoader\cache_loader.h" />
     <ClInclude Include="H2MOD\Tags\MetaLoader\meta_struct.h" />
     <ClInclude Include="H2MOD\Tags\MetaLoader\tag_loader.h" />
-    <ClInclude Include="Blam\LazyBlam\LazyBlam.hpp" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Util\curl-interface.h" />
     <ClInclude Include="Util\Memory.h" />


### PR DESCRIPTION
- crash happens after you try to scale the crosshair in the main menu after loading a map and returning to the main menu, the code for clearing the data didn't get run while in the main menu.

- remove member functions in h2mod for game mode (duplicated info that already exists within the game, grab from options on map load and global options while in-game instead)
- don't include lazyblam in project build (never used so no point in compiling it)