### PR TITLE
Allow proper multi-controller support in H2V

### DIFF
--- a/xlive/Blam/Engine/game/player_vibration.cpp
+++ b/xlive/Blam/Engine/game/player_vibration.cpp
@@ -12,9 +12,9 @@
 #include "H2MOD/Tags/TagInterface.h"
 
 s_vibration_globals* vibration_globals_get(void);
-s_vibration_state vibration_get_state_usercall(s_vibration_user_globals* user_globals);
+XINPUT_VIBRATION vibration_get_state_usercall(s_vibration_user_globals* user_globals);
 
-s_vibration_state vibration_get_state(s_vibration_user_globals* user_globals);
+XINPUT_VIBRATION vibration_get_state(s_vibration_user_globals* user_globals);
 
 void __cdecl rumble_player_set_scripted_scale(real32 scale)
 {
@@ -58,7 +58,7 @@ void __cdecl vibration_update(real32 dt)
             for (uint32 user_index = 0; user_index < k_number_of_users; user_index++)
             {
                 s_vibration_user_globals* globals = vibration_get(user_index);
-                s_vibration_state state = vibration_get_state(globals);
+                XINPUT_VIBRATION state = vibration_get_state(globals);
                 datum player_index = player_index_from_user_index(user_index);
 
                 dt = tick_length;       // Increment by the tick_length instead of dt for now to fix issues when playing above 30fps
@@ -76,7 +76,7 @@ void __cdecl vibration_update(real32 dt)
                     s_player* player = (s_player*)datum_get(s_player::get_data(), player_index);
                     if (player->controller_index != NONE && user_interface_controller_get_rumble_enabled(player->controller_index))
                     {
-                        input_set_gamepad_rumbler_state(player->controller_index, state.left, state.right);
+                        input_set_gamepad_rumbler_state(player->controller_index, state.wLeftMotorSpeed, state.wRightMotorSpeed);
 
                         ASSERT(VALID_INDEX(player->controller_index, k_number_of_controllers));
                         controller_rumble_enabled[player->controller_index] = true;
@@ -105,9 +105,9 @@ s_vibration_globals* vibration_globals_get(void)
     return *Memory::GetAddress<s_vibration_globals**>(0x4CA378, 0x4F3DC4);
 }
 
-s_vibration_state vibration_get_state_usercall(s_vibration_user_globals* user_globals) 
+XINPUT_VIBRATION vibration_get_state_usercall(s_vibration_user_globals* user_globals)
 {
-    s_vibration_state state;
+    XINPUT_VIBRATION state;
     void* fn = (void*)Memory::GetAddress(0x90254);
     __asm {
         mov eax, user_globals
@@ -117,7 +117,7 @@ s_vibration_state vibration_get_state_usercall(s_vibration_user_globals* user_gl
     return state;
 }
 
-s_vibration_state vibration_get_state(s_vibration_user_globals* user_globals)
+XINPUT_VIBRATION vibration_get_state(s_vibration_user_globals* user_globals)
 {
     // Copy user values to calculate
     real32 intensities[2] = { user_globals->intensity[0],user_globals->intensity[1] };
@@ -165,7 +165,7 @@ s_vibration_state vibration_get_state(s_vibration_user_globals* user_globals)
     intensities[0] *= (real32)UINT16_MAX;
     intensities[1] *= (real32)UINT16_MAX;
 
-    s_vibration_state state
+    XINPUT_VIBRATION state
     {
         (uint16)PIN(intensities[0], 0.0f, (real32)UINT16_MAX),  // Left
         (uint16)PIN(intensities[1], 0.0f, (real32)UINT16_MAX)   // Right

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -1,7 +1,61 @@
 #include "stdafx.h"
 #include "input_abstraction.h"
 
+s_input_abstraction_globals* input_abstraction_globals;
+
+void __cdecl input_abstraction_initialize()
+{
+	INVOKE(0x61D43, 0x0, input_abstraction_initialize);
+}
+
+void __cdecl input_abstraction_dispose()
+{
+	INVOKE(0x5E296, 0x0, input_abstraction_dispose);
+}
+
+void __cdecl input_abstraction_get_controller_preferences(e_controller_index controller_index, s_gamepad_input_preferences* preferences)
+{
+	INVOKE(0x61BF4, 0x0, input_abstraction_get_controller_preferences, controller_index, preferences);
+}
+
+void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state)
+{
+	INVOKE(0x61C3B, 0x0, input_abstraction_get_input_state, controller_index, state);
+}
+
+void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity)
+{
+	INVOKE(0x61D0B, 0x0, input_abstraction_get_player_look_angular_velocity, controller_index, angular_velocity);
+}
+
+void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_controller_index controller_index, real_euler_angles2d* angular_velocity)
+{
+	INVOKE(0x61CD3, 0x0, input_abstraction_get_player_look_angular_velocity_for_mouse, controller_index, angular_velocity);
+}
+
+bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_functions button_index)
+{
+	return INVOKE(0x61C5B, 0x0, input_abstraction_controller_button_test, controller_index, button_index);
+}
+
+e_button_functions __cdecl input_abstraction_get_primary_fire_button(datum unit)
+{
+	return INVOKE(0x5E2B6, 0x0, input_abstraction_get_primary_fire_button, unit);
+}
+
+e_button_functions __cdecl input_abstraction_get_secondary_fire_button(datum unit)
+{
+	return INVOKE(0x5E2ED, 0x0, input_abstraction_get_secondary_fire_button, unit);
+}
+
+
 bool __cdecl input_abstraction_get_key_state(int16 key)
 {
 	return INVOKE(0x2EF86, 0x0, input_abstraction_get_key_state, key);
+}
+
+
+void input_abstraction_patches_apply()
+{
+	input_abstraction_globals = Memory::GetAddress<s_input_abstraction_globals*>(0x4A89B0);
 }

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -13,6 +13,11 @@ void __cdecl input_abstraction_dispose()
 	INVOKE(0x5E296, 0x0, input_abstraction_dispose);
 }
 
+void __cdecl input_abstraction_handle_device_change(uint32 flags)
+{
+	INVOKE(0x61C72, 0x0, input_abstraction_handle_device_change, flags);
+}
+
 void __cdecl input_abstraction_get_controller_preferences(e_controller_index controller_index, s_gamepad_input_preferences* preferences)
 {
 	INVOKE(0x61BF4, 0x0, input_abstraction_get_controller_preferences, controller_index, preferences);

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "controllers.h"
+#include "input_windows.h"
 
 #define K_MAXIMUM_NUMBER_OF_GAME_FUNCTION_BINDS 8
 
@@ -119,12 +120,6 @@ struct s_gamepad_input_preferences
 	int16 gamepad_axial_deadzone_right_y;
 };
 CHECK_STRUCT_SIZE(s_gamepad_input_preferences, 0x1680);
-
-struct s_key_state
-{
-	uint8 gap[0x8];
-};
-CHECK_STRUCT_SIZE(s_key_state, 0x8);
 
 struct s_keyboard_input_preferences
 {

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -166,6 +166,7 @@ extern s_input_abstraction_globals* input_abstraction_globals;
 
 void __cdecl input_abstraction_initialize();
 void __cdecl input_abstraction_dispose();
+void __cdecl input_abstraction_handle_device_change(uint32 flags);
 void __cdecl input_abstraction_get_controller_preferences(e_controller_index controller_index, s_gamepad_input_preferences* preferences);
 void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state);
 void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity);

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -1,3 +1,184 @@
 #pragma once
 
