### PR TITLE
rewrite render functions to fix splitscreen viewports

### DIFF
--- a/xlive/Blam/Engine/bink/wmv_playback.cpp
+++ b/xlive/Blam/Engine/bink/wmv_playback.cpp
@@ -5,3 +5,9 @@ bool __cdecl media_foundation_player_running(void)
 {
 	return INVOKE(0x39F09, 0x0, media_foundation_player_running);
 }
+
+void __cdecl media_foundation_player_frame(void)
+{
+	INVOKE(0x3A264, 0x0, media_foundation_player_frame);
+	return;
+}

--- a/xlive/Blam/Engine/bink/wmv_playback.h
+++ b/xlive/Blam/Engine/bink/wmv_playback.h
@@ -1,3 +1,5 @@
 #pragma once
 
 bool __cdecl media_foundation_player_running(void);
+
+void __cdecl media_foundation_player_frame(void);

--- a/xlive/Blam/Engine/cache/pc_geometry_cache.cpp
+++ b/xlive/Blam/Engine/cache/pc_geometry_cache.cpp
@@ -1,0 +1,8 @@
+#include "stdafx.h"
+#include "pc_geometry_cache.h"
+
+void __cdecl pc_geometry_cache_block_count_clear(void)
+{
+	INVOKE(0x264F31, 0x0, pc_geometry_cache_block_count_clear);
+	return;
+}

--- a/xlive/Blam/Engine/cache/pc_geometry_cache.h
+++ b/xlive/Blam/Engine/cache/pc_geometry_cache.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void __cdecl pc_geometry_cache_block_count_clear(void);

--- a/xlive/Blam/Engine/camera/camera.h
+++ b/xlive/Blam/Engine/camera/camera.h
@@ -1,7 +1,5 @@
 #pragma once
 
-
-
 struct s_camera
 {
 	real_point3d point;

--- a/xlive/Blam/Engine/cutscene/cinematics.cpp
+++ b/xlive/Blam/Engine/cutscene/cinematics.cpp
@@ -55,7 +55,13 @@ bool cinematic_in_progress(void)
 	return result;
 }
 
-void cinematics_apply_patches()
+void cinematics_draw_line(rectangle2d* points, pixel32 rect_color)
+{
+	INVOKE(0x3B101, 0x0, cinematics_draw_line, points, rect_color);
+	return;
+}
+
+void cinematics_apply_patches(void)
 {
 	// allow cinematics to run at 60 fps
 	// Don't run these since interpolation does not currently work in cutscenes

--- a/xlive/Blam/Engine/cutscene/cinematics.h
+++ b/xlive/Blam/Engine/cutscene/cinematics.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "math/color_math.h"
 #include "tag_files/string_id.h"
 
 struct s_cinematic_globals_flags
@@ -43,4 +44,6 @@ bool cinematic_is_running(void);
 
 bool cinematic_in_progress(void);
 
-void cinematics_apply_patches();
+void cinematics_draw_line(rectangle2d* points, pixel32 rect_color);
+
+void cinematics_apply_patches(void);

--- a/xlive/Blam/Engine/effects/beam.cpp
+++ b/xlive/Blam/Engine/effects/beam.cpp
@@ -1,0 +1,8 @@
+#include "stdafx.h"
+#include "beam.h"
+
+void __cdecl render_beam(void)
+{
+	INVOKE(0xFEB7E, 0x0, render_beam);
+	return;
+}

--- a/xlive/Blam/Engine/effects/beam.h
+++ b/xlive/Blam/Engine/effects/beam.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void __cdecl render_beam(void);

--- a/xlive/Blam/Engine/effects/player_effects.cpp
+++ b/xlive/Blam/Engine/effects/player_effects.cpp
@@ -177,3 +177,9 @@ real32 player_effect_transition_function_evaluate(e_transition_function_type fun
     real32 function_value = 1.0f - (elapsed_time / duration);
     return transition_function_evaluate(function_type, function_value) * scale;
 }
+
+void __cdecl render_screen_flash(int32 player_index, s_screen_flash* screen_flash)
+{
+    INVOKE(0xA408F, 0x0, render_screen_flash, player_index, screen_flash);
+    return;
+}

--- a/xlive/Blam/Engine/effects/player_effects.h
+++ b/xlive/Blam/Engine/effects/player_effects.h
@@ -137,4 +137,14 @@ struct s_player_effect_globals
 };
 ASSERT_STRUCT_SIZE(s_player_effect_globals, 688);
 
+struct s_screen_flash
+{
+	int32 field_0;
+	real32 intensity;
+	real_argb_color color;
+};
+
 void player_effect_apply_camera_effect_matrix(int32 user_index, real_matrix4x3* matrix);
