### PR TITLE
crash fix and misc

### DIFF
--- a/xlive/Blam/Engine/saved_games/cartographer_player_profile.cpp
+++ b/xlive/Blam/Engine/saved_games/cartographer_player_profile.cpp
@@ -100,6 +100,11 @@ s_saved_game_cartographer_player_profile* cartographer_player_profile_get_by_use
 
 void cartographer_player_profile_sign_in(e_controller_index controller_index, uint32 enumerated_file_index)
 {
+	// The game will re-sign in the profiles when switching between maps no need to
+	// re-read the profile binary unless the player has actually signed out
+	if (enumerated_file_index == g_cartographer_profiles[controller_index].enumerated_file_index)
+		return;
+
 	s_saved_game_cartographer_player_profile* current_profile = &g_cartographer_profiles[controller_index].profile;
 
 	g_cartographer_profiles[controller_index].enumerated_file_index = enumerated_file_index;

--- a/xlive/Blam/Engine/saved_games/saved_game_files.cpp
+++ b/xlive/Blam/Engine/saved_games/saved_game_files.cpp
@@ -78,7 +78,7 @@ bool saved_games_get_file_info(s_saved_game_main_menu_globals_save_file_info* ou
 			{
 				if (enumerated_index == saved_game_files_globals->cached_save_files[i]->enumerated_index)
 				{
-					csmemcpy(out_info, &saved_game_files_globals->cached_save_files[i]->file_info, saved_game_files_globals->cached_save_files.get_type_size());
+					csmemcpy(out_info, &saved_game_files_globals->cached_save_files[i]->file_info, sizeof(s_saved_game_main_menu_globals_save_file_info));
 					return true;
 				}
 			}

--- a/xlive/Blam/Engine/saved_games/saved_game_files_async_windows.cpp
+++ b/xlive/Blam/Engine/saved_games/saved_game_files_async_windows.cpp
@@ -47,9 +47,9 @@ void saved_games_async_helper_get_saved_game_bin_path(uint32 enumerated_file_ind
 	s_saved_game_main_menu_globals_save_file_info file_info{};
 	saved_games_get_file_info(&file_info, enumerated_file_index);
 
-	wcsncpy(out_path, file_info.file_path, 256);
-	wcscat(out_path, binary_name);
-	wcscat(out_path, L".bin");
+	ustrnzcpy(out_path, file_info.file_path, NUMBEROF(file_info.file_path));
+	ustrnzcat(out_path, binary_name, ustrnlen(binary_name, NUMBEROF(file_info.file_path)));
+	ustrnzcat(out_path, L".bin", 4);
 	return;
 }
 
@@ -132,9 +132,9 @@ bool __cdecl saved_games_async_helper_read_file_internal(int enumerated_index, v
 		uint32 abs_index = (enumerated_index >> 8) & 0x1FFF;
 		uint32 last_index = saved_game_globals->default_save_files.get_count() - 1;
 
-		// Removed check of buffer_size so it can read the entry from the globals
-		// potentially unsafe will have to come up with a way to verify if this was actually needed or not.
-		if ((abs_index <= last_index || abs_index == last_index))
+		// checking the size of the buffer is not specifically for player_profile it is whatever the
+		// largest structure that can be stored in the default save files static_array is.
+		if (abs_index <= last_index && buffer_size <= sizeof(s_saved_game_player_profile))
 		{
 			csmemcpy(buffer, saved_game_globals->default_save_files[abs_index]->buffer, buffer_size);
 			in_out_completion->unk_2 = true;


### PR DESCRIPTION
fixed a crash when loading between different singleplayer maps. the code for getting the saved game file info used an incorrect size for copying memory when using cached save files.

prevented the cartographer profile from being loaded multiple times after already being signed in, due to how the game reloads the player profile saved_game in between loading screens.