+#include "controllers.h"
+
+#define K_MAXIMUM_NUMBER_OF_GAME_FUNCTION_BINDS 8
+
+enum e_input_preference_device_type :uint32
+{
+	_input_preference_device_general = 0xFFFFFFFF,
+	_input_preference_device_mouse = 0x0,
+	_input_preference_device_keyboard = 0x1,
+	_input_preference_device_gamepad = 0x2,
+};
+
+enum e_button_functions
+{
+	_button_jump = 0x0,
+	_button_trick = 0x1,
+	_button_brake = 0x2,
+	_button_switch_grenade = 0x3,
+	_button_switch_weapon = 0x4,
+	_button_melee_attack = 0x5,
+	_button_flashlight = 0x6,
+	_button_throw_grenade = 0x7,
+	_button_speed_boost = 0x8,
+	_button_e_brake = 0x9,
+	_button_fire = 0xA,
+	_button_start = 0xB,
+	_button_back = 0xC,
+	_button_crouch = 0xD,
+	_button_scope_zoom = 0xE,
+	_button_scope_zoom_in = 0xF,
+	_button_scope_zoom_out = 0x10,
+	_button_lean_left = 0x11,
+	_button_lean_right = 0x12,
+	_button_accept = 0x13,
+	_button_cancel = 0x14,
+	_button_banshee_bomb = 0x15,
+	_button_dual_wield_primary_fire = 0x16,
+	_button_dual_wield_secondary_fire = 0x17,
+	_button_vehicle_primary_fire = 0x18,
+	_button_vehicle_secondary_fire = 0x19,
+	_button_text_chat_toggle = 0x1A,
+	_button_text_chat_team = 0x1B,
+	_button_ui_scroll_up = 0x1C,
+	_button_ui_scroll_down = 0x1D,
+	_button_team_voice = 0x1E,
+	_button_flip_vehicle = 0x1F,
+	_button_touch_device = 0x20,
+	_button_enter_vehicle = 0x21,
+	_button_board_vehicle = 0x22,
+	_button_evict_from_vehicle = 0x23,
+	_button_trade_weapon = 0x24,
+	_button_pick_up_primary_weapon = 0x25,
+	_button_pick_up_primary_multiplayer_weapon = 0x26,
+	_button_pick_up_secondary_weapon = 0x27,
+	_button_pick_up_secondary_multiplayer_weapon = 0x28,
+	_button_put_away_secondary_weapon = 0x29,
+	_button_put_away_or_drop_secondary_weapon = 0x2A,
+	_button_reload = 0x2B,
+	_button_exit_vehicle = 0x2C,
+	_button_move_forward = 0x2D,
+	_button_move_backward = 0x2E,
+	_button_strafe_left = 0x2F,
+	_button_strafe_right = 0x30,
+	_button_mouse_yaw_left = 0x31,
+	_button_mouse_yaw_right = 0x32,
+	_button_mouse_pitch_forward = 0x33,
+	_button_mouse_pitch_backward = 0x34,
+	_extended_button_gamepad_yaw_left = 0x35,
+	_extended_button_gamepad_yaw_right = 0x36,
+	_extended_button_gamepad_pitch_forward = 0x37,
+	_extended_button_gamepad_pitch_backward = 0x38,
+
+	NUMBER_OF_BUTTON_KEYS = 0x39,
+	NUMBER_OF_ABSTRACT_BUTTONS = 0x2D,
+};
+
+#pragma pack(push,1)
+struct s_game_function_bind
+{
+	e_input_preference_device_type m_device_type;
+	uint32 m_button_key;
+	uint32 unknown;
+};
+CHECK_STRUCT_SIZE(s_game_function_bind, 0xC);
+
+struct s_game_function
+{
+	uint32 m_bind_count;
+	s_game_function_bind m_bind[K_MAXIMUM_NUMBER_OF_GAME_FUNCTION_BINDS];
+};
+CHECK_STRUCT_SIZE(s_game_function, 0x64);
+
+
+struct s_gamepad_input_preferences
+{
+	real32 mouse_yaw_rate;
+	real32 mouse_pitch_rate;
+	real32 gamepad_yaw_rate;
+	real32 gamepad_pitch_rate;
+	bool gamepad_invert_look;
+	bool mouse_invert_look;
+	bool invert_aircraft_control;
+	uint8 gap_13;
+	s_game_function game_function_mapping[NUMBER_OF_BUTTON_KEYS];
+	uint32 field_1658;
+	real32 binary_yaw_rate;
+	real32 binary_pitch_rate;
+	real32 stick_threshold;
+	real32 mouse_delta_threshold;
+	real32 mouse_wheel_threshold;
+	bool invert_dual_wield;
+	uint8 gap_1671[3];
+	real32 mouse_acceleration;
+	int16 gamepad_axial_deadzone_left_x;
+	int16 gamepad_axial_deadzone_left_y;
+	int16 gamepad_axial_deadzone_right_x;
+	int16 gamepad_axial_deadzone_right_y;
+};
+CHECK_STRUCT_SIZE(s_gamepad_input_preferences, 0x1680);
+
+struct s_key_state
+{
+	uint8 gap[0x8];
+};
+CHECK_STRUCT_SIZE(s_key_state, 0x8);
+
+struct s_keyboard_input_preferences
+{
+	s_key_state keys[NUMBER_OF_BUTTON_KEYS];
+};
+CHECK_STRUCT_SIZE(s_keyboard_input_preferences, 0x1C8);
+
+// TODO : verify this struct and NUMBER_OF_ABSTRACT_BUTTONS
+struct s_game_input_state
+{
+	uint8 m_down_frames[NUMBER_OF_ABSTRACT_BUTTONS];
+	uint8 pad2E;
+	uint16 m_down_msec[NUMBER_OF_ABSTRACT_BUTTONS];
+	real32 primary_fire;
+	real32 secondary_fire;
+	real32 forward_movement;
+	real32 strafe;
+	real_euler_angles2d mouse;
+	real_euler_angles2d gamepad;
+	real32 mouse_pitch2;
+	real32 gamepad_pitch2;
+	uint32 field_B0;
+	uint32 field_B4;
+};
+CHECK_STRUCT_SIZE(s_game_input_state, 0xB8);
+
+
+struct s_input_abstraction_globals
+{
+	s_gamepad_input_preferences preferences[k_number_of_controllers];
+	s_keyboard_input_preferences keyboard_preferences;
+	s_game_input_state input_states[k_number_of_controllers];
+	uint32 controller_detection_timer;
+	bool input_has_gamepad[k_number_of_controllers];
+	bool input_device_changed;
+	uint8 gap_5EB1[7];
+};
+CHECK_STRUCT_SIZE(s_input_abstraction_globals, 0x5EB8);
+#pragma pack(pop)
+
+
+extern s_input_abstraction_globals* input_abstraction_globals;
+
+
+void __cdecl input_abstraction_initialize();
+void __cdecl input_abstraction_dispose();
+void __cdecl input_abstraction_get_controller_preferences(e_controller_index controller_index, s_gamepad_input_preferences* preferences);
+void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state);
+void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
+void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
+bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_functions button_index);
+e_button_functions __cdecl input_abstraction_get_primary_fire_button(datum unit);
+e_button_functions __cdecl input_abstraction_get_secondary_fire_button(datum unit);
+
 bool __cdecl input_abstraction_get_key_state(int16 key);