+
+// Render screen flash
+void __cdecl render_screen_flash(int32 player_index, s_screen_flash* screen_flash);

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -914,7 +914,7 @@ void __cdecl first_person_weapon_get_worldspace_node_matrix_interpolated(int32 u
 
 	s_first_person_weapon* first_person_data = first_person_weapons_get(user_index);
     int32 weapon_slot = first_person_weapon_slot_by_weapon_datum_index(user_index, weapon_index);
-	s_first_person_weapon_data* weapon_data = first_person_weapon_data_get(user_index, first_person_data);
+	s_first_person_weapon_data* weapon_data = first_person_weapon_data_get(weapon_slot, first_person_data);
 	if (TEST_BIT(weapon_data->flags, 0)
 		&& weapon_data->weapon_index != NONE)
 	{
@@ -932,7 +932,7 @@ real_matrix4x3* first_person_weapon_get_relative_node_matrix_interpolated(int32 
     real_matrix4x3* result = NULL;
     s_first_person_weapon* first_person_data = first_person_weapons_get(user_index);
     int32 weapon_slot = first_person_weapon_slot_by_weapon_datum_index(user_index, weapon_index);
-    s_first_person_weapon_data* weapon_data = first_person_weapon_data_get(user_index, first_person_data);
+    s_first_person_weapon_data* weapon_data = first_person_weapon_data_get(weapon_slot, first_person_data);
     if (TEST_BIT(weapon_data->flags, 0)
         && weapon_data->weapon_index != NONE)
     {

--- a/xlive/Blam/Engine/interface/hud.cpp
+++ b/xlive/Blam/Engine/interface/hud.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "hud.h"
-#include "new_hud_definitions.h"
 
+#include "new_hud_definitions.h"
 
 #include "game/game_globals.h"
 
@@ -60,6 +60,12 @@ void set_crosshair_offset(float offset)
 	{
 		scenario_get_game_globals()->player_control[0]->crosshair_location.y = offset;
 	}
+}
+
+void __cdecl draw_hud(void)
+{
+	INVOKE(0x2278AA, 0x0, draw_hud);
+	return;
 }
 
 void hud_patches_on_map_load()

--- a/xlive/Blam/Engine/interface/hud.h
+++ b/xlive/Blam/Engine/interface/hud.h
@@ -12,5 +12,8 @@ float* get_ui_scale();
 float* get_primary_hud_scale();
 float* get_secondary_hud_scale();
 void set_crosshair_offset(float offset);
+
+void __cdecl draw_hud(void);
+
 void hud_patches_on_map_load();
 void hud_apply_pre_winmain_patches();

--- a/xlive/Blam/Engine/interface/interface.cpp
+++ b/xlive/Blam/Engine/interface/interface.cpp
@@ -1,0 +1,84 @@
+#include "stdafx.h"
+#include "interface.h"
+
+#include "cutscene/cinematics.h"
+
+#define k_splitscreen_line_colour D3DCOLOR_ARGB(255, 0, 0, 0);
+int get_player_window_count()
+{
+	return *Memory::GetAddress<int*>(0x4E6974);
+}
+
+e_split_type get_splitscreen_split_type()
+{
+	return *Memory::GetAddress<e_split_type*>(0x4E6970);
+}
+
+
+void set_display_type(e_display_type display_type)
+{
+	WriteValue<e_display_type>(Memory::GetAddress(0xA3E460), display_type);
+}
+
+// Renders the lines inbetween windows in splitscreen
+// Updated function so it works when the resolution isnt 640x480
+void render_splitscreen_line(void)
+{
+	int32 player_window_count = get_player_window_count();
+
+	ASSERT(IN_RANGE_INCLUSIVE(player_window_count, 1, 4));
+
+	int g_resolution_x = *Memory::GetAddress<int*>(0xA3E408);
+	int g_resolution_y = *Memory::GetAddress<int*>(0xA3E40C);
+
+	const int32 line_width = g_resolution_y / 480;
+	
+	rectangle2d line;
+	pixel32 color;
+	color.color = k_splitscreen_line_colour;
+	if (player_window_count > 1)
+	{
+		if (get_splitscreen_split_type() == _split_type_vertical)
+		{
+			line.top = (g_resolution_y / 2) - line_width;
+			line.left = 0;
+			line.bottom = (g_resolution_y / 2) + line_width;
+			line.right = g_resolution_x;
+			cinematics_draw_line(&line, color);
+
+			// Draw horizontal line between players
+			if (player_window_count > 2)
+			{
+				line.left = (g_resolution_x / 2) - line_width;
+				line.bottom = g_resolution_y;
+				line.right = (g_resolution_x / 2) + line_width;
+				line.top = (player_window_count == 3 ? g_resolution_y / 2 : 0);
+			}
+		}
+		else
+		{
+			line.top = 0;
+			line.left = (g_resolution_x / 2) - line_width;
+			line.bottom = g_resolution_y;
+			line.right = (g_resolution_x / 2) + line_width;
+			cinematics_draw_line(&line, color);
+
+			// Draw vertical line between players
+			if (player_window_count > 2)
+			{
+				line.top = (g_resolution_y / 2) - line_width;
+				line.bottom = (g_resolution_y / 2) + line_width;
+				line.right = g_resolution_x;
+				line.left = (player_window_count == 3 ? g_resolution_x / 2 : 0);
+			}
+		}
+		cinematics_draw_line(&line, color);
+	}
+	return;
+}
+
+void apply_interface_hooks(void)
+{
+	PatchCall(Memory::GetAddress(0x227A17), render_splitscreen_line);
+	return;
+}

--- a/xlive/Blam/Engine/interface/interface.h
+++ b/xlive/Blam/Engine/interface/interface.h
@@ -1,0 +1,15 @@
+#pragma once
+
+enum e_split_type : int32
+{
+	_split_type_horizontal = 0,
+	_split_type_vertical = 1
+};
+
+enum e_display_type : int32
+{
+	_display_type_widescreen = 0,
+	_display_type_4_by_3 = 1
+};
+
+void apply_interface_hooks(void);

--- a/xlive/Blam/Engine/interface/user_interface.cpp
+++ b/xlive/Blam/Engine/interface/user_interface.cpp
@@ -5,3 +5,17 @@ float* get_ui_scale_factor()
 {
 	return Memory::GetAddress<float*>(0xA3E424);
 }
+
+void render_menu_user_interface_to_usercall(int32 window_index, int32 controller_index, int32 player_count, rectangle2d* rect2d)
+{
+	static void* render_menu_user_interface = (void*)Memory::GetAddress(0x20B697);
+	__asm {
+		push rect2d
+		push player_count
+		push controller_index
+		mov esi, window_index
+		call render_menu_user_interface
+		add esp, 12
+	}
+	return;
+}

--- a/xlive/Blam/Engine/interface/user_interface.h
+++ b/xlive/Blam/Engine/interface/user_interface.h
@@ -1,3 +1,3 @@
 #pragma once
 
-void render_menu_user_interface_to_usercall(int32 controller_index, int32 window_index, int32 player_count, rectangle2d* rect2d);
+void render_menu_user_interface_to_usercall(int32 window_index, int32 controller_index, int32 player_count, rectangle2d* rect2d);

--- a/xlive/Blam/Engine/interface/user_interface.h
+++ b/xlive/Blam/Engine/interface/user_interface.h
@@ -1,1 +1,3 @@
 #pragma once
+
+void render_menu_user_interface_to_usercall(int32 controller_index, int32 window_index, int32 player_count, rectangle2d* rect2d);

--- a/xlive/Blam/Engine/main/main_screenshot.cpp
+++ b/xlive/Blam/Engine/main/main_screenshot.cpp
@@ -1,10 +1,13 @@
 #include "stdafx.h"
 #include "main_screenshot.h"
 
-s_screenshot_globals* get_screenshot_globals()
+s_screenshot_globals* get_screenshot_globals(void)
 {
-	if (Memory::IsDedicatedServer()) 
-		return nullptr;
-
+	ASSERT(!Memory::IsDedicatedServer());
 	return Memory::GetAddress<s_screenshot_globals*>(0xA55630);
+}
+
+bool screenshot_in_progress(void)
+{
+	return get_screenshot_globals()->taking_screenshot;
 }

--- a/xlive/Blam/Engine/main/main_screenshot.h
+++ b/xlive/Blam/Engine/main/main_screenshot.h
@@ -19,4 +19,6 @@ struct s_screenshot_globals
 };
 ASSERT_STRUCT_SIZE(s_screenshot_globals, 276);
 
-s_screenshot_globals* get_screenshot_globals();
+s_screenshot_globals* get_screenshot_globals(void);
+
+bool screenshot_in_progress(void);

--- a/xlive/Blam/Engine/math/color_math.h
+++ b/xlive/Blam/Engine/math/color_math.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 struct pixel32
 {
 	D3DCOLOR color;

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
@@ -122,7 +122,7 @@ void rasterizer_present(bitmap_data* screenshot_bitmap)
             {
                 result = false;
             }
-            rasterizer_set_render_target(global_d3d_surface_render_primary_get(), (IDirect3DSurface9*)NONE, true);
+            rasterizer_dx9_set_render_target(global_d3d_surface_render_primary_get(), NONE, true);
             clear_render_target(0, NONE, 0.0f, false);
         }
 
@@ -157,9 +157,9 @@ void __cdecl sub_65F600(int16 stage, datum bitmap_tag_index, int16 bitmap_data_i
     return;
 }
 
-bool __cdecl rasterizer_set_render_target(IDirect3DSurface9* target, IDirect3DSurface9* z_stencil, bool a3)
+bool __cdecl rasterizer_dx9_set_render_target(IDirect3DSurface9* target, int32 z_stencil, bool a3)
 {
-    return INVOKE(0x26EBF8, 0x0, rasterizer_set_render_target, target, z_stencil, a3);
+    return INVOKE(0x26EBF8, 0x0, rasterizer_dx9_set_render_target, target, z_stencil, a3);
 }
 
 void __cdecl clear_render_target(uint32 flags, D3DCOLOR color, real32 z, bool stencil)
@@ -191,4 +191,24 @@ void __cdecl rasterizer_cache_bitmaps(void)
 {
     INVOKE(0x261720, 0x0, rasterizer_cache_bitmaps);
     return;
+}
+
+bool __cdecl rasterizer_window_begin(s_frame* preferences)
+{
+    return INVOKE(0x2620CF, 0x0, rasterizer_window_begin, preferences);
+}
+
+void __cdecl rasterizer_update_cameras(void)
+{
+    return INVOKE(0x26268D, 0x0, rasterizer_update_cameras);
+}
+
+void __cdecl rasterizer_dx9_set_stencil_mode(int16 mode)
+{
+    return INVOKE(0x2603D2, 0x0, rasterizer_dx9_set_stencil_mode, mode);
+}
+
+void __cdecl rasterizer_dx9_set_render_state(D3DRENDERSTATETYPE render_state, D3DBLEND blend)
+{
+    return INVOKE(0x26F8E2, 0x0, rasterizer_dx9_set_render_state, render_state, blend);
 }

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
@@ -12,7 +12,6 @@ typedef void(__cdecl* sub_65F600_t)(int16, datum, int16, real32);
 sub_65F600_t p_sub_65F600;
 
 void __cdecl sub_65F600(int16 stage, datum bitmap_tag_index, int16 bitmap_data_index, real32 a4);
-bool __cdecl rasterizer_set_render_target(IDirect3DSurface9* target, IDirect3DSurface9* z_stencil, bool a3);
 void __cdecl clear_render_target(uint32 flags, D3DCOLOR color, real32 z, bool stencil);
 void __cdecl rasterizer_set_stream_source(void);
 void __cdecl debug_frame_usage_draw(void);
@@ -34,7 +33,7 @@ bool* rasterizer_clear_screen_global_get(void)
     return Memory::GetAddress<bool*>(0xA3E4D5);
 }
 
-rectangle2d* rasterizer_globals_screen_bounds_get(void)
+rectangle2d* rasterizer_draw_on_main_back_buffer_get(void)
 {
     return Memory::GetAddress<rectangle2d*>(0xA3E410);
 }
@@ -84,7 +83,7 @@ void rasterizer_present(bitmap_data* screenshot_bitmap)
         *g_clear_screen = false;
         if (screenshot_bitmap && screenshot_bitmap->base_address)
         {
-            const rectangle2d* screen_bounds = rasterizer_globals_screen_bounds_get();
+            const rectangle2d* screen_bounds = rasterizer_draw_on_main_back_buffer_get();
             int16 right = screen_bounds->right;
             if (screen_bounds->right > screen_bounds->left + screenshot_bitmap->width_pixels)
             {
@@ -135,7 +134,7 @@ void rasterizer_present(bitmap_data* screenshot_bitmap)
             debug_frame_usage_draw();
             rasterizer_present_backbuffer();
 #endif
-            ++ * frame_presented_count_get();
+            ++*frame_presented_count_get();
             // nullsub_69();
             if (!loading_screen_in_progress())
             {

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.h
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.h
@@ -1,11 +1,18 @@
 #pragma once
 #include "bitmaps/bitmap_group.h"
+#include "render/render.h"
+
+bool* rasterizer_clear_screen_global_get(void);
 
 static D3DFORMAT g_supported_depth_stencil_formats[] = { D3DFMT_D24S8, D3DFMT_D24X4S4 };
 
 datum last_bitmap_tag_index_get(void);
 
 IDirect3D9* rasterizer_dx9_get_interface(void);
+
+IDirect3DSurface9* global_d3d_surface_screenshot_get(void);
+
+bool __cdecl rasterizer_dx9_set_render_target(IDirect3DSurface9* target, int32 z_stencil, bool a3);
 
 IDirect3DDevice9Ex* rasterizer_dx9_device_get_interface(void);
 
@@ -14,3 +21,11 @@ void rasterizer_dx9_main_apply_patches(void);
 bool __cdecl rasterizer_initialize(void);
 
 void __cdecl rasterizer_present(bitmap_data* screenshot_bitmap);
+
+bool __cdecl rasterizer_window_begin(s_frame* preferences);
+
+void __cdecl rasterizer_update_cameras(void);
+
+void __cdecl rasterizer_dx9_set_stencil_mode(int16 mode);
+
+void __cdecl rasterizer_dx9_set_render_state(D3DRENDERSTATETYPE render_state, D3DBLEND blend);

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_screen_effect.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_screen_effect.cpp
@@ -1,0 +1,8 @@
+#include "stdafx.h"
+#include "rasterizer_dx9_screen_effect.h"
+
+void __cdecl rasterizer_dx9_render_screen_effect(void)
+{
+	INVOKE(0x27C86D, 0x0, rasterizer_dx9_render_screen_effect);
+	return;
+}

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_screen_effect.h
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_screen_effect.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void __cdecl rasterizer_dx9_render_screen_effect(void);

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.cpp
@@ -1,0 +1,8 @@
+#include "stdafx.h"
+#include "rasterizer_dx9_shader_submit_new.h"
+
+void __cdecl rasterizer_shader_level_of_detail_bias_update(void)
+{
+	INVOKE(0x266525, 0x0, rasterizer_shader_level_of_detail_bias_update);
+	return;
+}

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.h
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void __cdecl rasterizer_shader_level_of_detail_bias_update(void);

--- a/xlive/Blam/Engine/rasterizer/rasterizer_settings.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_settings.cpp
@@ -11,6 +11,12 @@ void __cdecl rasterizer_discard_refresh_rate();
 
 s_display_option g_display_options[k_max_display_option_count] = {};
 
+
+bool* get_render_fog_enabled(void)
+{
+	return Memory::GetAddress<bool*>(0x41F6AA, 0x3C2B7E);
+}
+
 typedef void(__cdecl* update_screen_settings_t)(int, int, short, short, short, short, float, float);
 update_screen_settings_t p_update_screen_settings;
 

--- a/xlive/Blam/Engine/rasterizer/rasterizer_settings.h
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_settings.h
@@ -51,4 +51,6 @@ struct s_video_settings
 };
 static_assert(sizeof(s_video_settings) == 48, "s_video_settings total bytes wrong");
 
+bool* get_render_fog_enabled(void);
+
 void rasterizer_settings_apply_hooks();

--- a/xlive/Blam/Engine/render/render.cpp
+++ b/xlive/Blam/Engine/render/render.cpp
@@ -1,7 +1,317 @@
 #include "stdafx.h"
 #include "render.h"
 
+#include "render_first_person.h"
+#include "render_lights.h"
+#include "render_sky.h"
+#include "render_visibility_collection.h"
+
+#include "bink/wmv_playback.h"
+#include "cache/pc_geometry_cache.h"
+#include "effects/beam.h"
+#include "effects/player_effects.h"
+#include "game/players.h"
+#include "interface/hud.h"
+#include "interface/user_interface.h"
+#include "main/main_screenshot.h"
+#include "math/color_math.h"
+#include "rasterizer/dx9/rasterizer_dx9_main.h"
+#include "rasterizer/dx9/rasterizer_dx9_screen_effect.h"
+#include "rasterizer/dx9/rasterizer_dx9_shader_submit_new.h"
+#include "rasterizer/rasterizer_settings.h"
+#include "scenario/scenario_fog.h"
+#include "structures/structures.h"
+
+
+void render_apply_patches(void)
+{
+    PatchCall(Memory::GetAddress(0x19224A), render_window);
+    PatchCall(Memory::GetAddress(0x19DA7C), render_window);
+    return;
+}
+
 real64 get_current_render_time(void)
 {
-	return *Memory::GetAddress<real64*>(0x4E6968);
+    return *Memory::GetAddress<real64*>(0x4E6968);
+}
+
+int32* get_global_window_bound_index(void)
+{
+    return Memory::GetAddress<int32*>(0x4E6978, 0x50EC48);
+}
+
+int32* get_global_window_out_cluster_index(int32 index)
+{
+    return &Memory::GetAddress<int32*>(0x4E697C, 0x50EC4C)[index];
+}
+
+int32* get_global_window_out_leaf_index(int32 index)
+{
+    return &Memory::GetAddress<int32*>(0x4E698C, 0x50EC5C)[index];
+}
+
+uint32* global_frame_num_get(void)
+{
+    return Memory::GetAddress<uint32*>(0x4E6960);
+}
+
+int32* curent_window_bound_index_get(void)
+{
+    return Memory::GetAddress<int32*>(0x4E67FC);
+}
+
+int32* global_cluster_index_get(void)
+{
+    return Memory::GetAddress<int32*>(0x4E680C);
+}
+
+int32* global_user_render_index_get(void)
+{
+    return Memory::GetAddress<int32*>(0x4E6800);
+}
+
+int32* global_leaf_index_get(void)
+{
+    return Memory::GetAddress<int32*>(0x4E6808);
+}
+
+bool* global_bsp_test_failed_get(void)
+{
+    return Memory::GetAddress<bool*>(0x4E6810);
+}
+
+bool* global_sky_active_get(void)
+{
+    return Memory::GetAddress<bool*>(0x4E6811);
+}
+
+int32* global_sky_index_get(void)
+{
+    return Memory::GetAddress<int32*>(0x4E6814);
+}
+
+s_scenario_fog_result* global_fog_result_get(void)
+{
+    return Memory::GetAddress<s_scenario_fog_result*>(0x4E6818);
+}
+
+bool* global_byte_4E6938_get(void)
+{
+    return Memory::GetAddress<bool*>(0x4E6938);
+}
+
+bool __cdecl structure_get_cluster_and_leaf_from_render_point(real_point3d* point, int32* out_cluster_index, int32* out_leaf_index)
+{   
+    return INVOKE(0x191032, 0x0, structure_get_cluster_and_leaf_from_render_point, point, out_cluster_index, out_leaf_index);
+}
+
+void __cdecl render_scene_wrapper(bool is_texture_camera) 
+{
+    INVOKE(0x25F015, 0x0, render_scene_wrapper, is_texture_camera);
+    return;
+}
+
+void render_view(
+    real_rectangle2d* frustum_bounds,
+    s_camera* rasterizer_camera,
+    int32 window_bound_index,
+    s_camera* render_camera,
+    bool is_texture_camera,
+    int32 cluster_index,
+    int32 leaf_index,
+    bool bsp_test_failed,
+    int16 render_type,
+    int32 user_index,
+    int32 controller_index,
+    bool sky_active,
+    int32 sky_id,
+    s_scenario_fog_result* fog,
+    int8 zero_1,
+    int16 neg_one,
+    void* window_bound_unk_data,
+    int8 zero_2,
+    s_screen_flash* screen_flash) 
+{
+    ASSERT(render_camera);
+    s_camera* camera = (rasterizer_camera ? rasterizer_camera : render_camera);
+    ++*global_frame_num_get();
+
+    ASSERT(fog);
+    *curent_window_bound_index_get() = window_bound_index;
+    *global_cluster_index_get() = cluster_index;
+    *global_leaf_index_get() = leaf_index;
+    *global_bsp_test_failed_get() = bsp_test_failed;
+    *global_user_render_index_get() = user_index;
+    *global_sky_active_get() = sky_active;
+    *global_sky_index_get() = sky_id;
+
+    *global_fog_result_get() = *fog;
+    *global_byte_4E6938_get() = 0;
+    
+    s_camera* global_camera = get_global_camera();
+    *global_camera = *render_camera;
+
+    render_camera_build_projection(global_camera, frustum_bounds, global_projection_get());
+    render_first_person();
+    render_sky_model();
+    render_lights();
+
+    s_frame frame = {};
+    frame.camera = *camera;
+    render_camera_build_projection(&frame.camera, frustum_bounds, &frame.projection);
+
+    frame.render_type = render_type;
+    frame.field_6 = zero_1;
+    frame.window_bound_index = window_bound_index;
+    frame.is_texture_camera = is_texture_camera;
+    frame.field_4 = neg_one;
+    frame.color = fog->color;
+    frame.alpha = 2;
+    frame.fog_result = *fog;
+    frame.screen_flash = *screen_flash;
+    frame.field_290 = window_bound_unk_data;
+    frame.field_294_zero = zero_2;
+
+    bool result = rasterizer_window_begin(&frame);
+    rasterizer_shader_level_of_detail_bias_update();
+    if (result)
+    {
+        if (media_foundation_player_running())
+        {
+            media_foundation_player_frame();
+        }
+        else
+        {
+            pc_geometry_cache_block_count_clear();
+            render_beam();
+            render_light_clear_data();
+            render_scene_visibility_to_usercall(user_index);
+            render_scene_wrapper(is_texture_camera);
+
+            IDirect3DDevice9Ex* global_d3d_device = rasterizer_dx9_device_get_interface();
+            IDirect3DSurface9* surface = NULL;
+            IDirect3DSurface9* global_d3d_surface_screenshot = global_d3d_surface_screenshot_get();
+            if (screenshot_in_progress())
+            {
+                surface = global_d3d_surface_screenshot;
+                global_d3d_surface_screenshot->AddRef();
+            }
+            else
+            {
+                global_d3d_device->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &surface);
+            }
+
+            rasterizer_dx9_set_render_target(surface, NONE, 1);
+            if (surface)
+            {
+                surface->Release();
+                surface = NULL;
+            }
+
+            rasterizer_dx9_set_stencil_mode(0);
+            draw_hud();
+            rasterizer_dx9_render_screen_effect();
+
+            if (screenshot_in_progress())
+            {
+                surface = global_d3d_surface_screenshot;
+                global_d3d_surface_screenshot->AddRef();
+            }
+            else
+            {
+                global_d3d_device->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &surface);
+            }
+
+            rasterizer_dx9_set_render_target(surface, NONE, 1);
+            if (surface)
+            {
+                surface->Release();
+                surface = NULL;
+            }
+            render_menu_user_interface_to_usercall(0, controller_index, NONE, &camera->viewport_bounds);
+            rasterizer_dx9_set_render_state(D3DRS_ZFUNC, D3DBLEND_INVSRCCOLOR);
+        }
+    }
+
+    rasterizer_update_cameras();
+    return;
+}
+
+void __cdecl render_window(window_bound* window, bool is_texture_camera)
+{
+    s_screen_flash screen_flash;
+    screen_flash.color = *global_real_argb_black;
+    *get_global_window_bound_index() = window->window_bound_index;
+    int32 cluster_index = *get_global_window_out_cluster_index(window->window_bound_index);
+    int32 leaf_index = *get_global_window_out_leaf_index(window->window_bound_index);
+    screen_flash.intensity = 0.0f;
+    screen_flash.field_0 = 0;
+    bool bsp_test_success = structure_get_cluster_and_leaf_from_render_point(&window->render_camera.point, &cluster_index, &leaf_index);
+
+    if (bsp_test_success)
+    {
+        *get_global_window_out_cluster_index(window->window_bound_index) = cluster_index;
+        *get_global_window_out_leaf_index(window->window_bound_index) = leaf_index;
+    }
+
+    int32 visible_sky_index;
+    real_rgb_color clear_color = *global_real_rgb_white;
+    bool clear_color_active = false;
+    bool sky_bool = structure_get_sky(cluster_index, &visible_sky_index, &clear_color, &clear_color_active);
+
+    s_scenario_fog_result fog;
+    render_scenario_fog(cluster_index, &window->render_camera, &window->render_camera.forward, sky_bool, *get_render_fog_enabled(), &fog);
+    if (clear_color_active)
+    {
+        fog.color = clear_color;
+    }
+
+    if (fog.unk_bool_18 && window->render_camera.z_far > fog.z_far && fog.z_far > window->render_camera.z_near)
+    {
+        window->render_camera.z_far = fog.z_far;
+    }
+
+    real_rectangle2d frustum_bounds;
+    render_camera_build_viewport_frustum_bounds(&window->render_camera, &frustum_bounds);
+    
+    int32 controller_index = NONE;
+    if (window->user_index != NONE)
+    {
+        controller_index = s_player::get(player_index_from_user_index(window->user_index))->controller_index;
+        render_screen_flash(window->user_index, &screen_flash);
+    }
+
+    ASSERT(!memcmp(&window->render_camera.viewport_bounds, &window->rasterizer_camera.viewport_bounds, sizeof(rectangle2d)));
+    ASSERT(!memcmp(&window->render_camera.window_bounds, &window->rasterizer_camera.window_bounds, sizeof(rectangle2d)));
+
+    *rasterizer_clear_screen_global_get() = false;
+    if (window->render_camera.vertical_field_of_view > k_real_math_epsilon)
+    {
+        render_view(
+            &frustum_bounds,
+            &window->rasterizer_camera,
+            window->window_bound_index,
+            &window->render_camera,
+            is_texture_camera,
+            cluster_index,
+            leaf_index,
+            !bsp_test_success,
+            0,
+            window->user_index,
+            controller_index,
+            sky_bool,
+            visible_sky_index,
+            &fog,
+            0,
+            -1,
+            window->gap_f4,
+            0,
+            &screen_flash);
+    }
+    else
+    {
+        error(2, "Tried to render a view with a field of view of %f", window->render_camera.vertical_field_of_view);
+    }
+
+    return;
 }

--- a/xlive/Blam/Engine/render/render.h
+++ b/xlive/Blam/Engine/render/render.h
@@ -18,7 +18,7 @@ struct s_frame
 	s_camera camera;
 	render_projection projection;
 	s_scenario_fog_result fog_result;
-	bool field_14C;
+	bool render_fog;
 	int8 pad_26D[3];
 	s_screen_flash screen_flash;
 	int8 field_288[8];

--- a/xlive/Blam/Engine/render/render.h
+++ b/xlive/Blam/Engine/render/render.h
@@ -1,3 +1,53 @@
 #pragma once
+#include "render_cameras.h"
+
+#include "camera/camera.h"
+#include "effects/player_effects.h"
+#include "scenario/scenario_fog.h"
+
+struct s_frame
+{
+	int16 window_bound_index;
+	int16 render_type;
+	int16 field_4;
+	bool field_6;
+	bool is_texture_camera;
+	int16 alpha;
+	int16 pad;
+	real_rgb_color color;
+	s_camera camera;
+	render_projection projection;
+	s_scenario_fog_result fog_result;
+	bool field_14C;
+	int8 pad_26D[3];
+	s_screen_flash screen_flash;
+	int8 field_288[8];
+	void* field_290;
+	bool field_294_zero;
+	int8 pad_295[3];
+};
+ASSERT_STRUCT_SIZE(s_frame, 664);
+
+
+struct window_bound
+{
+	int32 single_view;
+	int32 window_bound_index;
+	int32 user_index;
+	s_camera render_camera;
+	s_camera rasterizer_camera;
+	int8 gap_f4[36];
+};
+ASSERT_STRUCT_SIZE(window_bound, 280);
+
+void render_apply_patches(void);
 
 real64 get_current_render_time(void);
+
+// CLIENT ONLY
+// Get cluster index and leaf index from render position provided
+// Return true if out_cluster_index and out_leaf_index are valid
+bool __cdecl structure_get_cluster_and_leaf_from_render_point(real_point3d* point, int32* out_cluster_index, int32* out_leaf_index);
+
+// Render window
+void __cdecl render_window(window_bound* window, bool is_texture_camera);

--- a/xlive/Blam/Engine/render/render_cameras.cpp
+++ b/xlive/Blam/Engine/render/render_cameras.cpp
@@ -3,28 +3,43 @@
 
 #include "H2MOD/Modules/Shell/Config.h"
 
+void __cdecl render_camera_build_projection_static(s_camera* camera, real_rectangle2d* frustum_bounds, render_projection* out_projection);
 
-typedef void(__cdecl render_camera_build_projection_t)(s_camera*, float*, real_matrix4x3*);
-render_camera_build_projection_t* p_render_camera_build_projection;
-
-void __cdecl render_camera_build_projection_hook(s_camera* camera, float* frustum_bounds, real_matrix4x3* out_projection)
+void render_cameras_apply_patches(void)
 {
-	p_render_camera_build_projection = Memory::GetAddress<render_camera_build_projection_t*>(0x1953f5);
+	PatchCall(Memory::GetAddress(0x191440), render_camera_build_projection_static);
+	return;
+}
 
-	float old_camera_field_of_view = camera->vertical_field_of_view;
+render_projection* global_projection_get(void)
+{
+	return Memory::GetAddress<render_projection*>(0x4E673C);
+}
+
+void __cdecl render_camera_build_projection(s_camera* camera,
+	real_rectangle2d* frustum_bounds,
+	render_projection* projection)
+{
+	INVOKE(0x1953f5, 0x0, render_camera_build_projection, camera, frustum_bounds, projection);
+	return;
+}
+
+void __cdecl render_camera_build_projection_static(s_camera* camera, real_rectangle2d* frustum_bounds, render_projection* out_projection)
+{
+	real32 old_camera_field_of_view = camera->vertical_field_of_view;
 	
 	if (H2Config_static_first_person) 
 	{
 		camera->vertical_field_of_view = DEGREES_TO_RADIANS(64.f) * 0.78500003f;
 	}
 	
-	p_render_camera_build_projection(camera, frustum_bounds, out_projection);
-	
+	render_camera_build_projection(camera, frustum_bounds, out_projection);
 	camera->vertical_field_of_view = old_camera_field_of_view;
+	return;
 }
 
-
-void render_cameras_apply_patches()
+void __cdecl render_camera_build_viewport_frustum_bounds(const s_camera* camera, real_rectangle2d* frustum_bounds)
 {
-	PatchCall(Memory::GetAddress(0x191440), render_camera_build_projection_hook);
+	INVOKE(0x194FBD, 0x180EB6, render_camera_build_viewport_frustum_bounds, camera, frustum_bounds);
+	return;
 }

--- a/xlive/Blam/Engine/render/render_cameras.h
+++ b/xlive/Blam/Engine/render/render_cameras.h
@@ -2,5 +2,29 @@
 #include "camera/camera.h"
 #include "math/matrix_math.h"
 
-void __cdecl render_camera_build_projection_hook(s_camera* camera, float* frustum_bounds, real_matrix4x3* out_projection);
-void render_cameras_apply_patches();
+struct s_oriented_bounding_box
+{
+	real32 matrix[4][4];
+};
+ASSERT_STRUCT_SIZE(s_oriented_bounding_box, 64);
+
+struct render_projection
+{
+	real_matrix4x3 world_to_view;
+	real_matrix4x3 view_to_world;
+	real_rectangle2d projection_bounds;
+	s_oriented_bounding_box projection_matrix;
+	real_vector2d unknownB8;
+};
+ASSERT_STRUCT_SIZE(render_projection, 192);
+
+void render_cameras_apply_patches(void);
+
+render_projection* global_projection_get(void);
+
+void __cdecl render_camera_build_projection(s_camera* camera,
+	real_rectangle2d* frustum_bounds,
+	render_projection* projection);
+
+// Builds frustum bounds from render camera
+void __cdecl render_camera_build_viewport_frustum_bounds(const s_camera* camera, real_rectangle2d* frustum_bounds);

--- a/xlive/Blam/Engine/render/render_first_person.cpp
+++ b/xlive/Blam/Engine/render/render_first_person.cpp
@@ -1,0 +1,9 @@
+#include "stdafx.h"
+#include "render_first_person.h"
+
+
+void __cdecl render_first_person(void)
+{
+	INVOKE(0x195E72, 0x0, render_first_person);
+	return;
+}

--- a/xlive/Blam/Engine/render/render_first_person.h
+++ b/xlive/Blam/Engine/render/render_first_person.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void __cdecl render_first_person(void);

--- a/xlive/Blam/Engine/render/render_lights.cpp
+++ b/xlive/Blam/Engine/render/render_lights.cpp
@@ -1,0 +1,14 @@
+#include "stdafx.h"
+#include "render_lights.h"
+
+void __cdecl render_lights(void)
+{
+	INVOKE(0x14CB17, 0x0, render_lights);
+	return;
+}
+
+void __cdecl render_light_clear_data(void)
+{
+	INVOKE(0x1A0F39, 0x0, render_light_clear_data);
+	return;
+}

--- a/xlive/Blam/Engine/render/render_lights.h
+++ b/xlive/Blam/Engine/render/render_lights.h
@@ -17,3 +17,8 @@ struct render_lighting
 	int16 pad;
 };
 ASSERT_STRUCT_SIZE(render_lighting, 84);
