### PR TITLE
Draw string cleanup

### DIFF
--- a/xlive/Blam/Engine/main/main_render.cpp
+++ b/xlive/Blam/Engine/main/main_render.cpp
@@ -4,11 +4,11 @@
 #include "render/render_cartographer_ingame_ui.h"
 #include "rasterizer/dx9/rasterizer_dx9.h"
 
-/* -------- prototypes */
+/*  prototypes */
 
 void main_render_hook(void);
 
-/* -------- public code */
+/* public code */
 
 void main_render_apply_patches(void)
 {
@@ -18,7 +18,7 @@ void main_render_apply_patches(void)
 	return;
 }
 
-/* -------- private code */
+/* private code */
 
 void main_render_hook(void)
 {

--- a/xlive/Blam/Engine/main/main_render.cpp
+++ b/xlive/Blam/Engine/main/main_render.cpp
@@ -4,27 +4,25 @@
 #include "render/render_cartographer_ingame_ui.h"
 #include "rasterizer/dx9/rasterizer_dx9.h"
 
-/* prototypes */
+/* -------- prototypes */
 
 void main_render_hook(void);
 
-/* public code */
+/* -------- public code */
 
 void main_render_apply_patches(void)
 {
 	// this is replacing a nullsub
 	PatchCall(Memory::GetAddress(0x19228E), main_render_hook);
+
 	return;
 }
 
-/* private code */
+/* -------- private code */
 
 void main_render_hook(void)
 {
-	rasterizer_dx9_perf_event_begin("render cartographer text", NULL);
-	render_cartographer_status_text();
-	render_cartographer_achievements();
-	render_cartographer_update();
-	rasterizer_dx9_perf_event_end("render cartographer text");
+	render_cartographer_ingame_ui();
+
 	return;
 }

--- a/xlive/Blam/Engine/main/main_render.h
+++ b/xlive/Blam/Engine/main/main_render.h
@@ -1,5 +1,5 @@
 #pragma once
 
-/* public code */
+/* -------- public code */
 
 void main_render_apply_patches(void);

--- a/xlive/Blam/Engine/main/main_render.h
+++ b/xlive/Blam/Engine/main/main_render.h
@@ -1,5 +1,5 @@
 #pragma once
 
-/* -------- public code */
+/* prototypes */
 
 void main_render_apply_patches(void);

--- a/xlive/Blam/Engine/rasterizer/rasterizer_text.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_text.cpp
@@ -3,7 +3,7 @@
 
 /* -------- public code */
 
-void __cdecl draw_unicode_string(rectangle2d const* bounds, wchar_t const* string)
+void __cdecl rasterizer_draw_unicode_string(rectangle2d const* bounds, wchar_t const* string)
 {
-	INVOKE(0x271BC8, 0, draw_unicode_string, bounds, string);
+	INVOKE(0x271BC8, 0, rasterizer_draw_unicode_string, bounds, string);
 }

--- a/xlive/Blam/Engine/rasterizer/rasterizer_text.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_text.cpp
@@ -1,0 +1,9 @@
+#include "stdafx.h"
+#include "rasterizer_text.h"
+
+/* -------- public code */
+
+void __cdecl draw_unicode_string(rectangle2d const* bounds, wchar_t const* string)
+{
+	INVOKE(0x271BC8, 0, draw_unicode_string, bounds, string);
+}

--- a/xlive/Blam/Engine/rasterizer/rasterizer_text.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_text.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "rasterizer_text.h"
 
-/* -------- public code */
+/* public code */
 
 void __cdecl rasterizer_draw_unicode_string(rectangle2d const* bounds, wchar_t const* string)
 {

--- a/xlive/Blam/Engine/rasterizer/rasterizer_text.h
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_text.h
@@ -1,0 +1,6 @@
+#pragma once
+
+/* -------- prototypes */
+
+// name is from halo 1
+void __cdecl draw_unicode_string(rectangle2d const* bounds, wchar_t const* string);

--- a/xlive/Blam/Engine/rasterizer/rasterizer_text.h
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_text.h
@@ -1,6 +1,6 @@
 #pragma once
 
-/* -------- prototypes */
+/* prototypes */
 
 // name is from halo 1
 void __cdecl rasterizer_draw_unicode_string(rectangle2d const* bounds, wchar_t const* string);

--- a/xlive/Blam/Engine/rasterizer/rasterizer_text.h
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_text.h
@@ -3,4 +3,4 @@
 /* -------- prototypes */
 
 // name is from halo 1
-void __cdecl draw_unicode_string(rectangle2d const* bounds, wchar_t const* string);
+void __cdecl rasterizer_draw_unicode_string(rectangle2d const* bounds, wchar_t const* string);

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -26,7 +26,7 @@
 //#define ACHIVEMENT_RENDER_DEBUG_ENABLED
 
 // define this to render git branch information (if GEN_GIT_VER_VERSION_STRING is defined)
-//#define CARTOGRAPHER_TEST_BUILD_DRAW_TEXT
+#define CARTOGRAPHER_TEST_BUILD_DRAW_TEXT
 
 /* constants */
 
@@ -248,7 +248,7 @@ void render_cartographer_update_message(const char* update_text, int64 update_si
 	if (update_size_bytes > 0)
 	{
 		wchar_t update_message_buffer[256];
-		float percent_complate = 100.f * ((float)update_downloaded_bytes / update_size_bytes);
+		real32 percent_complate = 100.f * ((real32)update_downloaded_bytes / update_size_bytes);
 		swprintf_s(update_message_buffer, NUMBEROF(update_message_buffer), L"(progress: %.2f%%)", percent_complate);
 		rasterizer_draw_unicode_string(&bounds, update_message_buffer);
 	}

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -120,13 +120,13 @@ void render_cartographer_status_bar(const char *build_text)
 		if (g_twizzler_status)
 		{
 			draw_string_set_format(0, 1, 0, false);
-			draw_unicode_string(&bounds, L"Anti-cheat is enabled");
+			rasterizer_draw_unicode_string(&bounds, L"Anti-cheat is enabled");
 			draw_string_set_format(0, 0, 0, false);
 		}
-		draw_unicode_string(&bounds, build_string_buffer);
+		rasterizer_draw_unicode_string(&bounds, build_string_buffer);
 		bounds.top += line_height;
 		bounds.bottom = bounds.top + line_height;
-		draw_unicode_string(&bounds, master_state_string_buffer);
+		rasterizer_draw_unicode_string(&bounds, master_state_string_buffer);
 	}
 
 	return;
@@ -151,11 +151,11 @@ void render_cartographer_git_build_info(void)
 	wchar_t result_text_buffer[1024];
 
 	swprintf(result_text_buffer, NUMBEROF(result_text_buffer), L"%S %S", __DATE__, __TIME__);
-	draw_unicode_string(&bounds, result_text_buffer);
+	rasterizer_draw_unicode_string(&bounds, result_text_buffer);
 	bounds.top += line_height;
 	bounds.bottom = bounds.top + line_height;
 	swprintf(result_text_buffer, NUMBEROF(result_text_buffer), L"%S %S branch: %S", GEN_GIT_VER_VERSION_STRING, GET_GIT_VER_USERNAME, GET_GIT_VER_BRANCH);
-	draw_unicode_string(&bounds, result_text_buffer);
+	rasterizer_draw_unicode_string(&bounds, result_text_buffer);
 #endif
 }
 
@@ -190,13 +190,13 @@ bool render_cartographer_achievement_message(const char *achivement_message)
 
 		rasterizer_get_screen_bounds(&bounds);
 		bounds.top += rectangle2d_height(&bounds) / 3 - (widget_total_height / 2);
-		draw_unicode_string(&bounds, L"Achievement Unlocked");
+		rasterizer_draw_unicode_string(&bounds, L"Achievement Unlocked");
 		bounds.top += get_text_size_from_font_cache(k_cheevo_title_font);
 
 		draw_string_set_font(k_cheevo_message_font);
-		draw_unicode_string(&bounds, cheevo_message);
+		rasterizer_draw_unicode_string(&bounds, cheevo_message);
 		bounds.top += get_text_size_from_font_cache(k_cheevo_message_font);
-		draw_unicode_string(&bounds, divider_position ? (divider_position + 1) : L"<invalid achievement description>");
+		rasterizer_draw_unicode_string(&bounds, divider_position ? (divider_position + 1) : L"<invalid achievement description>");
 	}
 	else
 	{
@@ -240,7 +240,7 @@ void render_cartographer_update_message(const char* update_text, int64 update_si
 
 		for (int32 line_index = 0; line_index < line_count; line_index++)
 		{
-			draw_unicode_string(&bounds, lines[line_index].get_string());
+			rasterizer_draw_unicode_string(&bounds, lines[line_index].get_string());
 			bounds.top += get_text_size_from_font_cache(k_update_status_font);
 		}
 	}
@@ -250,7 +250,7 @@ void render_cartographer_update_message(const char* update_text, int64 update_si
 		wchar_t update_message_buffer[256];
 		float percent_complate = 100.f * ((float)update_downloaded_bytes / update_size_bytes);
 		swprintf_s(update_message_buffer, NUMBEROF(update_message_buffer), L"(progress: %.2f%%)", percent_complate);
-		draw_unicode_string(&bounds, update_message_buffer);
+		rasterizer_draw_unicode_string(&bounds, update_message_buffer);
 	}
 
 	return;

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -5,6 +5,7 @@
 #include "game/game.h"
 #include "interface/hud.h"
 #include "rasterizer/rasterizer_globals.h"
+#include "rasterizer/rasterizer_text.h"
 #include "rasterizer/dx9/rasterizer_dx9.h"
 #include "shell/shell_windows.h"
 #include "text/draw_string.h"
@@ -15,44 +16,89 @@
 #include "H2MOD/Modules/Achievements/Achievements.h"
 #include "H2MOD/Modules/Shell/Config.h"
 
+#if defined(GEN_GIT_VER_VERSION_STRING)
 #include "version_git.h"
+#endif
 
-/* constants */
+/* -------- defines */
 
 // define this to enable queueing a test message in render_cartographer_achievements
-// #define ACHIVEMENT_RENDER_DEBUG_ENABLED
-#define CARTOGRAPHER_TEST_BUILD_DRAW_TEXT
+//#define ACHIVEMENT_RENDER_DEBUG_ENABLED
 
-#define k_status_text_font 0
+// define this to render git branch information (if GEN_GIT_VER_VERSION_STRING is defined)
+//#define CARTOGRAPHER_TEST_BUILD_DRAW_TEXT
 
-#define k_cheevo_display_lifetime (5 * k_shell_time_msec_denominator)
-#define k_cheevo_title_font 10
-#define k_cheevo_message_font 1
+/* -------- constants */
 
-#define k_update_status_font 5
+enum
+{
+	k_status_text_font = 0,
+	k_update_status_font = 5,
+	k_cheevo_title_font = 10,
+	k_cheevo_message_font = 1,
+	k_cheevo_display_lifetime = (5 * k_shell_time_msec_denominator),
+};
 
-/* globals */
+/* -------- prototypes */
 
-// defined in XLiveRendering.cpp
-extern char* buildText;
+static void render_cartographer_status_bar(const char* build_text);
+static void render_cartographer_git_build_info(void);
+static bool render_cartographer_achievement_message(const char* achivement_message);
+static void render_cartographer_update_message(const char* update_text, int64 update_size_bytes, int64 update_downloaded_bytes);
 
-// defined in Modules\Updater\Updater.cpp
-extern char* autoUpdateText;
-extern long long sizeOfDownload;
-extern long long sizeOfDownloaded;
+/* -------- public code */
 
-/* public code */
+void render_cartographer_ingame_ui(void)
+{
+	// these are global variables defined in legacy files where
+	// various d3dx9 rendering functions originally were.
 
-void render_cartographer_status_text(void)
+	// defined in XLiveRendering.cpp
+	extern char* buildText;
+	// defined in Modules\Updater\Updater.cpp
+	extern char* autoUpdateText;
+	extern long long sizeOfDownload;
+	extern long long sizeOfDownloaded;
+
+#ifdef ACHIVEMENT_RENDER_DEBUG_ENABLED
+	static bool x_test = false;
+	if (x_test)
+	{
+		AchievementMap.insert({ "achievement title|achievement message", false });
+		x_test = false;
+	}
+#endif
+
+	rasterizer_dx9_perf_event_begin("render cartographer ingame ui", NULL);
+	render_cartographer_status_bar(buildText);
+	render_cartographer_update_message(autoUpdateText, sizeOfDownload, sizeOfDownloaded);
+	if (!AchievementMap.empty())
+	{
+		auto it = AchievementMap.begin();
+		it->second = true;
+		if (!render_cartographer_achievement_message(it->first.c_str()))
+		{
+			AchievementMap.erase(it);
+		}
+	}
+	render_cartographer_git_build_info();
+	rasterizer_dx9_perf_event_end("render cartographer ingame ui");
+
+	return;
+}
+
+/* -------- private code */
+
+void render_cartographer_status_bar(const char *build_text)
 {
 	rectangle2d bounds;
 	rasterizer_get_frame_bounds(&bounds);
 
 	bool game_is_main_menu = game_is_ui_shell();
-	bool paused_or_in_menus = *Memory::GetAddress<bool*>(0x47A568) != 0;
+	bool paused_or_in_menus = (*Memory::GetAddress<bool*>(0x47A568) != false);
 
 	wchar_t build_string_buffer[256];
-	utf8_string_to_wchar_string(buildText, build_string_buffer, NUMBEROF(build_string_buffer));
+	utf8_string_to_wchar_string(build_text, build_string_buffer, NUMBEROF(build_string_buffer));
 
 	wchar_t master_state_string_buffer[256];
 	utf8_string_to_wchar_string(GetMasterStateStr(), master_state_string_buffer, NUMBEROF(master_state_string_buffer));
@@ -63,129 +109,121 @@ void render_cartographer_status_text(void)
 		text_color_console.alpha = .5f;
 	}
 
-	int32 line_height = get_text_size_from_font_cache(k_status_text_font);
+	const int32 line_height = get_text_size_from_font_cache(k_status_text_font);
 	bool paused_or_in_main_menu = game_is_main_menu || paused_or_in_menus;
-	if (paused_or_in_main_menu) {
+	if (paused_or_in_main_menu)
+	{
 		draw_string_reset();
-		draw_string_set_font_and_options(k_status_text_font, 0, 0, 0, &text_color_console, global_real_argb_black, false);
+		draw_string_set_draw_mode(k_status_text_font, 0, 0, 0, &text_color_console, global_real_argb_black, false);
 
 		bounds.bottom = bounds.top + line_height;
-
 		if (g_twizzler_status)
 		{
-			draw_string_set_options(0, 1, 0, false);
-			draw_string_render(&bounds, L"Anti-cheat is enabled");
-			draw_string_set_options(0, 0, 0, false);
+			draw_string_set_format(0, 1, 0, false);
+			draw_unicode_string(&bounds, L"Anti-cheat is enabled");
+			draw_string_set_format(0, 0, 0, false);
 		}
-
-		draw_string_render(&bounds, build_string_buffer);
+		draw_unicode_string(&bounds, build_string_buffer);
 		bounds.top += line_height;
 		bounds.bottom = bounds.top + line_height;
-		draw_string_render(&bounds, master_state_string_buffer);
+		draw_unicode_string(&bounds, master_state_string_buffer);
 	}
 
+	return;
+}
+
+void render_cartographer_git_build_info(void)
+{
 #if defined(GEN_GIT_VER_VERSION_STRING) && defined(CARTOGRAPHER_TEST_BUILD_DRAW_TEXT) 
-	{
-		const s_rasterizer_globals* rasterizer_globals = rasterizer_globals_get();
+	const s_rasterizer_globals* rasterizer_globals = rasterizer_globals_get();
 
-		rasterizer_get_frame_bounds(&bounds);
-		int32 test_build_font = k_status_text_font;
-		line_height = get_text_size_from_font_cache(test_build_font);
+	rasterizer_get_frame_bounds(&bounds);
+	const int32 line_height = get_text_size_from_font_cache(k_status_text_font);
 
-		text_color_console.alpha = .55f;
-		bounds.top += (1050 * rasterizer_globals->ui_scale);
-		bounds.left = bounds.right - (765 * rasterizer_globals->ui_scale);
-		bounds.bottom = bounds.top + line_height;
-		
-		draw_string_reset();
-		draw_string_set_font_and_options(test_build_font, 0, 0, 0, &text_color_console, global_real_argb_black, false);
+	text_color_console.alpha = .55f;
+	bounds.top += (1050 * rasterizer_globals->ui_scale);
+	bounds.left = bounds.right - (765 * rasterizer_globals->ui_scale);
+	bounds.bottom = bounds.top + line_height;
 
-		wchar_t result_text_buffer[1024];
+	draw_string_reset();
+	draw_string_set_draw_mode(k_status_text_font, 0, 0, 0, &text_color_console, global_real_argb_black, false);
 
-		swprintf(result_text_buffer, NUMBEROF(result_text_buffer), L"%S %S", __DATE__, __TIME__);
-		draw_string_render(&bounds, result_text_buffer);
-		bounds.top += line_height;
-		bounds.bottom = bounds.top + line_height;
-		swprintf(result_text_buffer, NUMBEROF(result_text_buffer), L"%S %S branch: %S", GEN_GIT_VER_VERSION_STRING, GET_GIT_VER_USERNAME, GET_GIT_VER_BRANCH);
-		draw_string_render(&bounds, result_text_buffer);
-	}
+	wchar_t result_text_buffer[1024];
+
+	swprintf(result_text_buffer, NUMBEROF(result_text_buffer), L"%S %S", __DATE__, __TIME__);
+	draw_unicode_string(&bounds, result_text_buffer);
+	bounds.top += line_height;
+	bounds.bottom = bounds.top + line_height;
+	swprintf(result_text_buffer, NUMBEROF(result_text_buffer), L"%S %S branch: %S", GEN_GIT_VER_VERSION_STRING, GET_GIT_VER_USERNAME, GET_GIT_VER_BRANCH);
+	draw_unicode_string(&bounds, result_text_buffer);
 #endif
 }
 
-void render_cartographer_achievements(void)
+bool render_cartographer_achievement_message(const char *achivement_message)
 {
 	static int64 x_cheevo_timer = 0;
 	int64 time_now = shell_time_now_msec();
+	bool result = true;
 
-#ifdef ACHIVEMENT_RENDER_DEBUG_ENABLED
-	static bool x_test = false;
-	if (x_test)
+	if (x_cheevo_timer == 0)
 	{
-		AchievementMap.insert({ "Why are we still here? Just to suffer?|I can feel my leg, my arm... even my fingers.", false });
-		x_test = false;
+		x_cheevo_timer = time_now + k_cheevo_display_lifetime;
 	}
-#endif
 
-	if (!AchievementMap.empty())
-	{
-		// hover over this type to die instantly
-		auto it = AchievementMap.begin();
-		if (it->second == false)
-		{
-			it->second = true;
-			x_cheevo_timer = time_now + k_cheevo_display_lifetime;
-		}
-
-		if (x_cheevo_timer - time_now < 0)
-		{
-			AchievementMap.erase(it);
-		}
-		else
-		{
-			rectangle2d bounds;
-			wchar_t cheevo_message[256];
-			int32 widget_total_height = get_text_size_from_font_cache(k_cheevo_title_font) + (get_text_size_from_font_cache(k_cheevo_message_font) * 2);
-			real_argb_color text_color = *global_real_argb_white;
-			text_color.alpha = (float)(x_cheevo_timer - time_now) / k_cheevo_display_lifetime;
-
-			// there should be a better way of doing this instead of every frame!
-			utf8_string_to_wchar_string(it->first.c_str(), cheevo_message, NUMBEROF(cheevo_message));
-			wchar_t* divider_position = wcschr(cheevo_message, '|');
-			if (divider_position)
-			{
-				*divider_position = '\0';
-			}
-
-			draw_string_reset();
-			draw_string_set_font_and_options(k_cheevo_title_font, 0, 2, 0, &text_color, global_real_argb_black, false);
-
-			rasterizer_get_screen_bounds(&bounds);
-			bounds.top += rectangle2d_height(&bounds) / 3 - (widget_total_height / 2);
-			draw_string_render(&bounds, L"Achievement Unlocked");
-			bounds.top += get_text_size_from_font_cache(k_cheevo_title_font);
-
-			draw_string_set_font(k_cheevo_message_font);
-			draw_string_render(&bounds, cheevo_message);
-			bounds.top += get_text_size_from_font_cache(k_cheevo_message_font);
-			draw_string_render(&bounds, divider_position ? divider_position + 1 : L"<invalid achievement description>");
-		}
-	}
-}
-
-void render_cartographer_update(void)
-{
-	if (autoUpdateText)
+	if (x_cheevo_timer - time_now > 0)
 	{
 		rectangle2d bounds;
+		wchar_t cheevo_message[256];
+		int32 widget_total_height = get_text_size_from_font_cache(k_cheevo_title_font) + (get_text_size_from_font_cache(k_cheevo_message_font) * 2);
+		real_argb_color text_color = *global_real_argb_white;
+		text_color.alpha = (float)(x_cheevo_timer - time_now) / k_cheevo_display_lifetime;
+
+		utf8_string_to_wchar_string(achivement_message, cheevo_message, NUMBEROF(cheevo_message));
+		wchar_t* divider_position = wcschr(cheevo_message, '|');
+		if (divider_position)
+		{
+			*divider_position = '\0';
+		}
+
+		draw_string_reset();
+		draw_string_set_draw_mode(k_cheevo_title_font, 0, 2, 0, &text_color, global_real_argb_black, false);
+
+		rasterizer_get_screen_bounds(&bounds);
+		bounds.top += rectangle2d_height(&bounds) / 3 - (widget_total_height / 2);
+		draw_unicode_string(&bounds, L"Achievement Unlocked");
+		bounds.top += get_text_size_from_font_cache(k_cheevo_title_font);
+
+		draw_string_set_font(k_cheevo_message_font);
+		draw_unicode_string(&bounds, cheevo_message);
+		bounds.top += get_text_size_from_font_cache(k_cheevo_message_font);
+		draw_unicode_string(&bounds, divider_position ? (divider_position + 1) : L"<invalid achievement description>");
+	}
+	else
+	{
+		x_cheevo_timer = 0;
+		result = false;
+	}
+
+	return result;
+}
+
+void render_cartographer_update_message(const char* update_text, int64 update_size_bytes, int64 update_downloaded_bytes)
+{
+	rectangle2d bounds;
+	rasterizer_get_frame_bounds(&bounds);
+	bounds.top += rectangle2d_height(&bounds) * .1f;
+
+	if (update_text != nullptr)
+	{
 		wchar_t update_message_buffer[256];
 		wchar_t* last_line = update_message_buffer;
 		c_static_wchar_string128 lines[16];
 		int32 line_count = 0;
 		int32 update_message_length = 0;
 
-		utf8_string_to_wchar_string(autoUpdateText, update_message_buffer, NUMBEROF(update_message_buffer));
+		utf8_string_to_wchar_string(update_text, update_message_buffer, NUMBEROF(update_message_buffer));
 		update_message_length = ustrnlen(update_message_buffer, NUMBEROF(update_message_buffer));
-	
+
 		for (int32 character_index = 0; character_index < NUMBEROF(update_message_buffer) && character_index < update_message_length && line_count < NUMBEROF(lines); character_index++)
 		{
 			wchar_t* character = &update_message_buffer[character_index];
@@ -198,24 +236,22 @@ void render_cartographer_update(void)
 		}
 
 		draw_string_reset();
-		draw_string_set_font_and_options(k_update_status_font, 0, 0, 0, global_real_argb_white, global_real_argb_black, false);
-	
-		rasterizer_get_frame_bounds(&bounds);
-		bounds.top += rectangle2d_height(&bounds) * .1f;
+		draw_string_set_draw_mode(k_update_status_font, 0, 0, 0, global_real_argb_white, global_real_argb_black, false);
 
 		for (int32 line_index = 0; line_index < line_count; line_index++)
 		{
-			draw_string_render(&bounds, lines[line_index].get_string());
+			draw_unicode_string(&bounds, lines[line_index].get_string());
 			bounds.top += get_text_size_from_font_cache(k_update_status_font);
 		}
-
-		if (sizeOfDownload > 0)
-		{
-			wchar_t update_message_buffer[256];
-			float percent_complate = 100.f * ((float)sizeOfDownloaded / sizeOfDownload);
-			swprintf_s(update_message_buffer, NUMBEROF(update_message_buffer), L"(progress: %.2f%%)", percent_complate);
-			draw_string_render(&bounds, update_message_buffer);
-		}
 	}
+
+	if (update_size_bytes > 0)
+	{
+		wchar_t update_message_buffer[256];
+		float percent_complate = 100.f * ((float)update_downloaded_bytes / update_size_bytes);
+		swprintf_s(update_message_buffer, NUMBEROF(update_message_buffer), L"(progress: %.2f%%)", percent_complate);
+		draw_unicode_string(&bounds, update_message_buffer);
+	}
+
 	return;
 }

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -20,7 +20,7 @@
 #include "version_git.h"
 #endif
 
-/* -------- defines */
+/* defines */
 
 // define this to enable queueing a test message in render_cartographer_achievements
 //#define ACHIVEMENT_RENDER_DEBUG_ENABLED
@@ -28,7 +28,7 @@
 // define this to render git branch information (if GEN_GIT_VER_VERSION_STRING is defined)
 //#define CARTOGRAPHER_TEST_BUILD_DRAW_TEXT
 
-/* -------- constants */
+/* constants */
 
 enum
 {
@@ -39,14 +39,14 @@ enum
 	k_cheevo_display_lifetime = (5 * k_shell_time_msec_denominator),
 };
 
-/* -------- prototypes */
+/* prototypes */
 
 static void render_cartographer_status_bar(const char* build_text);
 static void render_cartographer_git_build_info(void);
 static bool render_cartographer_achievement_message(const char* achivement_message);
 static void render_cartographer_update_message(const char* update_text, int64 update_size_bytes, int64 update_downloaded_bytes);
 
-/* -------- public code */
+/* public code */
 
 void render_cartographer_ingame_ui(void)
 {
@@ -87,7 +87,7 @@ void render_cartographer_ingame_ui(void)
 	return;
 }
 
-/* -------- private code */
+/* private code */
 
 void render_cartographer_status_bar(const char *build_text)
 {

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -16,9 +16,7 @@
 #include "H2MOD/Modules/Achievements/Achievements.h"
 #include "H2MOD/Modules/Shell/Config.h"
 
-#if defined(GEN_GIT_VER_VERSION_STRING)
 #include "version_git.h"
-#endif
 
 /* defines */
 
@@ -137,10 +135,12 @@ void render_cartographer_git_build_info(void)
 #if defined(GEN_GIT_VER_VERSION_STRING) && defined(CARTOGRAPHER_TEST_BUILD_DRAW_TEXT) 
 	const s_rasterizer_globals* rasterizer_globals = rasterizer_globals_get();
 
-	rasterizer_get_frame_bounds(&bounds);
 	const int32 line_height = get_text_size_from_font_cache(k_status_text_font);
-
+	real_argb_color text_color_console = *global_real_argb_white;
 	text_color_console.alpha = .55f;
+
+	rectangle2d bounds;
+	rasterizer_get_frame_bounds(&bounds);
 	bounds.top += (1050 * rasterizer_globals->ui_scale);
 	bounds.left = bounds.right - (765 * rasterizer_globals->ui_scale);
 	bounds.bottom = bounds.top + line_height;

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -20,7 +20,7 @@
 
 /* defines */
 
-// define this to enable queueing a test message in render_cartographer_achievements
+// define this to enable queueing a test message in render_cartographer_achievement_message
 //#define ACHIVEMENT_RENDER_DEBUG_ENABLED
 
 // define this to render git branch information (if GEN_GIT_VER_VERSION_STRING is defined)

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.h
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* public code */
+/* -------- public code */
 
-void render_cartographer_status_text(void);
-void render_cartographer_achievements(void);
-void render_cartographer_update(void);
+void render_cartographer_ingame_ui(void);

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.h
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.h
@@ -1,5 +1,5 @@
 #pragma once
 
-/* -------- public code */
+/* public code */
 
 void render_cartographer_ingame_ui(void);

--- a/xlive/Blam/Engine/text/draw_string.cpp
+++ b/xlive/Blam/Engine/text/draw_string.cpp
@@ -21,23 +21,17 @@ void __cdecl draw_string_set_font(int32 font_index)
 	INVOKE(0x98A87, 0, draw_string_set_font, font_index);
 }
 
-void __cdecl draw_string_set_options(int32 style, int32 justification, uint32 flags, bool wrap_horizontally)
+void __cdecl draw_string_set_format(int32 style, int32 justification, uint32 flags, bool wrap_horizontally)
 {
-	INVOKE(0x98A9D, 0, draw_string_set_options, style, justification, flags, wrap_horizontally);
+	INVOKE(0x98A9D, 0, draw_string_set_format, style, justification, flags, wrap_horizontally);
 }
 
-void __cdecl draw_string_set_font_and_options(int32 font, int32 style, int32 justification, uint32 flags, real_argb_color const* color, real_argb_color const* shadow_color, bool wrap_horizontally)
+void __cdecl draw_string_set_draw_mode(int32 font, int32 style, int32 justification, uint32 flags, real_argb_color const* color, real_argb_color const* shadow_color, bool wrap_horizontally)
 {
-	INVOKE(0x98AC4, 0, draw_string_set_font_and_options, font, style, justification, flags, color, shadow_color, wrap_horizontally);
+	INVOKE(0x98AC4, 0, draw_string_set_draw_mode, font, style, justification, flags, color, shadow_color, wrap_horizontally);
 }
 
 void __cdecl draw_string_reset()
 {
 	INVOKE(0x98CDC, 0, draw_string_reset);
-}
-
-// is this in a different file? where should this be
-void __cdecl draw_string_render(rectangle2d const* bounds, wchar_t const* string)
-{
-	INVOKE(0x271BC8, 0, draw_string_render, bounds, string);
 }

--- a/xlive/Blam/Engine/text/draw_string.h
+++ b/xlive/Blam/Engine/text/draw_string.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "math/color_math.h"
 
-/* -------- prototypes */
+/* prototypes */
 
 void __cdecl draw_string_get_color(real_argb_color* color);
 void __cdecl draw_string_set_color(real_argb_color const* color);

--- a/xlive/Blam/Engine/text/draw_string.h
+++ b/xlive/Blam/Engine/text/draw_string.h
@@ -1,12 +1,12 @@
 #pragma once
 #include "math/color_math.h"
 
+/* -------- prototypes */
 
 void __cdecl draw_string_get_color(real_argb_color* color);
 void __cdecl draw_string_set_color(real_argb_color const* color);
 void __cdecl draw_string_set_shadow_color(real_argb_color const* color);
 void __cdecl draw_string_set_font(int32 font_index);
-void __cdecl draw_string_set_options(int32 style, int32 justification, uint32 flags, bool wrap_horizontally);
-void __cdecl draw_string_set_font_and_options(int32 font, int32 style, int32 justification, uint32 flags, real_argb_color const* color, real_argb_color const* shadow_color, bool wrap_horizontally);
+void __cdecl draw_string_set_format(int32 style, int32 justification, uint32 flags, bool wrap_horizontally);
+void __cdecl draw_string_set_draw_mode(int32 font, int32 style, int32 justification, uint32 flags, real_argb_color const* color, real_argb_color const* shadow_color, bool wrap_horizontally);
 void __cdecl draw_string_reset();
-void __cdecl draw_string_render(rectangle2d const* bounds, wchar_t const* string);

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -652,6 +652,7 @@
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_loading.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_screen_effects.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_settings.cpp" />
+    <ClCompile Include="Blam\Engine\rasterizer\rasterizer_text.cpp" />
     <ClCompile Include="Blam\Engine\render\render.cpp" />
     <ClCompile Include="Blam\Engine\render\render_cameras.cpp" />
     <ClCompile Include="Blam\Engine\render\render_cartographer_ingame_ui.cpp" />
@@ -998,6 +999,7 @@
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_loading.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_screen_effects.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_settings.h" />
+    <ClInclude Include="Blam\Engine\rasterizer\rasterizer_text.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_vertex_buffers.h" />
     <ClInclude Include="Blam\Engine\render\render.h" />
     <ClInclude Include="Blam\Engine\render\render_cartographer_ingame_ui.h" />

--- a/xlive/Project_Cartographer.vcxproj.filters
+++ b/xlive/Project_Cartographer.vcxproj.filters
@@ -356,6 +356,7 @@
     <ClCompile Include="Blam\Engine\scenario\scenario_interpolators.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_dynamic_geometry.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_dynavobgeom.cpp" />
+    <ClCompile Include="Blam\Engine\rasterizer\rasterizer_text.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="3rdparty\miniupnpc\include\miniupnpc\codelength.h" />
@@ -970,6 +971,7 @@
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_screen_effects.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_dynamic_geometry.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_dynavobgeom.h" />
+    <ClInclude Include="Blam\Engine\rasterizer\rasterizer_text.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="resources\Resource.rc" />


### PR DESCRIPTION
separates functions in ``render_cartographer_ingame_ui.cpp`` and prepares file for later modifications coming down the pipe

renames functions in ``draw_string.cpp`` to their real names brought in from halo 1 and creates ``rasterizer_text.cpp`` to put ``rasterizer_draw_unicode_string`` in its proper place