+
+void input_abstraction_patches_apply();

--- a/xlive/Blam/Engine/input/input_windows.cpp
+++ b/xlive/Blam/Engine/input/input_windows.cpp
@@ -6,7 +6,7 @@
 
 #include "interface/user_interface_controller.h"
 
-s_vibration_state g_vibration_state[k_number_of_controllers]{};
+XINPUT_VIBRATION g_vibration_state[k_number_of_controllers]{};
 real32 g_rumble_factor = 1.0f;
 
 int32* hs_debug_simulate_gamepad_global_get(void)
@@ -23,11 +23,11 @@ void __cdecl input_set_gamepad_rumbler_state(int16 gamepad_index, uint16 left, u
 {
 	ASSERT(VALID_INDEX(gamepad_index, k_number_of_controllers));
 
-	s_vibration_state state = { left, right };
-	s_vibration_state state_none = { 0, 0 };
+	XINPUT_VIBRATION state = { left, right };
+	XINPUT_VIBRATION state_none = { 0, 0 };
 
-	state.left *= g_rumble_factor;
-	state.right *= g_rumble_factor;
+	state.wLeftMotorSpeed *= g_rumble_factor;
+	state.wRightMotorSpeed *= g_rumble_factor;
 
 	bool enabled = user_interface_controller_get_rumble_enabled((e_controller_index)gamepad_index);
 	g_vibration_state[gamepad_index] = (enabled ? state : state_none);

--- a/xlive/Blam/Engine/input/input_windows.cpp
+++ b/xlive/Blam/Engine/input/input_windows.cpp
@@ -6,8 +6,68 @@
 
 #include "interface/user_interface_controller.h"
 
+s_input_globals* input_globals;
+
 XINPUT_VIBRATION g_vibration_state[k_number_of_controllers]{};
 real32 g_rumble_factor = 1.0f;
+
+void __cdecl input_initialize()
+{
+	INVOKE(0x2FD23, 0x0, input_initialize);
+}
+
+void __cdecl input_dispose()
+{
+	INVOKE(0x2E309, 0x0, input_dispose);
+}
+
+void __cdecl input_update()
+{
+	INVOKE(0x2F9AC, 0x0, input_update);
+}
+
+void __cdecl input_update_gamepads(uint32 duration_ms)
+{
+	INVOKE(0x2E7A4, 0x0, input_update_gamepads, duration_ms);
+}
+
+void __cdecl input_update_mouse(DIMOUSESTATE2* mouse_state, uint32 duration_ms)
+{
+	INVOKE(0x2E60C, 0x0, input_update_mouse, mouse_state, duration_ms);
+}
+
+bool __cdecl input_has_gamepad(uint16 gamepad_index, bool* a2)
+{
+	return INVOKE(0x2F3CD, 0x0, input_has_gamepad, gamepad_index, a2);
+}
+s_gamepad_input_state* __cdecl input_get_gamepad(uint16 gamepad_index)
+{
+	//s_gamepad_input_state* global = Memory::GetAddress<s_gamepad_input_state*>(0x47A5C8);
+	//return &global[gamepad_index];
+	return &input_globals->gamepad_states[gamepad_index];
+}
+
+s_gamepad_input_button_state* __cdecl input_get_gamepad_state(uint16 gamepad_index)
+{
+	return INVOKE(0x2F433, 0x0, input_get_gamepad_state, gamepad_index);
+}
+
+DIMOUSESTATE2* __cdecl input_get_mouse_state()
+{
+	//return INVOKE(0x2E404, 0x0, input_get_mouse_state);
+	if (!input_globals->mouse_dinput_device)
+		return nullptr;
+	if (!input_globals->input_suppressed)
+		return &input_globals->mouse_state;
+
+	return &input_globals->suppressed_mouse_state;
+}
+
+bool __cdecl input_get_key(s_key_state* keystate)
+{
+	return INVOKE(0x2E3CB, 0x0, input_get_key, keystate);
+}
+
 
 int32* hs_debug_simulate_gamepad_global_get(void)
 {
@@ -37,6 +97,8 @@ void __cdecl input_set_gamepad_rumbler_state(int16 gamepad_index, uint16 left, u
 
 void input_windows_apply_patches(void)
 {
+	input_globals = Memory::GetAddress<s_input_globals*>(0x479F50);
+
 	PatchCall(Memory::GetAddress(0x9020F), input_set_gamepad_rumbler_state);    // Replace call in rumble_clear_all_now
 	return;
 }

--- a/xlive/Blam/Engine/input/input_windows.cpp
+++ b/xlive/Blam/Engine/input/input_windows.cpp
@@ -61,7 +61,7 @@ void __cdecl input_update_gamepads(uint32 duration_ms)
 	if (input_handled
 		&& g_window_handle == GetFocus()
 		&& g_window_handle == GetForegroundWindow()
-		&& game_is_minimized())
+		&& !game_is_minimized())
 	{
 		if ((input_globals->field7D8 & 1) == 0)
 		{

--- a/xlive/Blam/Engine/input/input_windows.h
+++ b/xlive/Blam/Engine/input/input_windows.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "controllers.h"
 
+#define K_NUMBER_OF_WINDOWS_INPUT_VIRTUAL_CODES 256
+#define K_NUMBER_OF_XINPUT_BUTTONS 14
+
 class input_device
 {
 public:
@@ -36,7 +39,102 @@ public:
 CHECK_STRUCT_SIZE(dinput_device, 0x40);
 
 
+
+#pragma pack(push,1)
+struct s_key_state
+{
+	uint8 gap[0x8];
+};
+CHECK_STRUCT_SIZE(s_key_state, 0x8);
+
+struct s_gamepad_input_button_state
+{
+	uint8 trigger_msec_down[2];
+	uint8 max_trigger_msec_down[2];
+	uint8 trigger_button_frames_down[2];
+	uint8 button_frames_down[K_NUMBER_OF_XINPUT_BUTTONS];
+	uint16 trigger_button_msec_down[2];
+	uint16 button_msec_down[K_NUMBER_OF_XINPUT_BUTTONS];
+	point2d thumb_left;
+	point2d thumb_right;
+};
+CHECK_STRUCT_SIZE(s_gamepad_input_button_state, 0x3C);
+
+struct s_gamepad_input_state
+{
+	bool connected;
+	bool m_device_just_joined;
+	bool m_device_just_left;
+	uint8 gap_3;
+	s_gamepad_input_button_state state;
+};
+CHECK_STRUCT_SIZE(s_gamepad_input_state, 0x40);
+
+struct s_keyboard_input_state
+{
+	uint8 frames_down[K_NUMBER_OF_WINDOWS_INPUT_VIRTUAL_CODES];
+	uint16 msec_down[K_NUMBER_OF_WINDOWS_INPUT_VIRTUAL_CODES];
+	bool key_bool[K_NUMBER_OF_WINDOWS_INPUT_VIRTUAL_CODES];
+};
+CHECK_STRUCT_SIZE(s_keyboard_input_state, 0x400);
+
+class c_input_dx9_mouse_cursor; //TODO
+
+struct s_input_globals
+{
+	bool initialized;
+	bool mouse_acquired;
+	bool input_suppressed;
+	bool feedback_suppress;
+	uint32 update_time;
+	uint32 update_msec;
+	IDirectInput8A* dinput;
+	s_keyboard_input_state keyboard;
+	int16 buffered_key_read_index;
+	int16 buffered_key_read_count;
+	s_key_state buffered_keys[64];
+	LPDIRECTINPUTDEVICE8A mouse_dinput_device;
+	bool mouse_show;
+	uint8 gap_619[3];
+	uint32 field_61C;
+	DIMOUSESTATE2 mouse_state;
+	int16 mouse_buttons[8];
+	DIMOUSESTATE2 suppressed_mouse_state;
+	uint8 gap_658[24];
+	uint32 mouse_cursor_state;
+	void* mouse_cursor_dx9;
+	s_gamepad_input_state gamepad_states[4];
+	s_gamepad_input_button_state suppressed_gamepad_state;
+	XINPUT_VIBRATION rumble_states[4];
+	uint32 main_controller_index;
+	bool hardware_device_changed;
+	char gap[3];
+	int debug_simulate_gamepad;
+	int field7D0;
+	int field7D8;
+};
+CHECK_STRUCT_SIZE(s_input_globals, 0x7D8);
+
+#pragma pack(pop)
+
+
+
+
+extern s_input_globals* input_globals;
+
 extern XINPUT_VIBRATION g_vibration_state[k_number_of_controllers];
+
+
+void __cdecl input_initialize();
+void __cdecl input_dispose();
+void __cdecl input_update();
+void __cdecl input_update_gamepads(uint32 duration_ms);
+void __cdecl input_update_mouse(DIMOUSESTATE2* mouse_state, uint32 duration_ms);
+bool __cdecl input_has_gamepad(uint16 gamepad_index, bool* a2);
+s_gamepad_input_state* __cdecl input_get_gamepad(uint16 gamepad_index);
+s_gamepad_input_button_state* __cdecl input_get_gamepad_state(uint16 gamepad_index);
+DIMOUSESTATE2* __cdecl input_get_mouse_state();
+bool __cdecl input_get_key(s_key_state* keystate);
 
 int32* hs_debug_simulate_gamepad_global_get(void);
 

--- a/xlive/Blam/Engine/input/input_windows.h
+++ b/xlive/Blam/Engine/input/input_windows.h
@@ -135,6 +135,7 @@ s_gamepad_input_state* __cdecl input_get_gamepad(uint16 gamepad_index);
 s_gamepad_input_button_state* __cdecl input_get_gamepad_state(uint16 gamepad_index);
 DIMOUSESTATE2* __cdecl input_get_mouse_state();
 bool __cdecl input_get_key(s_key_state* keystate);
+void __cdecl input_update_main_device_state();
 
 int32* hs_debug_simulate_gamepad_global_get(void);
 

--- a/xlive/Blam/Engine/input/input_windows.h
+++ b/xlive/Blam/Engine/input/input_windows.h
@@ -4,26 +4,39 @@
 class input_device
 {
 public:
-	virtual void nullsub_0(void) = 0;
-	virtual void nullsub_1(void) = 0;
-	virtual void update_state_error_checking(void) = 0;
-	virtual uint32 get_state(XINPUT_STATE* state) = 0;
-	virtual void set_state(XINPUT_VIBRATION* state) = 0;
-	virtual void update_state(void) = 0;
-
-protected:
-	uint32 controller_index;
-	uint32 controller_state;
-	XINPUT_STATE state;
+	virtual void XInputOpen(void) = 0;
+	virtual void XInputClose(void) = 0;
+	virtual void XUpdateState(void) = 0;
+	virtual uint32 XGetState(XINPUT_STATE* state) = 0;
+	virtual void XSetState(XINPUT_VIBRATION* state) = 0;
+	virtual void XUpdateImmediate(void) = 0;
 };
 
-struct s_vibration_state
+class dinput_device : public input_device
 {
-	uint16 left;
-	uint16 right;
+protected:
+	GUID m_rguid;
+	LPDIRECTINPUTDEVICE8A dinput_device;
+	uint32 error_level;
+	XINPUT_STATE gamepad_state;
+	bool m_device_acquired;
+	bool byte2D;
+	uint32 field30;
+	uint32 field34;
+	uint32 field38;
+	uint32 field3C;
+public:
+	virtual void XInputOpen(void) override;
+	virtual void XInputClose(void) override;
+	virtual void XUpdateState(void) override;
+	virtual uint32 XGetState(XINPUT_STATE* state) override;
+	virtual void XSetState(XINPUT_VIBRATION* state) { return; };
+	virtual void XUpdateImmediate(void) { return; };
 };
+CHECK_STRUCT_SIZE(dinput_device, 0x40);
 
-extern s_vibration_state g_vibration_state[k_number_of_controllers];
+
+extern XINPUT_VIBRATION g_vibration_state[k_number_of_controllers];
 
 int32* hs_debug_simulate_gamepad_global_get(void);
 

--- a/xlive/Blam/Engine/input/input_xinput.cpp
+++ b/xlive/Blam/Engine/input/input_xinput.cpp
@@ -6,7 +6,7 @@
 
 bool g_input_feedback_suppress = false;
 XINPUT_VIBRATION g_xinput_vibration{};
-xinput_device** g_xinput_devices;
+input_device** g_xinput_devices;
 uint32* g_main_controller_index;
 
 void input_xinput_clear_rumble_state(void)
@@ -17,10 +17,10 @@ void input_xinput_clear_rumble_state(void)
 
     for (uint32 i = 0; i < 4; i++)
     {
-        xinput_device* device = g_xinput_devices[i];
+        input_device* device = g_xinput_devices[i];
         if (device && controller_button_state_get((e_controller_index)i)->plugged_in)
         {
-            device->set_state(&vibration);
+            device->XSetState(&vibration);
         }
     }
     return;
@@ -41,13 +41,13 @@ void input_xinput_update_rumble_state(void)
 
     if (controller_button_state_get(_controller_index_0)->plugged_in)
     {
-        g_xinput_vibration.wLeftMotorSpeed = (suppress_rumble ? 0 : g_vibration_state[_controller_index_0].left);
-        g_xinput_vibration.wRightMotorSpeed = (suppress_rumble ? 0 : g_vibration_state[_controller_index_0].right);
-        xinput_device* device = g_xinput_devices[*g_main_controller_index];
+        g_xinput_vibration.wLeftMotorSpeed = (suppress_rumble ? 0 : g_vibration_state[_controller_index_0].wLeftMotorSpeed);
+        g_xinput_vibration.wRightMotorSpeed = (suppress_rumble ? 0 : g_vibration_state[_controller_index_0].wRightMotorSpeed);
+        input_device* device = g_xinput_devices[*g_main_controller_index];
         
         if (device)
         {
-            device->set_state(&g_xinput_vibration);
+            device->XSetState(&g_xinput_vibration);
         }
     }
 
@@ -57,7 +57,7 @@ void input_xinput_update_rumble_state(void)
 
 void xinput_apply_patches(void)
 {
-    g_xinput_devices = Memory::GetAddress<xinput_device**>(0x479F00);
+    g_xinput_devices = Memory::GetAddress<input_device**>(0x479F00);
     g_main_controller_index = Memory::GetAddress<uint32*>(0x47A714);
 
     PatchCall(Memory::GetAddress(0x2FBDA), input_xinput_update_rumble_state);

--- a/xlive/Blam/Engine/input/input_xinput.h
+++ b/xlive/Blam/Engine/input/input_xinput.h
@@ -3,13 +3,18 @@
 
 class xinput_device : public input_device
 {
+protected:
+	uint32 dwUserIndex;
+	uint32 error_level;
+	XINPUT_STATE xinput_state;
 public:
-	virtual void nullsub_0(void) { return; };
-	virtual void nullsub_1(void) { return; };
-	virtual void update_state_error_checking(void) override;
-	virtual uint32 get_state(XINPUT_STATE* state) override;
-	virtual void set_state(XINPUT_VIBRATION* state) override;
-	virtual void update_state(void) override;
+	virtual void XInputOpen(void) { return; };
+	virtual void XInputClose(void) { return; };
+	virtual void XUpdateState(void) override;
+	virtual uint32 XGetState(XINPUT_STATE* state) override;
+	virtual void XSetState(XINPUT_VIBRATION* state) override;
+	virtual void XUpdateImmediate(void) override;
 };
+CHECK_STRUCT_SIZE(xinput_device, 0x1C);
 
 void xinput_apply_patches(void);

--- a/xlive/Blam/Engine/input/input_xinput.h
+++ b/xlive/Blam/Engine/input/input_xinput.h
@@ -17,4 +17,6 @@ public:
 };
 CHECK_STRUCT_SIZE(xinput_device, 0x1C);
 
+bool input_xinput_update_gamepad(uint32 gamepad_index, uint32 duration_ms, struct s_gamepad_input_button_state* gamepad_state);
+
 void xinput_apply_patches(void);

--- a/xlive/Blam/Engine/math/math.h
+++ b/xlive/Blam/Engine/math/math.h
@@ -14,6 +14,10 @@
 // Ensure a value stays within a certain range
 #define PIN(v, v_min, v_max) MAX(v_min, MIN(v, v_max))
 
+#define CLAMP_LOWER(x, low, high) ((x) >= (high) - (low) ? (x) - (high) : (low))
+
+#define CLAMP_UPPER(x, low, high) ((x) <= (high) - (low) ? (x) + (low) : (high))
+
 // decimal part <0.5, floor
 // decimal part >0.5, ceil
 // TODO rework


### PR DESCRIPTION
# Includes
* Adds `input_globals` and `input_abstraction_globals`
* Fixes some of the hired-gun patches that tied all inputs to `input_globals.gamepad_state[0]`
* User interfaces like pregame lobby can now detect multiple controller inputs successfully

# Todo List
* Completely breaks Imgui AdvancedSetting ControllerInput.cpp hacky patches that will crash you anytime
* `input_abstraction_update()` needs to be redone to fix all other issues
* Certain UIs like main_menu dont like multiple local users