+
+
+void __cdecl render_lights(void);
+
+void __cdecl render_light_clear_data(void);

--- a/xlive/Blam/Engine/render/render_sky.cpp
+++ b/xlive/Blam/Engine/render/render_sky.cpp
@@ -1,7 +1,13 @@
 #include "stdafx.h"
 #include "render_sky.h"
 
-real32 __cdecl get_current_sky_render_model_scale()
+real32 __cdecl get_current_sky_render_model_scale(void)
 {
 	return INVOKE(0x19A139, 0x186E29, get_current_sky_render_model_scale);
+}
+
+void __cdecl render_sky_model(void)
+{
+	INVOKE(0x19A099, 0x0, get_current_sky_render_model_scale);
+	return;
 }

--- a/xlive/Blam/Engine/render/render_sky.h
+++ b/xlive/Blam/Engine/render/render_sky.h
@@ -1,3 +1,5 @@
 #pragma once
 
-real32 __cdecl get_current_sky_render_model_scale();
+real32 __cdecl get_current_sky_render_model_scale(void);
+
+void __cdecl render_sky_model(void);

--- a/xlive/Blam/Engine/render/render_visibility_collection.cpp
+++ b/xlive/Blam/Engine/render/render_visibility_collection.cpp
@@ -18,7 +18,7 @@ bool __cdecl render_visibility_check_location_cluster_active(s_location* locatio
 	return INVOKE(0x19447C, 0, render_visibility_check_location_cluster_active, location);
 }
 
