### PR TITLE
don't show other parts of the hud when show hud is unchecked

### DIFF
--- a/xlive/Blam/Engine/interface/new_hud.cpp
+++ b/xlive/Blam/Engine/interface/new_hud.cpp
@@ -27,7 +27,12 @@ void should_draw_hud_override_set(bool flag)
 
 s_new_hud_engine_globals* get_new_hud_engine_globals(void)
 {
-	return *Memory::GetAddress<s_new_hud_engine_globals**>(0x9770F4);
+	return *Memory::GetAddress<s_new_hud_engine_globals**>(0x9770F4, 0x99E93C);
+}
+
+s_hud_scripted_globals* get_hud_scripted_globals(void)
+{
+	return *Memory::GetAddress<s_hud_scripted_globals**>(0x9765CC, 0x99FBB4);
 }
 
 bool __cdecl render_ingame_chat_check() 

--- a/xlive/Blam/Engine/interface/new_hud.cpp
+++ b/xlive/Blam/Engine/interface/new_hud.cpp
@@ -6,6 +6,7 @@
 #include "Blam/Engine/game/game.h"
 #include "Blam/Engine/interface/hud.h"
 #include "Blam/Engine/interface/new_hud_definitions.h"
+#include "Blam/Engine/main/main_screenshot.h"
 #include "Blam/Engine/Networking/logic/life_cycle_manager.h"
 #include "Blam/Math/integer_math.h"
 
@@ -14,10 +15,17 @@
 #include "H2MOD/Tags/TagInterface.h"
 #include "Util/Hooks/Hook.h"
 
+bool g_should_draw_hud_override = true;
 std::vector<datum> crosshair_bitmap_datums;				// Store all the crosshair bitmap datums
 std::vector<point2d> crosshair_original_bitmap_sizes;	// We use point2d struct to store the original resolutions (x as width and y as height)
 
-s_new_hud_engine_globals* get_new_hud_engine_globals()
+void should_draw_hud_override_set(bool flag)
+{
+	g_should_draw_hud_override = flag;
+	return;
+}
+
+s_new_hud_engine_globals* get_new_hud_engine_globals(void)
 {
 	return *Memory::GetAddress<s_new_hud_engine_globals**>(0x9770F4);
 }
@@ -166,6 +174,20 @@ void initialize_crosshair_scale(bool game_mode_ui_shell)
 	set_crosshair_scale(H2Config_crosshair_scale);
 }
 
+// Checks if we shouldn't draw the hud
+bool new_hud_dont_draw(void)
+{
+	// Added check for get_new_hud_engine_globals()->show_hud since it will still render other parts of the hud if show_hud is set to false
+	// This does not match legacy behaviour, however the text for picking up weapons is a part of the hud so I assume this is a mistake from bungie
+	bool dont_draw_hud = !g_should_draw_hud_override;
+
+	bool original_check = get_screenshot_globals()->taking_screenshot || get_screenshot_globals()->resolution_multiplier > 1;
+
+	// If original check or show_hud check are true we don't draw the hud
+	// Otherwise return false so we show the hud
+	return (original_check || dont_draw_hud ? true : false);
+}
+
 void new_hud_apply_patches()
 {
 	if (Memory::IsDedicatedServer()) { return; }
@@ -182,6 +204,9 @@ void new_hud_apply_patches()
 
 	// Hook ui_get_hud_elements for modifying the hud anchor for text
 	PatchCall(Memory::GetAddress(0x22D25A), ui_get_hud_elemet_bounds_hook);
+
+	// Hook new_hud_dont_draw so we can use another bool to make sure we don't draw any parts of the hud
+	PatchCall(Memory::GetAddress(0x2278B3), new_hud_dont_draw);
 }
 
 void new_hud_patches_on_map_load(bool game_mode_ui_shell)

--- a/xlive/Blam/Engine/interface/new_hud.h
+++ b/xlive/Blam/Engine/interface/new_hud.h
@@ -2,6 +2,14 @@
 #include "Blam/Engine/game/players.h"
 #include "Blam/Engine/Networking/Session/NetworkSession.h"
 
