### PR TITLE
fix for rewritten tag_get_unsafe and injected tags

### DIFF
--- a/xlive/Blam/Engine/game/players.cpp
+++ b/xlive/Blam/Engine/game/players.cpp
@@ -82,12 +82,6 @@ void s_player::set_unit_character_type(datum player_index, e_character_type char
 	}
     s_player* player = get(player_index);
 
-    // ### FIXME flood biped prevents client players from spawning
-    if (character_type == _character_type_flood)
-    {
-        character_type = _character_type_elite;
-    }
-
     // shouldn't be needed
     player->properties[0].profile_traits.profile.player_character_type = character_type;
     //player->properties[1].profile_traits.profile.player_character_type = character_type;

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
@@ -90,6 +90,8 @@ void tag_injection_scenario_load_setup(uint32 allocation_size)
 	{
 		memcpy(g_tag_table, (BYTE*)*tag_table_start, 0x3BA40);
 		*tag_table_start = (uint32)g_tag_table;
+		s_cache_file_memory_globals* cache_file_memory_globals = cache_file_memory_globals_get();
+		cache_file_memory_globals->tags_header->tag_instances = (cache_file_tag_instance*)g_tag_table;
 	}
 }
 

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
@@ -125,7 +125,7 @@ void c_tag_injecting_manager::set_active_map(const wchar_t* map_name)
 	this->m_active_map_verified = true;
 	
 	// TODO: write out error
-	_wfopen_s(&this->m_active_map_file_handle, this->m_active_map.get_string(), L"rb");
+	this->m_active_map_file_handle = _wfsopen(this->m_active_map.get_string(), L"rb", SH_DENYNO);
 
 	// Read cache header from map file
 	file_seek_and_read(this->m_active_map_file_handle, 0, sizeof(s_cache_header), 1, &this->m_active_map_cache_header);

--- a/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.cpp
+++ b/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.cpp
@@ -53,7 +53,7 @@ namespace CustomVariantSettings
 	void SendCustomVariantSettings(int peerIndex)
 	{
 		c_network_session* session = NetworkSession::GetActiveNetworkSession();
-		if (NetworkSession::LocalPeerIsSessionHost())
+		if (NetworkSession::LocalPeerIsSessionHost() && Memory::IsDedicatedServer())
 		{
 			//TODO: Find and map out struct with current variant information.
 			auto VariantName = std::wstring(Memory::GetAddress<wchar_t*>(0, 0x534A18));


### PR DESCRIPTION
the rewritten tag_get_unsafe was rewritten to use a different pointer to the tag_header->tag_instances. The pointer it originally used was a on-compilation pointer added by the inlining of tag getting operations.

Updated the code of the injector to also point the g_cache_file_memory_globals->tag_header.tag_instances to point to the redirected tag_instance table.