-void render_scene_visibility_to_usercall(int32 user_index)
+void render_view_visibility_compute_to_usercall(int32 user_index)
 {
 	void* render_scene_visibility = (void*)Memory::GetAddress(0x190755);
 	__asm {

--- a/xlive/Blam/Engine/render/render_visibility_collection.cpp
+++ b/xlive/Blam/Engine/render/render_visibility_collection.cpp
@@ -18,3 +18,12 @@ bool __cdecl render_visibility_check_location_cluster_active(s_location* locatio
 	return INVOKE(0x19447C, 0, render_visibility_check_location_cluster_active, location);
 }
 
+void render_scene_visibility_to_usercall(int32 user_index)
+{
+	void* render_scene_visibility = (void*)Memory::GetAddress(0x190755);
+	__asm {
+		mov edi, user_index
+		call render_scene_visibility
+	}
+	return;
+}

--- a/xlive/Blam/Engine/render/render_visibility_collection.h
+++ b/xlive/Blam/Engine/render/render_visibility_collection.h
@@ -7,4 +7,4 @@ void __cdecl predicted_resources_precache(int32 cluster_index);
 
 bool __cdecl render_visibility_check_location_cluster_active(s_location* location);
 
-void render_scene_visibility_to_usercall(int32 user_index);
+void render_view_visibility_compute_to_usercall(int32 user_index);

--- a/xlive/Blam/Engine/render/render_visibility_collection.h
+++ b/xlive/Blam/Engine/render/render_visibility_collection.h
@@ -6,3 +6,5 @@ void __cdecl render_visibility_predict_resources_for_pvs(int32 cluster_index);
 void __cdecl predicted_resources_precache(int32 cluster_index);
 
 bool __cdecl render_visibility_check_location_cluster_active(s_location* location);
+
+void render_scene_visibility_to_usercall(int32 user_index);

--- a/xlive/Blam/Engine/scenario/scenario_fog.cpp
+++ b/xlive/Blam/Engine/scenario/scenario_fog.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "scenario_fog.h"
 
-bool __cdecl render_scenario_fog(int cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result)
+bool __cdecl render_scenario_fog(int32 cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result)
 {
     return INVOKE(0xBA3EA, 0x0, render_scenario_fog, cluster_index, camera_position, camera_forward, a4, render_fog, result);
 }

--- a/xlive/Blam/Engine/scenario/scenario_fog.cpp
+++ b/xlive/Blam/Engine/scenario/scenario_fog.cpp
@@ -1,0 +1,7 @@
+#include "stdafx.h"
+#include "scenario_fog.h"
+
+bool __cdecl render_scenario_fog(int cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result)
+{
+    return INVOKE(0xBA3EA, 0x0, render_scenario_fog, cluster_index, camera_position, camera_forward, a4, render_fog, result);
+}

--- a/xlive/Blam/Engine/scenario/scenario_fog.h
+++ b/xlive/Blam/Engine/scenario/scenario_fog.h
@@ -1,10 +1,9 @@
 #pragma once
+#include "camera/camera.h"
+#include "math/color_math.h"
+#include "tag_files/string_id.h"
 #include "tag_files/tag_block.h"
 #include "tag_files/tag_reference.h"
-
-#include "math/color_math.h"
-
-#include "tag_files/string_id.h"
 
 #define MAXIMUM_ATMOSPHERIC_FOG_PALETTE_ENTRIES_PER_SCENARIO 127
 #define k_maximum_mixers_per_scenario_atmospheric_fog_palette_entry 2
@@ -18,6 +17,20 @@ enum e_camera_immersion_flags : short
     camera_immersion_flag_invert_planar_fog_priorities = FLAG(3),
     camera_immersion_flag_disable_water = FLAG(4)
 };
+
+struct s_scenario_fog_result
+{
+    int32 field_0;
+    real_rgb_color color;
+    bool unk_bool_10;
+    bool unk_bool_11;
+    int8 pad_12[2];
+    real32 z_far;
+    bool unk_bool_18;
+    int8 pad[3];
+    int8 gap_18[260];
+};
+ASSERT_STRUCT_SIZE(s_scenario_fog_result, 288);
 
 // max count: k_maximum_mixers_per_scenario_atmospheric_fog_palette_entry 2
 struct scenario_atmospheric_fog_mixer_block
@@ -87,3 +100,6 @@ struct s_scenario_planar_fog_palette_entry
 };
 ASSERT_STRUCT_SIZE(s_scenario_planar_fog_palette_entry, 16);
 
