### PR TITLE
fixed crash when deleting attached turrets

### DIFF
--- a/xlive/Blam/Engine/simulation/simulation_queue_entities.cpp
+++ b/xlive/Blam/Engine/simulation/simulation_queue_entities.cpp
@@ -546,6 +546,13 @@ void simulation_queue_entity_deletion_apply(const s_simulation_queue_element* el
 		game_entity.state_data = NULL;
 		game_entity.state_data_size = 0;
 
+		// validate the object index, mainly for attached objects
+		// cause they might have been deleted already with the parent
+		if (!simulation_object_index_valid(game_entity.object_index))
+		{
+			game_entity.object_index = NONE;
+		}
+
 		if (entity_def->delete_game_entity(&game_entity))
 		{
 			// SUCCESS


### PR DESCRIPTION
re-add deletion validation because attached turrets might have been already deleted with the parent object