+struct s_hud_scripted_globals
+{
+	bool unused_bool;
+	bool show_help_text;
+	bool show_hud_messages;
+};
+CHECK_STRUCT_SIZE(s_hud_scripted_globals, 3);
+
 struct s_new_hud_globals_player_info
 {
 	real32 unk_0;
@@ -36,6 +44,7 @@ CHECK_STRUCT_SIZE(s_new_hud_engine_globals, 564);
 
 void should_draw_hud_override_set(bool flag);
 s_new_hud_engine_globals* get_new_hud_engine_globals(void);
+s_hud_scripted_globals* get_hud_scripted_globals(void);
 
 void set_crosshair_scale(float scale);
 void new_hud_apply_patches();

--- a/xlive/Blam/Engine/interface/new_hud.h
+++ b/xlive/Blam/Engine/interface/new_hud.h
@@ -1,37 +1,41 @@
 #pragma once
 #include "Blam/Engine/game/players.h"
+#include "Blam/Engine/Networking/Session/NetworkSession.h"
 
 struct s_new_hud_globals_player_info
 {
-	float unk_0;
-	float unk_4;
-	int unk_8;
-	byte unk_C[76];
+	real32 unk_0;
+	real32 unk_4;
+	int32 unk_8;
+	uint8 unk_C[76];
 	void* text_chat_widget;
-	byte unk_5C[36];
+	uint8 unk_5C[36];
 };
 CHECK_STRUCT_SIZE(s_new_hud_globals_player_info, 128);
 
 struct s_new_hud_engine_globals
 {
-	s_new_hud_globals_player_info player_data[4];
-	int field_200;
-	int field_204;
+	s_new_hud_globals_player_info player_data[k_number_of_users];
+	int32 field_200;
+	int32 field_204;
 	datum betraying_player_datum_index;
-	int gap_20C;
+	int32 gap_20C;
 	s_player_profile_traits default_profile_traits;
-	__int16 unk_220;
+	int16 unk_220;
 	bool show_hud;
 	bool flag_20D;			// initialized to 1 but unused?
 	bool flag_20E;			// initialized to 1 but unused?
 	bool connected_to_live;
-	byte gap_222[2];
-	float hud_opacity;
-	float unk_22C;
-	float unk_230;
+	int8 gap_222[2];
+	real32 hud_opacity;
+	real32 unk_22C;
+	real32 unk_230;
 };
 CHECK_STRUCT_SIZE(s_new_hud_engine_globals, 564);
-s_new_hud_engine_globals* get_new_hud_engine_globals();
+
+
+void should_draw_hud_override_set(bool flag);
+s_new_hud_engine_globals* get_new_hud_engine_globals(void);
 
 void set_crosshair_scale(float scale);
 void new_hud_apply_patches();

--- a/xlive/Blam/Engine/main/main_screenshot.h
+++ b/xlive/Blam/Engine/main/main_screenshot.h
@@ -11,9 +11,9 @@ struct s_screenshot_globals
 	bool dump_camera_data;
 	bool capture_cubemap;
 	bool camera_name_set;
-	int resolution_multiplier;
-	int fieldC;
-	char camera_name[256];
+	int32 resolution_multiplier;
+	int32 fieldC;
+	static_string256 camera_name;
 	bitmap_data* bloom_bitmap;
 };
 CHECK_STRUCT_SIZE(s_screenshot_globals, 276);

--- a/xlive/H2MOD/GUI/imgui_integration/AdvancedSettings.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/AdvancedSettings.cpp
@@ -33,7 +33,7 @@ namespace ImGuiHandler {
 		namespace
 		{
 			float crosshairSize = 1.0f;
-			bool g_showHud = true;
+			bool should_show_hud = true;
 			bool g_showFP = true;
 			bool g_UncappedFPS = false;
 			int g_fpsLimit = 60;
@@ -239,9 +239,9 @@ namespace ImGuiHandler {
 					if (ImGui::IsItemHovered())
 						ImGui::SetTooltip(GetString(static_fp_tooltip));
 					ImGui::NextColumn();
-					ImGui::Checkbox(GetString(show_hud), &g_showHud);
+					ImGui::Checkbox(GetString(show_hud), &should_show_hud);
 					if (ImGui::IsItemEdited())
-						get_new_hud_engine_globals()->show_hud = g_showHud;
+						should_draw_hud_override_set(should_show_hud);
 					ImGui::NextColumn();
 					ImGui::Checkbox(GetString(show_first_person), &g_showFP);
 					if (ImGui::IsItemEdited())


### PR DESCRIPTION
- fixes issue where pickup and welcome text were visible
- update struct types
- define hud scripted globals struct