+// CLIENT ONLY
+// Renders the fog defined in the scenario
+bool __cdecl render_scenario_fog(int cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result);

--- a/xlive/Blam/Engine/scenario/scenario_fog.h
+++ b/xlive/Blam/Engine/scenario/scenario_fog.h
@@ -18,17 +18,73 @@ enum e_camera_immersion_flags : short
     camera_immersion_flag_disable_water = FLAG(4)
 };
 
+enum e_fog_mode : uint32
+{
+    _fog_mode_none = 0,
+    _fog_mode_atmospheric = 1,
+    _fog_mode_sky_only = 2,
+    _fog_mode_planar = 3,
+    _fog_mode_planar_immersed = 4,
+    _fog_mode_planar_immersed_secondary = 5,
+    k_fog_mode_count
+};
+
 struct s_scenario_fog_result
 {
-    int32 field_0;
-    real_rgb_color color;
-    bool unk_bool_10;
-    bool unk_bool_11;
+    e_fog_mode fog_mode;
+    real_rgb_color clear_color;
+    bool draw_sky;
+    bool draw_sky_fog;
     int8 pad_12[2];
-    real32 z_far;
-    bool unk_bool_18;
-    int8 pad[3];
-    int8 gap_18[260];
+    real32 view_max_distance;
+    bool view_max_distance_changed;
+    int8 pad_19[3];
+    real_rgb_color atmospheric_color;
+    real32 atmospheric_max_density;
+    real32 atmospheric_min_distance;
+    real32 atmospheric_max_distance;
+    real_rgb_color secondary_color;
+    real32 secondary_max_density;
+    real32 secondary_min_distance;
+    real32 secondary_max_distance;
+    int8 field_4C[12];
+    real32 field_58;
+    real_rgb_color sky_fog_color;
+    real32 sky_fog_alpha;
+    datum patchy_fog_tag_index;
+    int8 gap_6C[38];
+    bool field_96;
+    bool field_97;
+    bool sort_behind_transparents;
+    int8 pad_99;
+    datum planar_fog_tag_index;
+    real_rgb_color planar_color;
+    real32 planar_max_density;
+    real32 planar_max_distance;
+    real32 planar_max_depth;
+    real32 field_BC;
+    real32 planar_max_atmospheric_depth;
+    bool planar_max_depth_not_set;
+    int8 pad_C1[3];
+    real32 planar_eye_offset_scale;
+    real_rgb_color planar_override_color;
+    real32 planar_override_density;
+    real32 planar_override_min_distance_bias;
+    real32 planar_override_amount;
+    real32 gamma_override;
+    int8 gap_E4[8];
+    real32 gamma_ramp;
+    uint32 flags;
+    real_plane3d fog_plane;
+    bool fog_plane_set;
+    int8 pad_105[3];
+    real32 planar_eye_distance_to_plane;
+    real32 planar_eye_density;
+    real32 planar_min_distance;
+    bool planar_separate_mode;
+    int8 pad_115[3];
+    real32 atmospheric_planar_blend;
+    real32 atmospheric_secondary_blend;
 };
 ASSERT_STRUCT_SIZE(s_scenario_fog_result, 288);
 
@@ -102,4 +158,4 @@ ASSERT_STRUCT_SIZE(s_scenario_planar_fog_palette_entry, 16);
 
 // CLIENT ONLY
 // Renders the fog defined in the scenario
-bool __cdecl render_scenario_fog(int cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result);
+bool __cdecl render_scenario_fog(int32 cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result);

--- a/xlive/Blam/Engine/structures/structures.cpp
+++ b/xlive/Blam/Engine/structures/structures.cpp
@@ -6,7 +6,7 @@ s_structure_globals* structure_globals_get(void)
 	return Memory::GetAddress<s_structure_globals*>(0x4D12A1, 0x4F5159);
 }
 
-bool __cdecl structure_get_sky(int32 cluster_index, int32* visible_sky_index, real_rgb_color* clear_color, bool* has_clear_color)
+bool __cdecl structure_get_sky(int32 cluster_index, int32* visible_sky_index, real_rgb_color* clear_color, bool* clear_color_active)
 {
-    return INVOKE(0xB3822, 0x0, structure_get_sky, cluster_index, visible_sky_index, clear_color, has_clear_color);
+    return INVOKE(0xB3822, 0x0, structure_get_sky, cluster_index, visible_sky_index, clear_color, clear_color_active);
 }

--- a/xlive/Blam/Engine/structures/structures.cpp
+++ b/xlive/Blam/Engine/structures/structures.cpp
@@ -5,3 +5,8 @@ s_structure_globals* structure_globals_get(void)
 {
 	return Memory::GetAddress<s_structure_globals*>(0x4D12A1, 0x4F5159);
 }
+
+bool __cdecl structure_get_sky(int32 cluster_index, int32* visible_sky_index, real_rgb_color* clear_color, bool* has_clear_color)
+{
+    return INVOKE(0xB3822, 0x0, structure_get_sky, cluster_index, visible_sky_index, clear_color, has_clear_color);
+}

--- a/xlive/Blam/Engine/structures/structures.h
+++ b/xlive/Blam/Engine/structures/structures.h
@@ -1,6 +1,6 @@
 #pragma once
-
 #include "cseries/cseries_strings.h"
+#include "math/color_math.h"
 #include "tag_files/tag_reference.h"
 
 #define MAXIMUM_SURFACE_REFERENCES_PER_STRUCTURE 262144
@@ -51,4 +51,7 @@ ASSERT_STRUCT_SIZE(s_structure_globals, 6159);
 
 s_structure_globals* structure_globals_get(void);
 
-
+// CLIENT ONLY
+// Get index of sky block in the scenario that's currently visible
+// Grabs the clear color and sets a bool if the sky has a clear color 
+bool __cdecl structure_get_sky(int32 cluster_index, int32* visible_sky_index, real_rgb_color* clear_color, bool* has_clear_color);

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -22,6 +22,7 @@
 #include "input/input_abstraction.h"
 #include "interface/hud.h"
 #include "interface/hud_messaging.h"
+#include "interface/interface.h"
 #include "interface/motion_sensor.h"
 #include "interface/first_person_camera.h"
 #include "interface/first_person_weapons.h"
@@ -40,6 +41,7 @@
 #include "rasterizer/rasterizer_lens_flares.h"
 #include "rasterizer/dx9/rasterizer_dx9_fog.h"
 #include "rasterizer/dx9/rasterizer_dx9_main.h"
+#include "render/render.h"
 #include "saved_games/game_state_procs.h"
 #include "simulation/simulation.h"
 #include "simulation/simulation_entity_database.h"
@@ -937,6 +939,8 @@ void H2MOD::ApplyHooks() {
 		player_vibration_apply_patches();
 		input_windows_apply_patches();
 		input_abstraction_patches_apply();
+		render_apply_patches();
+		apply_interface_hooks();
 	}
 	else {
 		LOG_INFO_GAME("{} - applying dedicated server hooks", __FUNCTION__);

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -312,6 +312,7 @@
     <ClCompile Include="Blam\Engine\bitmaps\bitmaps.cpp" />
     <ClCompile Include="Blam\Engine\cache\cache_files.cpp" />
     <ClCompile Include="Blam\Engine\cache\cache_file_verification.cpp" />
+    <ClCompile Include="Blam\Engine\cache\pc_geometry_cache.cpp" />
     <ClCompile Include="Blam\Engine\camera\camera.cpp" />
     <ClCompile Include="Blam\Engine\camera\dead_camera.cpp" />
     <ClCompile Include="Blam\Engine\camera\director.cpp" />
@@ -328,6 +329,7 @@
     <ClCompile Include="Blam\Engine\cseries\cseries_windows_modules.cpp" />
     <ClCompile Include="Blam\Engine\cseries\runtime_state.cpp" />
     <ClCompile Include="Blam\Engine\cutscene\cinematics.cpp" />
+    <ClCompile Include="Blam\Engine\effects\beam.cpp" />
     <ClCompile Include="Blam\Engine\effects\contrails.cpp" />
     <ClCompile Include="Blam\Engine\effects\effects.cpp" />
     <ClCompile Include="Blam\Engine\effects\particle_location.cpp" />
@@ -351,6 +353,7 @@
     <ClCompile Include="Blam\Engine\input\input_abstraction.cpp" />
     <ClCompile Include="Blam\Engine\input\input_windows.cpp" />
     <ClCompile Include="Blam\Engine\input\input_xinput.cpp" />
+    <ClCompile Include="Blam\Engine\interface\interface.cpp" />
     <ClCompile Include="Blam\Engine\interface\user_interface_controller.cpp" />
     <ClCompile Include="Blam\Engine\items\item_definitions.cpp" />
     <ClCompile Include="Blam\Engine\items\weapons.cpp" />
@@ -492,6 +495,7 @@
     <ClInclude Include="Blam\Engine\bitmaps\bitmaps.h" />
     <ClInclude Include="Blam\Engine\bitmaps\bitmap_group.h" />
     <ClInclude Include="Blam\Engine\cache\cache_file_verification.h" />
+    <ClInclude Include="Blam\Engine\cache\pc_geometry_cache.h" />
     <ClInclude Include="Blam\Engine\cache\predicted_resources.h" />
     <ClInclude Include="Blam\Engine\camera\dead_camera.h" />
     <ClInclude Include="Blam\Engine\camera\director.h" />
@@ -513,6 +517,7 @@
     <ClInclude Include="Blam\Engine\editor\editor_flags.h" />
     <ClInclude Include="Blam\Engine\cseries\cseries_windows_debug_pc.h" />
     <ClInclude Include="Blam\Engine\cutscene\cinematics.h" />
+    <ClInclude Include="Blam\Engine\effects\beam.h" />
     <ClInclude Include="Blam\Engine\effects\contrails.h" />
     <ClInclude Include="Blam\Engine\effects\effects.h" />
     <ClInclude Include="Blam\Engine\effects\effects_creation.h" />
@@ -553,6 +558,7 @@
     <ClInclude Include="Blam\Engine\interface\first_person_weapons.h" />
     <ClInclude Include="Blam\Engine\interface\hud.h" />
     <ClInclude Include="Blam\Engine\interface\hud_messaging.h" />
+    <ClInclude Include="Blam\Engine\interface\interface.h" />
     <ClInclude Include="Blam\Engine\interface\motion_sensor.h" />
     <ClInclude Include="Blam\Engine\interface\new_hud.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screens_patches.h" />
@@ -602,6 +608,8 @@
     <ClCompile Include="Blam\Engine\physics\havok_memory.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_main.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_fog.cpp" />
+    <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_shader_submit_new.cpp" />
+    <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_screen_effect.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_globals.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_lens_flares.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_loading.cpp" />
@@ -609,6 +617,8 @@
     <ClCompile Include="Blam\Engine\render\render.cpp" />
     <ClCompile Include="Blam\Engine\render\render_cameras.cpp" />
     <ClCompile Include="Blam\Engine\render\render_cartographer_ingame_ui.cpp" />
+    <ClCompile Include="Blam\Engine\render\render_first_person.cpp" />
+    <ClCompile Include="Blam\Engine\render\render_lights.cpp" />
     <ClCompile Include="Blam\Engine\render\render_submit.cpp" />
     <ClCompile Include="Blam\Engine\render\render_visibility_collection.cpp" />
     <ClCompile Include="Blam\Engine\saved_games\game_state.cpp" />
@@ -616,6 +626,7 @@
     <ClCompile Include="Blam\Engine\render\render_sky.cpp" />
     <ClCompile Include="Blam\Engine\saved_games\game_variant.cpp" />
     <ClCompile Include="Blam\Engine\scenario\scenario.cpp" />
+    <ClCompile Include="Blam\Engine\scenario\scenario_fog.cpp" />
     <ClCompile Include="Blam\Engine\scenario\scenario_kill_trigger_volumes.cpp" />
     <ClCompile Include="Blam\Engine\shell\shell.cpp" />
     <ClCompile Include="Blam\Engine\shell\shell_windows.cpp" />
@@ -929,6 +940,8 @@
     <ClInclude Include="Blam\Engine\physics\structure_physics.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_fog.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_main.h" />
+    <ClInclude Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_screen_effect.h" />
+    <ClInclude Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_shader_submit_new.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\shaders\compiled\motion_sensor_sweep.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_globals.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_lens_flares.h" />
@@ -938,6 +951,7 @@
     <ClInclude Include="Blam\Engine\render\render.h" />
     <ClInclude Include="Blam\Engine\render\render_cartographer_ingame_ui.h" />
     <ClInclude Include="Blam\Engine\render\render_debug_structure.h" />
+    <ClInclude Include="Blam\Engine\render\render_first_person.h" />
     <ClInclude Include="Blam\Engine\render\render_lights.h" />
     <ClInclude Include="Blam\Engine\render\render_lod_new.h" />
     <ClInclude Include="Blam\Engine\render\render_prt.h" />

--- a/xlive/Project_Cartographer.vcxproj.filters
+++ b/xlive/Project_Cartographer.vcxproj.filters
@@ -104,7 +104,6 @@
     <ClCompile Include="H2MOD\Modules\CustomMenu\c_brightness_menu.cpp" />
     <ClCompile Include="H2MOD\Modules\CustomMenu\c_user_interface_widget.cpp" />
     <ClCompile Include="H2MOD\Modules\CustomMenu\Accounts\c_account_list_menu.cpp" />
-    <ClCompile Include="H2MOD\Modules\Shell\Startup\WinMainH2.cpp" />
     <ClCompile Include="H2MOD\Modules\CustomMenu\c_error_menu.cpp" />
     <ClCompile Include="H2MOD\Modules\CustomMenu\c_screen_widget.cpp" />
     <ClCompile Include="H2MOD\Modules\CustomMenu\c_virtual_keyboard_menu.cpp" />
@@ -190,7 +189,6 @@
     <ClCompile Include="Blam\Engine\game\game.cpp" />
     <ClCompile Include="Blam\Engine\saved_games\game_variant.cpp" />
     <ClCompile Include="Blam\Engine\ai\actors.cpp" />
-    <ClCompile Include="Blam\Engine\game\game_preferences.cpp" />
     <ClCompile Include="Blam\Engine\cseries\cseries_windows.cpp" />
     <ClCompile Include="Blam\Engine\cseries\cseries_errors.cpp" />
     <ClCompile Include="Blam\Engine\cseries\cseries_windows_minidump.cpp" />
@@ -308,6 +306,25 @@
     <ClCompile Include="Blam\Engine\structures\structure_bsp_definitions.cpp" />
     <ClCompile Include="Blam\Engine\cartographer\tag_fixes\tag_fixes.cpp" />
     <ClCompile Include="Blam\Engine\math\math.cpp" />
+    <ClCompile Include="Blam\Engine\cache\cache_file_verification.cpp" />
+    <ClCompile Include="Blam\Engine\cache\pc_geometry_cache.cpp" />
+    <ClCompile Include="Blam\Engine\cartographer\tag_fixes\tag_fixes.cpp" />
+    <ClCompile Include="Blam\Engine\cseries\async.cpp" />
+    <ClCompile Include="Blam\Engine\cseries\runtime_state.cpp" />
+    <ClCompile Include="Blam\Engine\effects\beam.cpp" />
+    <ClCompile Include="Blam\Engine\main\game_preferences.cpp" />
+    <ClCompile Include="Blam\Engine\main\licensing.cpp" />
+    <ClCompile Include="Blam\Engine\math\math.cpp" />
+    <ClCompile Include="Blam\Engine\Networking\network_configuration.cpp" />
+    <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_shader_submit_new.cpp" />
+    <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_screen_effect.cpp" />
+    <ClCompile Include="Blam\Engine\render\render_first_person.cpp" />
+    <ClCompile Include="Blam\Engine\render\render_lights.cpp" />
+    <ClCompile Include="Blam\Engine\scenario\scenario_fog.cpp" />
+    <ClCompile Include="Blam\Engine\sound\sound_manager.cpp" />
+    <ClCompile Include="Blam\Engine\tag_files\tag_files.cpp" />
+    <ClCompile Include="Blam\Engine\text\font_group.cpp" />
+    <ClCompile Include="Blam\Engine\interface\interface.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="3rdparty\discord\discord_register.h" />
@@ -544,7 +561,6 @@
     <ClInclude Include="H2MOD\Modules\CustomMenu\c_brightness_menu.h" />
     <ClInclude Include="H2MOD\Modules\CustomMenu\c_user_interface_widget.h" />
     <ClInclude Include="H2MOD\Modules\CustomMenu\Accounts\c_account_list_menu.h" />
-    <ClInclude Include="H2MOD\Modules\Shell\Startup\WinMainH2.h" />
     <ClInclude Include="H2MOD\Modules\CustomMenu\c_error_menu.h" />
     <ClInclude Include="H2MOD\Modules\CustomMenu\c_screen_widget.h" />
     <ClInclude Include="H2MOD\Modules\CustomMenu\c_virtual_keyboard_menu.h" />
@@ -679,7 +695,6 @@
     <ClInclude Include="Blam\Engine\cseries\cseries.h" />
     <ClInclude Include="Blam\Engine\ai\pathfinding_utilities.h" />
     <ClInclude Include="Blam\Engine\ai\actor_firing_position.h" />
-    <ClInclude Include="Blam\Engine\game\game_preferences.h" />
     <ClInclude Include="Blam\Engine\game\materials.h" />
     <ClInclude Include="Blam\Engine\main\level_definitions.h" />
     <ClInclude Include="Blam\Engine\text\text_group.h" />


### PR DESCRIPTION
- doesn't fix all rendering issues but viewports now display properly
- rewrite function to display splitscreen lines so it has dynamic resolution support

![image](https://github.com/pnill/cartographer/assets/40469582/cc2dba15-3d89-46b0-8881-12087b101ec6)
