### PR TITLE
adjust header includes

### DIFF
--- a/xlive/Blam/Cache/TagGroups/scenario_lightmap_definition.hpp
+++ b/xlive/Blam/Cache/TagGroups/scenario_lightmap_definition.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "math/color_math.h"
+#include "tag_files/data_reference.h"
 #include "tag_files/tag_block.h"
 #include "tag_files/tag_reference.h"
-
 
 
 /*********************************************************************
@@ -642,7 +642,7 @@ struct s_scenario_structure_lightmap_group_definition
 	PAD(0xC);//0x88
 	struct s_errors_block
 	{
-		static_string256 name;//0x0
+		char name[256];//0x0
 		enum class e_report_type : __int16
 		{
 			silent = 0,
@@ -681,7 +681,7 @@ struct s_scenario_structure_lightmap_group_definition
 			};
 			e_flags flags;//0x2
 			data_reference text;//0x4
-			static_string32 source_filename;//0xC
+			char source_filename[32];//0xC
 			__int32 source_line_number;//0x2C
 			struct s_vertices_block
 			{

--- a/xlive/Blam/Engine/ai/actors.h
+++ b/xlive/Blam/Engine/ai/actors.h
@@ -3,8 +3,8 @@
 #include "actor_moving.h"
 #include "pathfinding_utilities.h"
 
+#include "game/game_allegiance.h"
 #include "memory/data.h"
-#include "objects/objects.h"
 #include "objects/object_placement.h"
 
 

--- a/xlive/Blam/Engine/ai/ai_scenario_definitions.h
+++ b/xlive/Blam/Engine/ai/ai_scenario_definitions.h
@@ -1,7 +1,6 @@
 #pragma once
-#include "cseries/cseries_strings.h"
+#include "game/game_allegiance.h"
 #include "tag_files/tag_block.h"
-#include "objects/objects.h"
 
 
 enum e_combination_rule : short
@@ -13,7 +12,7 @@ enum e_combination_rule : short
 // max count: 100
 struct squad_group_definition
 {
-    static_string32 name;
+    char name[32];
     short parent;           // Block index: squad_groups_definition
     short initial_orders;   // Block index: orders_definition
 };
@@ -104,7 +103,7 @@ struct actor_starting_location_definition
     float initial_movement_distance;        // before doing anything else, the actor will travel the given distance in its forward direction
     short emitter_vehicle;                  // Block index: scenario_vehicle
     e_initial_movement_mode initial_movement_mode;
-    static_string32 placement_script;
+    char placement_script[32];
     short placement_script_index;
     short unk;
 };
@@ -113,7 +112,7 @@ ASSERT_STRUCT_SIZE(actor_starting_location_definition, 100);
 // max count: 335
 struct squad_definition
 {
-    static_string32 name;
+    char name[32];
     e_squad_definition_flags flags;
     e_game_team team;
     short parent;                           // Block index: squad_group_definition
@@ -135,7 +134,7 @@ struct squad_definition
     short initial_order;                    // Block index: orders
     string_id vehicle_variant;
     tag_block<actor_starting_location_definition> starting_locations;
-    static_string32 placement_script;
+    char placement_script[32];
     short placement_script_index;
     short unk;
 };
@@ -144,7 +143,7 @@ ASSERT_STRUCT_SIZE(squad_definition, 116);
 // max count: 128
 struct ai_animation_reference_definition
 {
-    static_string32 animation_name;
+    char animation_name[32];
     // leave this blank to use the unit's normal animation graph
     tag_reference animation_graph;   // jmad
     int padding540[3];
@@ -154,7 +153,7 @@ ASSERT_STRUCT_SIZE(ai_animation_reference_definition, 52);
 // max count: 128
 struct ai_script_reference_definition
 {
-    static_string32 script_name;
+    char script_name[32];
     int64_t pad;
 };
 ASSERT_STRUCT_SIZE(ai_script_reference_definition, 40);
@@ -162,7 +161,7 @@ ASSERT_STRUCT_SIZE(ai_script_reference_definition, 40);
 // max count: 128
 struct ai_recording_reference_definition
 {
-    static_string32 recording_name;
+    char recording_name[32];
     int64_t pad;
 };
 ASSERT_STRUCT_SIZE(ai_recording_reference_definition, 40);

--- a/xlive/Blam/Engine/ai/path.h
+++ b/xlive/Blam/Engine/ai/path.h
@@ -4,10 +4,10 @@
 #include "sector_geometry.h"
 #include "sector_environment_objects.h"
 
-
-#include "tag_files/tag_block.h"
 #include "physics/collision_bsp.h"
+#include "structures/instanced_geometry_definitions.h"
 #include "structures/structures.h"
+#include "tag_files/tag_block.h"
 
 enum e_pathfinding_hint_type : short
 {

--- a/xlive/Blam/Engine/cache/pc_geometry_cache.h
+++ b/xlive/Blam/Engine/cache/pc_geometry_cache.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "memory/data.h"
-#include "models/render_model_definitions.h"
+#include "geometry/geometry_block.h"
 
 struct pc_geometry_cache_geometry_block
 {

--- a/xlive/Blam/Engine/camera/first_person_camera.cpp
+++ b/xlive/Blam/Engine/camera/first_person_camera.cpp
@@ -1,11 +1,10 @@
 #include "stdafx.h"
 #include "first_person_camera.h"
 
-#include "camera.h"
 #include "director.h"
 #include "observer.h"
 #include "game/game_globals.h"
-#include "H2MOD/Modules/Shell/Config.h"
+#include "game/player_control.h"
 #include "saved_games/cartographer_player_profile.h"
 #include "units/units.h"
 #include "units/unit_definitions.h"

--- a/xlive/Blam/Engine/camera/observer.cpp
+++ b/xlive/Blam/Engine/camera/observer.cpp
@@ -8,7 +8,6 @@
 #include "game/game_time.h"
 #include "H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.h"
 #include "interface/first_person_weapons.h"
-#include "networking/Session/NetworkSession.h"
 #include "physics/collisions.h"
 #include "render/render_visibility_collection.h"
 #include "scenario/scenario.h"

--- a/xlive/Blam/Engine/cartographer/tag_fixes/tag_fixes.cpp
+++ b/xlive/Blam/Engine/cartographer/tag_fixes/tag_fixes.cpp
@@ -161,7 +161,8 @@ void tag_fixes_misty_rain(void)
 				// Set the field in the scenario
 				scenario* scenario_definition = get_global_scenario();
 				structure_weather_palette_entry* palette = scenario_definition->weather_palette[0];
-				palette->name.set("misty_cs");
+				const char name[] = "misty_cs";
+				csstrnzcpy(palette->name, name, NUMBEROF(name));
 				palette->weather_system.group.group = _tag_group_weather_system;
 				palette->weather_system.index = misty_rain_datum;
 
@@ -169,10 +170,10 @@ void tag_fixes_misty_rain(void)
 				for(int32 i = 0; i < scenario_definition->structure_bsps.count; ++i)
 				{
 					structure_bsp* bsp_definition = (structure_bsp*)tag_get_fast(get_global_scenario()->structure_bsps[i]->structure_bsp.index);
-					structure_weather_palette_entry* palette = bsp_definition->weather_palette[0];
-					palette->name.set("misty_cs");
-					palette->weather_system.group.group = _tag_group_weather_system;
-					palette->weather_system.index = misty_rain_datum;
+					structure_weather_palette_entry* bsp_palette = bsp_definition->weather_palette[0];
+					csstrnzcpy(bsp_palette->name, name, NUMBEROF(name));
+					bsp_palette->weather_system.group.group = _tag_group_weather_system;
+					bsp_palette->weather_system.index = misty_rain_datum;
 				}
 			}
 		}

--- a/xlive/Blam/Engine/cseries/cseries_windows_minidump_logs.cpp
+++ b/xlive/Blam/Engine/cseries/cseries_windows_minidump_logs.cpp
@@ -15,7 +15,7 @@ const wchar_t* k_report_text_file_names[k_report_text_file_type_count] = { L"exc
 
 // globals
 
-c_static_wchar_string260 g_report_text_file_paths[k_report_text_file_type_count];
+static c_static_wchar_string<MAX_PATH> g_report_text_file_paths[k_report_text_file_type_count];
 
 // forward declarations
 
@@ -279,7 +279,7 @@ void setup_game_options_text(const wchar_t* reports_path)
         fwprintf(file, L"Is Custom Map: ");
         print_bool_to_file(file, game_options->is_custom_map);
 
-        fwprintf(file, L"Custom Map Name: %ls\n", game_options->custom_map_name.get_string());
+        fwprintf(file, L"Custom Map Name: %ls\n", game_options->custom_map_name);
 
         fwprintf(file, L"Campaign ID: ");
         fwprintf(file, L"%d\n", game_options->campaign_id);
@@ -287,7 +287,7 @@ void setup_game_options_text(const wchar_t* reports_path)
         fwprintf(file, L"Map ID: ");
         fwprintf(file, L"%d\n", game_options->map_id);
 
-        fwprintf(file, L"Scenario Path: %ls\n", game_options->scenario_path.get_string());
+        fwprintf(file, L"Scenario Path: %ls\n", game_options->scenario_path);
 
         fwprintf(file, L"Map ID: ");
         fwprintf(file, L"%d\n", game_options->map_id);

--- a/xlive/Blam/Engine/decorators/decorator_definitions.h
+++ b/xlive/Blam/Engine/decorators/decorator_definitions.h
@@ -6,10 +6,26 @@
 #include "geometry/geometry_block.h"
 #include "math/color_math.h"
 
+/* constants */
 
 #define k_maximum_cache_block_count 4096
 #define k_maximum_group_count = 131072
 #define k_maximum_cell_collection_count 65535
+
+/* enums */
+
+enum e_decorator_type : int8
+{
+    _decorator_type_model = 0,
+    _decorator_type_floating_decal = 1,
+    _decorator_type_projected_decal = 2,
+    _decorator_type_screen_facing_quad = 3,
+    _decorator_type_axis_rotating_quad = 4,
+    _decorator_type_cross_quad = 5,
+    k_decorator_type_count
+};
+
+/* structures */
 
 // max count: 32*k_kilo 32768
 struct s_decorator_placement
@@ -63,16 +79,6 @@ public:
 };
 ASSERT_STRUCT_SIZE(c_decorator_cache_block, 52);
 
-enum e_decorator_type : char
-{
-    decorator_type_model = 0,
-    decorator_type_floating_decal = 1,
-    decorator_type_projected_decal = 2,
-    decorator_type_screen_facing_quad = 3,
-    decorator_type_axis_rotating_quad = 4,
-    decorator_type_cross_quad = 5
-};
-
 // max count: k_maximum_group_count 131072
 struct s_decorator_group
 {
@@ -91,6 +97,8 @@ struct s_decorator_group
     int compressed_bounding_center;
 };
 ASSERT_STRUCT_SIZE(s_decorator_group, 24);
+
+/* classes */
 
 // max count: k_maximum_cell_collection_count 65535
 class c_decorator_cell_collection

--- a/xlive/Blam/Engine/devices/devices.h
+++ b/xlive/Blam/Engine/devices/devices.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "objects/objects.h"
 #include "objects/object_definition.h"
 #include "tag_files/tag_reference.h"
 

--- a/xlive/Blam/Engine/effects/effects.h
+++ b/xlive/Blam/Engine/effects/effects.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "objects/damage.h"
 #include "objects/object_placement.h"
 #include "math/color_math.h"
 #include "math/matrix_math.h"

--- a/xlive/Blam/Engine/effects/player_effects.h
+++ b/xlive/Blam/Engine/effects/player_effects.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "camera/observer.h"
+#include "game/players.h"
 #include "math/matrix_math.h"
 #include "math/periodic_functions.h"
-#include "networking/Session/NetworkSession.h"
 
 enum e_player_effect_user_global_flags : uint8
 {

--- a/xlive/Blam/Engine/game/game_allegiance.h
+++ b/xlive/Blam/Engine/game/game_allegiance.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/* enums */
+
+enum e_game_team : int16
+{
+	// MP
+	_game_team_red = 0,
+	_game_team_blue = 1,
+	_game_team_yellow = 2,
+	_game_team_green = 3,
+	_game_team_purple = 4,
+	_game_team_orange = 5,
+	_game_team_brown = 6,
+	_game_team_pink = 7,
+	_game_team_neutral = 8,
+
+	k_game_multiplayer_team_count = 8,
+
+	// SP
+	_game_team_default = 0,
+	_game_team_player = 1,
+	_game_team_human = 2,
+	_game_team_covenant = 3,
+	_game_team_flood = 4,
+	_game_team_sentinel = 5,
+	_game_team_heretic = 6,
+	_game_team_prophet = 7,
+
+	// unassigned team ids
+	_game_team_unused8 = 8,
+	_game_team_unused9 = 9,
+	_game_team_unused10 = 10,
+	_game_team_unused11 = 11,
+	_game_team_unused12 = 12,
+	_game_team_unused13 = 13,
+	_game_team_unused14 = 14,
+	_game_team_unused15 = 15,
+
+	// Shared
+	_game_team_none = NONE
+};

--- a/xlive/Blam/Engine/game/game_engine.h
+++ b/xlive/Blam/Engine/game/game_engine.h
@@ -1,6 +1,10 @@
 #pragma once
+#include "game/game_allegiance.h"
 #include "game_statborg.h"
-#include "networking/Session/NetworkSession.h"
+#include "math/color_math.h"
+#include "tag_files/string_id.h"
+#include "tag_files/tag_block.h"
+#include "tag_files/tag_reference.h"
 
 /* constants */
 

--- a/xlive/Blam/Engine/game/game_globals.h
+++ b/xlive/Blam/Engine/game/game_globals.h
@@ -15,7 +15,6 @@
 
 
 #define NUMBER_OF_GLOBAL_SOUNDS 2
-#define k_unit_grenade_types_count 2
 #define k_global_vertex_shader_count 32
 #define k_maximum_material_types 256
 #define k_game_globals_maximum_multiplayer_colors 32

--- a/xlive/Blam/Engine/game/game_options.h
+++ b/xlive/Blam/Engine/game/game_options.h
@@ -1,21 +1,20 @@
 #pragma once
-#include "cseries/cseries_strings.h"
-#include "game/players.h"
+#include "networking/Session/NetworkSession.h"
 #include "saved_games/game_variant.h"
 #include "simulation/machine_id.h"
 
-enum e_game_simulation : __int8
+enum e_game_simulation : int8
 {
-	_game_simulation_none = 0x0,
-	_game_simulation_local = 0x1,
-	_game_simulation_synchronous_client = 0x2,
-	_game_simulation_synchronous_server = 0x3,
-	_game_simulation_distributed_client = 0x4,
-	_game_simulation_distributed_server = 0x5,
-	k_game_simulation_count = 0x6,
+	_game_simulation_none = 0,
+	_game_simulation_local = 1,
+	_game_simulation_synchronous_client = 2,
+	_game_simulation_synchronous_server = 3,
+	_game_simulation_distributed_client = 4,
+	_game_simulation_distributed_server = 5,
+	k_game_simulation_count,
 };
 
-enum e_game_mode : int
+enum e_game_mode : int32
 {
 	_game_mode_campaign = 1,
 	_game_mode_multiplayer = 2,
@@ -31,7 +30,7 @@ struct game_player_options
 	bool player_valid;
 	bool player_left_game;
 	int16 user_index;
-	int32 controller_index;
+	e_controller_index controller_index;
 	s_machine_identifier machine_identifier;
 	s_player_identifier player_identifier;
 	int16 field_16;
@@ -45,40 +44,40 @@ struct s_game_options
 {
 	e_game_mode game_mode;
 	e_game_simulation simulation_type;
-	char network_protocol_related;
+	int8 network_protocol_related;
 	bool session_host_is_dedicated;
 	bool scenario_custom;
-	short game_tick_rate;
-	short pad_C[3];
-	byte random_data[8];
-	int random_seed;
+	int16 game_tick_rate;
+	int16 pad_C[3];
+	uint8 random_data[8];
+	int32 random_seed;
 	bool is_custom_map;
-	byte field_1D;
-	c_static_wchar_string<48> custom_map_name;
-	short pad_7E;
-	int campaign_id;						// This should always be 1, since there can be multiple "camapaigns". However, this isn't taken advantage of in the retail game 
-	int map_id;
-	c_static_wchar_string260 scenario_path;
-	short initial_bsp_index;
-	short field_292;
+	uint8 field_1D;
+	wchar_t custom_map_name[48];
+	int16 pad_7E;
+	int32 campaign_id;						// This should always be 1, since there can be multiple "camapaigns". However, this isn't taken advantage of in the retail game 
+	int32 map_id;
+	wchar_t scenario_path[MAX_PATH];
+	int16 initial_bsp_index;
+	int16 field_292;
 	bool load_level_only;
-	byte local_peer_index;
+	uint8 local_peer_index;
 	bool dump_object_log;
 	bool dump_random_seeds;
 	bool playtest_mode;
-	byte pad_299;
-	short difficulty;
+	uint8 pad_299;
+	int16 difficulty;
 	bool coop;
-	byte player_count;
-	short pad_29E;
+	uint8 player_count;
+	int16 pad_29E;
 	s_game_variant game_variant;
-	DWORD menu_context;
-	DWORD valid_machine_mask;
-	s_machine_identifier machines[17];
+	uint32 menu_context;
+	uint32 valid_machine_mask;
+	s_machine_identifier machines[k_network_maximum_machines_per_session];
 	bool local_machine_exists;
 	s_machine_identifier local_machine_identifier;
-	char pad_444[3];
-	game_player_options players[16]; 
+	int8 pad_444[3];
+	game_player_options players[k_maximum_players]; 
 };
 ASSERT_STRUCT_SIZE(s_game_options, 4488);
 

--- a/xlive/Blam/Engine/game/game_portals.h
+++ b/xlive/Blam/Engine/game/game_portals.h
@@ -1,9 +1,12 @@
 #pragma once
-
 #include "objects/object_identifier.h"
 #include "tag_files/tag_block.h"
 
+/* constants */
+
 #define k_maximum_machine_door_portal_associations 128
+
+/* structures */
 
 // max: k_maximum_machine_door_portal_associations
 struct s_structure_portal_device_machine_association

--- a/xlive/Blam/Engine/game/player_vibration.h
+++ b/xlive/Blam/Engine/game/player_vibration.h
@@ -1,6 +1,6 @@
 #pragma once
+#include "game/players.h"
 #include "math/function_definitions.h"
-#include "networking/Session/NetworkSession.h"
 
 #define k_count_of_effects_that_effect_vibration 8 
 

--- a/xlive/Blam/Engine/game/players.cpp
+++ b/xlive/Blam/Engine/game/players.cpp
@@ -116,7 +116,8 @@ datum s_player::get_unit_index(datum player_index)
 	return get(player_index)->unit_index;
 }
 
-void s_player::set_player_unit_grenade_count(datum player_index, e_unit_grenade_type type, int8 count, bool reset_equipment)
+// TODO: remove this
+void s_player::set_player_unit_grenade_count(datum player_index, int16 type, int8 count, bool reset_equipment)
 {
     int32 abs_player_index = DATUM_INDEX_TO_ABSOLUTE_INDEX(player_index);
     datum unit_datum_index = s_player::get_unit_index(player_index);
@@ -136,24 +137,6 @@ void s_player::set_player_unit_grenade_count(datum player_index, e_unit_grenade_
 
         LOG_TRACE_GAME("set_player_unit_grenade_count() - sending grenade simulation update, playerIndex={0}, peerIndex={1}", abs_player_index, NetworkSession::GetPeerIndex(abs_player_index));
     }
-}
-
-unit_datum* s_player::get_player_unit_data(datum player_index)
-{
-    datum unit_index = s_player::get_unit_index(player_index);
-    if (unit_index == NONE)
-        return nullptr;
-
-    return (unit_datum*)object_get_fast_unsafe(unit_index);
-}
-
-real_point3d* s_player::get_unit_coords(datum player_index)
-{
-    unit_datum* player_unit = get_player_unit_data(player_index);
-    if (player_unit != nullptr)
-        return &player_unit->object.position;
-
-    return nullptr;
 }
 
 uint64 s_player::get_id(datum player_index)

--- a/xlive/Blam/Engine/game/players.h
+++ b/xlive/Blam/Engine/game/players.h
@@ -1,13 +1,12 @@
 #pragma once
-
+#include "game/game_allegiance.h"
 #include "input/controllers.h"
 #include "memory/data.h"
 #include "objects/damage_reporting.h"
 #include "objects/emblems.h"
-#include "objects/objects.h"
 #include "simulation/machine_id.h"
-#include "units/units.h"
 
+#define k_number_of_users 4
 #define k_maximum_players 16
 #define k_player_index_bit_count 4	// 4 because 4 bits can store 16 players in k_maximum_players
 
@@ -184,12 +183,10 @@ struct s_player
 	static s_player* get_from_unit_index(datum unit_index);
 	static void set_team(datum player_index, e_game_team team);
 	static void set_unit_character_type(datum player_index, e_character_type character_type);
-	static void set_player_unit_grenade_count(datum player_index, e_unit_grenade_type type, int8 count, bool reset_equipment);
+	static void set_player_unit_grenade_count(datum player_index, int16 type, int8 count, bool reset_equipment);
 	static void set_unit_speed(datum player_index, float speed);
 	static const wchar_t* get_name(datum player_index);
 	static datum get_unit_index(datum player_index);
-	static unit_datum* get_player_unit_data(datum player_index);
-	static real_point3d* get_unit_coords(datum player_index);
 	static uint64 get_id(datum player_index);
 };
 ASSERT_STRUCT_SIZE(s_player, 516);

--- a/xlive/Blam/Engine/geometry/geometry_definitions_new.h
+++ b/xlive/Blam/Engine/geometry/geometry_definitions_new.h
@@ -1,9 +1,8 @@
 #pragma once
-
+#include "math/color_math.h"
 #include "rasterizer/rasterizer_vertex_buffers.h"
 #include "tag_files/tag_reference.h"
 #include "tag_files/data_reference.h"
-#include "math/color_math.h"
 
 #define MAXIMUM_PARTS_PER_GEOMETRY_SECTION 255
 #define MAXIMUM_SUBPARTS_PER_SECTION 32768

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -10,10 +10,9 @@
 #include "main/interpolator.h"
 #include "models/models.h"
 #include "models/render_model_definitions.h"
-#include "objects/object_definition.h"
-#include "objects/objects.h"
-#include "tag_files/global_string_ids.h"
 #include "render/render_objects.h"
+#include "tag_files/global_string_ids.h"
+#include "units/units.h"
 
 bool show_first_person = true;
 

--- a/xlive/Blam/Engine/interface/motion_sensor.cpp
+++ b/xlive/Blam/Engine/interface/motion_sensor.cpp
@@ -6,7 +6,6 @@
 
 #include "game/game_time.h"
 #include "game/players.h"
-#include "networking/Session/NetworkSession.h"
 
 
 #define k_radar_size_multiplier 1.f

--- a/xlive/Blam/Engine/interface/motion_sensor.h
+++ b/xlive/Blam/Engine/interface/motion_sensor.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "networking/Session/NetworkSession.h"
+#include "game/players.h"
 
 enum e_motion_sensor_blip_size : int16
 {

--- a/xlive/Blam/Engine/interface/new_hud.h
+++ b/xlive/Blam/Engine/interface/new_hud.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "game/game_engine_territories.h"
 #include "game/players.h"
-#include "networking/Session/NetworkSession.h"
+#include "math/color_math.h"
 
 /* enums */
 

--- a/xlive/Blam/Engine/interface/new_hud_draw.cpp
+++ b/xlive/Blam/Engine/interface/new_hud_draw.cpp
@@ -11,6 +11,7 @@
 #include "render/render.h"
 #include "saved_games/cartographer_player_profile.h"
 #include "text/draw_string.h"
+#include "text/unicode.h"
 
 /* globals */
 

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.h
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.h
@@ -1,6 +1,6 @@
 #pragma once
-
 #include "interface/user_interface_headers.h"
+#include "main/game_preferences.h"
 
 #include "H2MOD/Modules/Accounts/Accounts.h"
 

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.h
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.h
@@ -4,6 +4,7 @@
 
 #include "interface/user_interface_headers.h"
 
+#include "main/game_preferences.h"
 #include "H2MOD/Modules/Updater/Updater.h"
 
 void* ui_load_cartographer_guide_menu();

--- a/xlive/Blam/Engine/interface/screens/screen_multiplayer_pregame_lobby.h
+++ b/xlive/Blam/Engine/interface/screens/screen_multiplayer_pregame_lobby.h
@@ -1,11 +1,10 @@
 #pragma once
-
+#include "game/game_allegiance.h"
 #include "interface/user_interface_widget_window.h"
 #include "interface/user_interface_widget_text.h"
 #include "interface/user_interface_widget_button.h"
 #include "interface/user_interface_widget_text_entry.h"
 #include "interface/signal_slot.h"
-#include "game/players.h"
 
 /* macro defines */
 

--- a/xlive/Blam/Engine/interface/user_interface_controller.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_controller.cpp
@@ -1,12 +1,13 @@
 #include "stdafx.h"
 #include "user_interface_controller.h"
+
 #include "user_interface_guide.h"
+
 #include "networking/online/online_account_xbox.h"
 #include "saved_games/cartographer_player_profile.h"
-#include "saved_games/saved_game_files_async_windows.h"
 #include "tag_files/global_string_ids.h"
-
-
+#include "tag_files/string_id.h"
+#include "text/unicode.h"
 
 
 s_user_interface_controller_globals* user_interface_controller_globals_get(void)
@@ -270,19 +271,19 @@ void __cdecl user_interface_controller_update_player_name(e_controller_index con
 		if (online_xuid_is_guest_account(*controller_xuid))
 		{
 			uint8 guest_no = online_xuid_get_guest_account_number(*controller_xuid);
-			c_static_wchar_string32 format;
-			user_interface_global_string_get(_string_id_guest_of_ascii_gamertag_unicode_format_string, format.get_buffer());// %d %hs
-			usnzprintf(controller->player_name.get_buffer(),
-				controller->player_name.max_length(),
-				format.get_string(),
+			wchar_t format[32];
+			user_interface_global_string_get(_string_id_guest_of_ascii_gamertag_unicode_format_string, format);// %d %hs
+			usnzprintf(controller->player_name,
+				NUMBEROF(controller->player_name),
+				format,
 				guest_no,
 				guide->m_gamertag);
 
 		}
 		else
 		{
-			usnzprintf(controller->player_name.get_buffer(),
-				controller->player_name.max_length(),
+			usnzprintf(controller->player_name,
+				NUMBEROF(controller->player_name),
 				L"%hs",
 				guide->m_gamertag);
 
@@ -293,11 +294,11 @@ void __cdecl user_interface_controller_update_player_name(e_controller_index con
 	}
 	else if (user_interface_controller_is_player_profile_valid(controller_index))
 	{
-		controller->player_name.set(controller->player_profile.name);
+		ustrncpy(controller->player_name, controller->player_profile.name, NUMBEROF(controller->player_profile.name));
 	}
 	else
 	{
-		controller->player_name.clear();
+		controller->player_name[0] = '\0';
 	}
 	user_interface_controller_update_network_properties(controller_index);
 }

--- a/xlive/Blam/Engine/interface/user_interface_controller.h
+++ b/xlive/Blam/Engine/interface/user_interface_controller.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "game/game_allegiance.h"
 #include "input/controllers.h"
 #include "saved_games/player_profile.h"
 
@@ -160,7 +160,7 @@ struct s_user_interface_controller
 	int8 achievement_flags;
 	PAD24;
 	s_player_identifier field_1234;
-	c_static_wchar_string32 player_name;
+	wchar_t player_name[32];
 };
 ASSERT_STRUCT_SIZE(s_user_interface_controller, 4732);
 

--- a/xlive/Blam/Engine/interface/user_interface_networking.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_networking.cpp
@@ -5,7 +5,6 @@
 #include "user_interface_controller.h"
 
 #include "networking/logic/life_cycle_manager.h"
-#include "networking/Session/NetworkSession.h"
 
 bool* byte_D6840E_get(void)
 {

--- a/xlive/Blam/Engine/interface/user_interface_player_widget.h
+++ b/xlive/Blam/Engine/interface/user_interface_player_widget.h
@@ -1,8 +1,7 @@
 #pragma once
 #include "user_interface_group_widget.h"
 #include "user_interface_screen_widget_definition.h"
-#include "game/players.h"
-
+#include "game/game_allegiance.h"
 
 /* classes */
 

--- a/xlive/Blam/Engine/items/weapon_definitions.cpp
+++ b/xlive/Blam/Engine/items/weapon_definitions.cpp
@@ -1,9 +1,6 @@
 #include "stdafx.h"
 #include "weapon_definitions.h"
 
-#include "H2MOD/Tags/TagInterface.h"
-
-
 weapon_first_person_interface_definition* first_person_interface_definition_get(const _weapon_definition* definition, e_character_type character_type)
 {
     weapon_first_person_interface_definition* result = NULL;

--- a/xlive/Blam/Engine/main/interpolator.h
+++ b/xlive/Blam/Engine/main/interpolator.h
@@ -1,6 +1,6 @@
 #pragma once
+#include "game/players.h"
 #include "models/render_models.h"
-#include "networking/Session/NetworkSession.h"
 
 #define k_interpolation_first_person_weapon_slot_count 4
 #define k_interpolation_positions_count 2

--- a/xlive/Blam/Engine/main/main_game.cpp
+++ b/xlive/Blam/Engine/main/main_game.cpp
@@ -4,9 +4,7 @@
 #include "cache/cache_files.h"
 #include "cseries/cseries_strings.h"
 #include "game/game.h"
-#include "networking/Session/NetworkSession.h"
 #include "saved_games/game_variant.h"
-
 
 
 s_game_options g_main_game_launch_options = {};
@@ -29,7 +27,7 @@ void main_game_initialize(void)
 
 void main_game_launch_set_map_name(const char* map_name)
 {
-    MultiByteToWideChar(CP_UTF8, 0, map_name, -1, g_main_game_launch_options.scenario_path.get_buffer(), 260);
+    MultiByteToWideChar(CP_UTF8, 0, map_name, -1, g_main_game_launch_options.scenario_path, 260);
     return;
 }
 

--- a/xlive/Blam/Engine/models/render_models.h
+++ b/xlive/Blam/Engine/models/render_models.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "math/matrix_math.h"
-#include "tag_files/string_id.h"
 #include "objects/objects.h"
+#include "tag_files/string_id.h"
 
 #define MAXIMUM_REGIONS_PER_MODEL 16
 #define MAXIMUM_PERMUTATIONS_PER_MODEL_REGION 32

--- a/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.cpp
+++ b/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.cpp
@@ -2,6 +2,7 @@
 #include "NetworkMessageTypeCollection.h"
 
 #include "cartographer/twizzler/twizzler.h"
+#include "game/game_allegiance.h"
 #include "interface/user_interface_controller.h"
 #include "memory/bitstream.h"
 #include "networking/transport/network_channel.h"

--- a/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.h
+++ b/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "objects/objects.h"
+#include "game/game_allegiance.h"
 
 #define player_identifier_size_bits (sizeof(unsigned long long) * CHAR_BIT)
 

--- a/xlive/Blam/Engine/networking/Session/NetworkSession.h
+++ b/xlive/Blam/Engine/networking/Session/NetworkSession.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "game/players.h"
 #include "input/controllers.h"
 #include "networking/Transport/transport.h"
@@ -44,8 +43,7 @@ struct s_membership_player;
 struct s_membership_peer;
 struct s_session_observer_channel;
 
-#define k_network_maximum_machines_per_session (16 + 1)
-#define k_number_of_users 4
+#define k_network_maximum_machines_per_session (k_maximum_players + 1)
 
 namespace NetworkSession
 {

--- a/xlive/Blam/Engine/networking/logic/life_cycle_manager.h
+++ b/xlive/Blam/Engine/networking/logic/life_cycle_manager.h
@@ -86,7 +86,7 @@ public:
 	int32 field_54;
 	int32 joining_user_count;
 	s_player_identifier player_identifiers[k_number_of_users];
-	wchar_t player_names[k_number_of_users][16];
+	wchar_t player_names[k_number_of_users][XUSER_NAME_SIZE];
 	int8 gapFC[128];
 	int32 field_17C;
 	bool field_180;

--- a/xlive/Blam/Engine/objects/light_definitions.h
+++ b/xlive/Blam/Engine/objects/light_definitions.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "memory/static_arrays.h"
 #include "math/function_definitions.h"
 #include "tag_files/tag_block.h"
 #include "tag_files/tag_reference.h"

--- a/xlive/Blam/Engine/objects/object_types.cpp
+++ b/xlive/Blam/Engine/objects/object_types.cpp
@@ -1,8 +1,7 @@
 #include "stdafx.h"
 #include "object_types.h"
 
-#include "object_placement.h"
-
+#include "objects.h"
 
 object_type_definition** get_object_type_definitions(void)
 {

--- a/xlive/Blam/Engine/objects/objects.h
+++ b/xlive/Blam/Engine/objects/objects.h
@@ -12,45 +12,6 @@
 
 #define k_maximum_objects_per_map 2048
 
-enum e_game_team : int16
-{
-	// MP
-	_game_team_red = 0,
-	_game_team_blue = 1,
-	_game_team_yellow = 2,
-	_game_team_green = 3,
-	_game_team_purple = 4,
-	_game_team_orange = 5,
-	_game_team_brown = 6,
-	_game_team_pink = 7,
-	_game_team_neutral = 8,
-
-	k_game_multiplayer_team_count = 8,
-
-	// SP
-	_game_team_default = 0,
-	_game_team_player = 1,
-	_game_team_human = 2,
-	_game_team_covenant = 3,
-	_game_team_flood = 4,
-	_game_team_sentinel = 5,
-	_game_team_heretic = 6,
-	_game_team_prophet = 7,
-
-	// unassigned team ids
-	_game_team_unused8 = 8,
-	_game_team_unused9 = 9,
-	_game_team_unused10 = 10,
-	_game_team_unused11 = 11,
-	_game_team_unused12 = 12,
-	_game_team_unused13 = 13,
-	_game_team_unused14 = 14,
-	_game_team_unused15 = 15,
-
-	// Shared
-	_game_team_none = NONE
-};
-
 enum e_object_data_flags : int32
 {
 	_object_hidden_bit = 0,

--- a/xlive/Blam/Engine/physics/character_physics_mode_melee.cpp
+++ b/xlive/Blam/Engine/physics/character_physics_mode_melee.cpp
@@ -4,7 +4,6 @@
 #include "game/game.h"
 #include "game/game_time.h"
 #include "math/math.h"
-#include "Util/Memory.h"
 
 FLOATING_POINT_ENV_ACCESS();
 

--- a/xlive/Blam/Engine/physics/structure_physics.h
+++ b/xlive/Blam/Engine/physics/structure_physics.h
@@ -2,6 +2,8 @@
 #include "tag_files/data_reference.h"
 #include "tag_files/tag_block.h"
 
+/* structures */
+
 // max: (8*1024) 8192
 struct s_structure_physics_breakable_surface_key_value
 {

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_water.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_water.cpp
@@ -6,6 +6,7 @@
 #include "rasterizer_dx9_targets.h"
 
 #include "camera/camera.h"
+#include "structures/structure_bsp_definitions.h"
 
 /* prototypes */
 

--- a/xlive/Blam/Engine/render/render_debug_structure.h
+++ b/xlive/Blam/Engine/render/render_debug_structure.h
@@ -1,9 +1,13 @@
 #pragma once
 #include "tag_files/tag_block.h"
 
+/* constants */
+
 #define MAXIMUM_CLUSTERS_PER_STRUCTURE 512
 #define MAXIMUM_FOG_PLANES_PER_STRUCTURE 127
 #define MAXIMUM_FOG_ZONES_PER_STRUCTURE 127
+
+/* enums */
 
 enum e_structure_debug_info_render_line_type : uint16
 {
@@ -28,6 +32,8 @@ enum e_structure_cluster_debug_errors : uint16
 	_structure_cluster_debug_error_fog_zone_collision = FLAG(1),
 	_structure_cluster_debug_error_fog_zone_immersion = FLAG(2)
 };
+
+/* structures */
 
 // max: SHORT_MAX
 struct s_structure_debug_info_render_line

--- a/xlive/Blam/Engine/render/render_lights.cpp
+++ b/xlive/Blam/Engine/render/render_lights.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "render_lights.h"
 
+/* public code */
+
 void __cdecl render_lights(void)
 {
 	INVOKE(0x14CB17, 0x0, render_lights);

--- a/xlive/Blam/Engine/render/render_lights.h
+++ b/xlive/Blam/Engine/render/render_lights.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "math/color_math.h"
 
+/* structures */
 
 // max: 1
 struct render_lighting
@@ -18,6 +19,7 @@ struct render_lighting
 };
 ASSERT_STRUCT_SIZE(render_lighting, 84);
 
+/* prototypes */
 
 void __cdecl render_lights(void);
 

--- a/xlive/Blam/Engine/render/render_lod_new.cpp
+++ b/xlive/Blam/Engine/render/render_lod_new.cpp
@@ -1,13 +1,12 @@
 #include "stdafx.h"
-
 #include "render_lod_new.h"
 
 #include "render.h"
-#include "render/render_objects.h"
 
+#include "game/player_control.h"
 #include "models/render_models.h"
-
 #include "rasterizer/rasterizer_memory.h"
+#include "render/render_objects.h"
 
 #include "H2MOD/Modules/Shell/Config.h"
 

--- a/xlive/Blam/Engine/render/render_water.h
+++ b/xlive/Blam/Engine/render/render_water.h
@@ -5,6 +5,8 @@
 #include "tag_files/tag_block.h"
 #include "tag_files/tag_reference.h"
 
+/* structures */
+
 // max: 1
 struct s_water_definition
 {

--- a/xlive/Blam/Engine/saved_games/player_profile.h
+++ b/xlive/Blam/Engine/saved_games/player_profile.h
@@ -1,10 +1,9 @@
 #pragma once
-
 #include "game_variant.h"
-#include "cseries/cseries.h"
+
 #include "game/players.h"
-#include "H2MOD/Modules/Input/ControllerInput.h"
 #include "input/input_abstraction.h"
+#include "memory/static_arrays.h"
 
 #define k_default_profiles_count 1
 

--- a/xlive/Blam/Engine/saved_games/saved_game_files.cpp
+++ b/xlive/Blam/Engine/saved_games/saved_game_files.cpp
@@ -2,6 +2,7 @@
 #include "saved_game_files.h"
 
 #include "cache/physical_memory_map.h"
+#include "text/unicode.h"
 
 /* globals */
 

--- a/xlive/Blam/Engine/saved_games/saved_game_files_async_windows.cpp
+++ b/xlive/Blam/Engine/saved_games/saved_game_files_async_windows.cpp
@@ -5,6 +5,7 @@
 
 #include "cseries/async.h"
 #include "tag_files/files_windows.h"
+#include "text/unicode.h"
 
 /* typedefs */
 

--- a/xlive/Blam/Engine/scenario/scenario.cpp
+++ b/xlive/Blam/Engine/scenario/scenario.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "scenario.h"
 
+#include "structures/structure_bsp_definitions.h"
+
 scenario* get_global_scenario(void) 
 {
 	return *Memory::GetAddress<scenario**>(0x479E74, 0x4A6430);

--- a/xlive/Blam/Engine/scenario/scenario_definitions.h
+++ b/xlive/Blam/Engine/scenario/scenario_definitions.h
@@ -3,7 +3,6 @@
 #include "scenario_interpolators.h"
 #include "scenario_kill_trigger_volumes.h"
 
-
 #include "ai/ai_flocks.h"
 #include "ai/ai_mission_dialogue.h"
 #include "ai/ai_orders.h"
@@ -12,7 +11,6 @@
 #include "ai/path.h"
 #include "ai/zone.h"
 #include "cache/predicted_resources.h"
-#include "cseries/cseries_strings.h"
 #include "decorators/decorator_definitions.h"
 #include "editor/editor_flags.h"
 #include "game/game_engine_spawning.h"
@@ -27,10 +25,10 @@
 #include "sound/sound_scenery.h"
 #include "structures/cluster_partitions.h"
 #include "structures/structure_audibility.h"
+#include "structures/structure_bsp_definitions.h"
 #include "tag_files/string_id.h"
 #include "tag_files/tag_block.h"
 #include "text/text.h"
-
 
 #define MAXIMUM_CHILD_SCENARIOS_PER_SCENARIO 16
 #define MAXIMUM_FUNCTIONS_PER_SCENARIO 32
@@ -123,7 +121,7 @@ enum e_bounds_mode : short
 struct scenario_function
 {
     e_scenario_function_flags flags;
-    static_string32 name;
+    char name[32];
     float period_seconds;               // Period for above function (lower values make function oscillate quickly; higher values make it oscillate slowly).
     
     // Multiply this function by above period
@@ -177,7 +175,7 @@ ASSERT_STRUCT_SIZE(scenario_environment_object, 64);
 // max count: MAXIMUM_OBJECT_NAMES_PER_SCENARIO 640
 struct scenario_object_name
 {
-    static_string32 name;
+    char name[32];
     e_object_type type;
     int8 pad;
     short placement_index;
@@ -421,7 +419,7 @@ enum e_device_group_flags : int
 // max count: MAXIMUM_DEVICE_GROUPS_PER_SCENARIO 128
 struct scenario_device_group
 {
-    static_string32 name;
+    char name[32];
     float initial_value;
     e_device_group_flags flags;
 };
@@ -578,7 +576,7 @@ ASSERT_STRUCT_SIZE(s_scenario_light, 108);
 // max count: MAXIMUM_SCENARIO_PLAYERS_PER_BLOCK 256
 struct scenario_starting_profile
 {
-    static_string32 name;
+    char name[32];
     float starting_health_damage;
     float starting_shield_damage;
     tag_reference primary_weapon;    // weap
@@ -670,7 +668,7 @@ ASSERT_STRUCT_SIZE(scenario_trigger_volume, 68);
 // max count: MAXIMUM_RECORDED_ANIMATIONS_PER_MAP 1024
 struct recorded_animation_definition
 {
-    static_string32 name;
+    char name[32];
     byte version;
     byte raw_animation_data;
     byte unit_control_data_version;
@@ -845,7 +843,7 @@ ASSERT_STRUCT_SIZE(character_palette_entry, 8);
 // max count: k_maximum_hs_scripts_per_scenario 1024
 struct hs_script
 {
-    static_string32 name;
+    char name[32];
     e_hs_script_type script_type;
     e_hs_type return_type;
     datum root_expression_index;
@@ -855,8 +853,8 @@ ASSERT_STRUCT_SIZE(hs_script, 40);
 // max count: MAXIMUM_CUTSCENE_FLAGS_PER_SCENARIO 512
 struct scenario_cutscene_flag
 {
-    int pad;
-    static_string32 name;
+    int32 pad;
+    char name[32];
     real_point3d position;
     real_euler_angles2d facing;
 };
@@ -880,7 +878,7 @@ struct scenario_cutscene_camera_point
 {
     e_cutscene_camera_point_flags flags;
     e_cutscene_camera_point_type type;
-    static_string32 name;
+    char name[32];
     
     /* cmed */
     int pad;
@@ -1052,7 +1050,7 @@ ASSERT_STRUCT_SIZE(s_scenario_structure_bsp_spherical_harmonic_lighting, 16);
 struct s_scenario_editor_folder
 {
     int parent_folder;                              // Block index: scenario_editor_folder
-    static_string256 name;
+    char name[256];
 };
 ASSERT_STRUCT_SIZE(s_scenario_editor_folder, 260);
 

--- a/xlive/Blam/Engine/simulation/game_interface/simulation_game_units.h
+++ b/xlive/Blam/Engine/simulation/game_interface/simulation_game_units.h
@@ -1,8 +1,7 @@
 #pragma once
-#include "simulation_game_entities.h"
 #include "simulation_game_objects.h"
 #include "game/players.h"
-
+#include "units/units.h"
 
 struct s_simulation_unit_state_data
 {

--- a/xlive/Blam/Engine/simulation/simulation_queue_entities.cpp
+++ b/xlive/Blam/Engine/simulation/simulation_queue_entities.cpp
@@ -3,6 +3,7 @@
 
 #include "simulation_gamestate_entities.h"
 
+#include "cseries/cseries_strings.h"
 #include "game/game.h"
 #include "simulation/simulation.h"
 #include "simulation/simulation_entity_database.h"

--- a/xlive/Blam/Engine/sound/sound_clusters.h
+++ b/xlive/Blam/Engine/sound/sound_clusters.h
@@ -1,8 +1,12 @@
 #pragma once
 #include "tag_files/tag_block.h"
 
+/* constants */
+
 #define MAXIMUM_CLUSTERS_PER_STRUCTURE 512
 #define MAXIMUM_CLUSTER_PORTALS_PER_STRUCTURE 512
+
+/* structures */
 
 // max: MAXIMUM_CLUSTERS_PER_STRUCTURE
 struct s_structure_sound_cluster

--- a/xlive/Blam/Engine/structures/instanced_geometry_definitions.h
+++ b/xlive/Blam/Engine/structures/instanced_geometry_definitions.h
@@ -1,11 +1,11 @@
 #pragma once
-
 #include "leaf_map.h"
 #include "structures.h"
+
 #include "geometry/geometry_block.h"
 #include "geometry/geometry_definitions_new.h"
-#include "physics/collision_model_definitions.h"
 #include "math/matrix_math.h"
+#include "physics/collision_model_definitions.h"
 
 #define k_maximum_instance_geometry_instances_per_structure_bsp 1024
 #define k_maximum_instance_geometry_definitions_per_structure_bsp 512

--- a/xlive/Blam/Engine/structures/structure_audibility.h
+++ b/xlive/Blam/Engine/structures/structure_audibility.h
@@ -1,7 +1,5 @@
 #pragma once
-
 #include "tag_files/tag_reference.h"
-#include "cseries/cseries_strings.h"
 
 #define k_maximum_cluster_sound_palette_entries_per_structure 64
 #define k_maximum_machine_door_portal_associations 128
@@ -17,7 +15,7 @@ enum e_background_sound_scale_flags : int
 // max count: k_maximum_cluster_sound_palette_entries_per_structure 64
 struct structure_background_sound_palette_entry
 {
-    static_string32 name;
+    char name[32];
     tag_reference background_sound;         // lsnd
 
     // Play only when player is inside cluster.
@@ -38,7 +36,7 @@ ASSERT_STRUCT_SIZE(structure_background_sound_palette_entry, 100);
 // max count: k_maximum_cluster_sound_palette_entries_per_structure 64
 struct structure_sound_environment_palette_entry
 {
-    static_string32 name;
+    char name[32];
     tag_reference sound_environment;    // snde
     float cutoff_distance;
     float interpolation_speed;          // 1 sec

--- a/xlive/Blam/Engine/structures/structure_bsp_definitions.cpp
+++ b/xlive/Blam/Engine/structures/structure_bsp_definitions.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "structure_bsp_definitions.h"
-#include "Util/Memory.h"
 
 int16 get_global_structure_bsp_index(void)
 {

--- a/xlive/Blam/Engine/structures/structure_bsp_definitions.h
+++ b/xlive/Blam/Engine/structures/structure_bsp_definitions.h
@@ -4,6 +4,7 @@
 #include "structure_audibility.h"
 #include "structure_lightmap_definitions.h"
 #include "structure_runtime_decals.h"
+
 #include "ai/path.h"
 #include "cache/predicted_resources.h"
 #include "decorators/decorator_definitions.h"
@@ -126,7 +127,7 @@ ASSERT_STRUCT_SIZE(structure_weather_polyhedron, 24);
 // max count: MAXIMUM_WEATHER_PALETTE_ENTRIES_PER_STRUCTURE 32
 struct structure_weather_palette_entry
 {
-    static_string32 name;
+    char name[32];
     tag_reference weather_system;   // weat
     short pad[2];
     int pad1[8];
@@ -134,7 +135,7 @@ struct structure_weather_palette_entry
     real_vector3d wind_direction;
     float wind_magnitude;
     int pad2;
-    static_string32 wind_scale_function;
+    char wind_scale_function[32];
 };
 ASSERT_STRUCT_SIZE(structure_weather_palette_entry, 136);
 
@@ -250,7 +251,7 @@ struct structure_breakable_surface
 // max: MAXIMUM_MARKERS_PER_STRUCTURE
 struct structure_marker
 {
-    static_string32 name;
+    char name[32];
     real_quaternion rotation;
     real_point3d position;
 };
@@ -271,14 +272,14 @@ ASSERT_STRUCT_SIZE(structure_environment_object_palette_entry, 20);
 // max: MAXIMUM_ENVIRONMENT_OBJECTS_PER_STRUCTURE
 struct structure_environment_object
 {
-    static_string32 name;
+    char name[32];
     real_quaternion rotation;
     real_point3d translation;
     // BlockIndex1("structure_bsp_environment_object_palette_block")
     uint16 palette_index;
     datum unique_id;
-    c_static_string<4> exported_object_type;
-	static_string32 scenario_object_name;
+    char exported_object_type[4];
+	char scenario_object_name[32];
 };
 ASSERT_STRUCT_SIZE(structure_environment_object, 104);
 

--- a/xlive/Blam/Engine/structures/structure_lightmap_definitions.h
+++ b/xlive/Blam/Engine/structures/structure_lightmap_definitions.h
@@ -1,7 +1,7 @@
 #pragma once
+#include "objects/object_identifier.h"
 #include "render/render_lights.h"
 #include "tag_files/tag_reference.h"
-#include "objects/object_identifier.h"
 
 #define MAXIMUM_LIGHTS_PER_MAP 350
 #define MAXIMUM_LIGHTMAP_GROUPS_PER_STRUCTURE 128

--- a/xlive/Blam/Engine/structures/structure_runtime_decals.h
+++ b/xlive/Blam/Engine/structures/structure_runtime_decals.h
@@ -1,6 +1,10 @@
 #pragma once
 
+/* constants */
+
 #define MAXIMUM_DECALS_PER_STRUCTURE 6144
+
+/* structures */
 
 // max: MAXIMUM_DECALS_PER_STRUCTURE
 struct structure_runtime_decal

--- a/xlive/Blam/Engine/units/unit_definitions.h
+++ b/xlive/Blam/Engine/units/unit_definitions.h
@@ -5,9 +5,9 @@
 
 #include "ai/ai.h"
 
+#include "game/game_allegiance.h"
 #include "interface/motion_sensor.h"
 #include "objects/object_definition.h"
-#include "objects/objects.h"
 
 enum e_unit_definition_flags : int32
 {

--- a/xlive/Blam/Engine/units/units.h
+++ b/xlive/Blam/Engine/units/units.h
@@ -1,5 +1,6 @@
 #pragma once
-#include "game/player_control.h"
+#include "game/aim_assist.h"
+#include "game/game_allegiance.h"
 #include "objects/objects.h"
 
 #define MAXIMUM_NUMBER_OF_UNIT_CAMERA_TRACKS 2

--- a/xlive/Blam/Engine/widgets/cloth.cpp
+++ b/xlive/Blam/Engine/widgets/cloth.cpp
@@ -5,8 +5,6 @@
 #include "memory/data.h"
 #include "objects/objects.h"
 
-
-
 void __cdecl sub_58F279(datum cloth_index)
 {
 	INVOKE(0x18F279, 0, sub_58F279, cloth_index);

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -36,7 +36,6 @@
 #include "networking/memory/networking_memory.h"
 #include "networking/network_configuration.h"
 #include "networking/Transport/transport.h"
-#include "objects/damage.h"
 #include "units/bipeds.h"
 #include "rasterizer/rasterizer_fog.h"
 #include "rasterizer/rasterizer_lens_flares.h"
@@ -483,10 +482,11 @@ bool __cdecl OnMapLoad(s_game_options* options)
 			//if anyone wants to run code on map load single player
 			addDebugText("Engine type: Singleplayer");
 			toggle_xbox_tickrate(options, true);
-			if ( H2Config_discord_enable)
+			if (H2Config_discord_enable)
 			{
-				int32 index = options->scenario_path.last_index_of(L"\\");
-				const wchar_t* scenario_name_wide = &options->scenario_path.get_string()[index + 1];
+				c_static_wchar_string<260> scenario_path(game_options_get()->scenario_path);
+				int32 index = scenario_path.last_index_of(L"\\");
+				const wchar_t* scenario_name_wide = &scenario_path.get_string()[index + 1];
 				utf8 scenario_name[MAX_PATH];
 				wchar_string_to_utf8_string(scenario_name_wide, scenario_name, sizeof(scenario_name));
 
@@ -556,23 +556,6 @@ bool BansheeBombIsEngineMPCheck() {
 
 bool FlashlightIsEngineSPCheck() {
 	return game_is_campaign();
-}
-
-void GivePlayerWeaponDatum(datum unit_datum, datum weapon_tag_index)
-{
-	if (unit_datum != NONE)
-	{
-		object_placement_data object_placement;
-
-		object_placement_data_new(&object_placement, weapon_tag_index, unit_datum, 0);
-
-		datum object_idx = object_new(&object_placement);
-		if (object_idx != NONE)
-		{
-			unit_delete_all_weapons(unit_datum);
-			unit_add_weapon_to_inventory(unit_datum, object_idx, _weapon_addition_method_one);
-		}
-	}
 }
 
 void H2MOD::team_player_indicator_visibility(bool toggle)

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
@@ -10,8 +10,9 @@
 #include "main/main_game_time.h"
 #include "networking/Session/NetworkSession.h"
 #include "networking/NetworkMessageTypeCollection.h"
-
+#include "objects/objects.h"
 #include "simulation/game_interface/simulation_game_action.h"
+#include "text/unicode.h"
 
 #include "H2MOD/GUI/imgui_integration/imgui_handler.h"
 #include "H2MOD/Modules/Shell/Config.h"
@@ -635,13 +636,10 @@ int CommandCollection::SpawnCmd(const std::vector<std::string>& tokens, ConsoleC
 
 	if (nearPlayerSpawn)
 	{
-		real_point3d* localPlayerPos = s_player::get_unit_coords(localPlayerIdx);
-		if (localPlayerPos != nullptr)
-		{
-			position.x = localPlayerPos->x + 0.5f;
-			position.y = localPlayerPos->y + 0.5f;
-			position.z = localPlayerPos->z + 0.5f;
-		}
+		real_point3d* localPlayerPos = &object_get_fast_unsafe(s_player::get(localPlayerIdx)->unit_index)->position;
+		position.x = localPlayerPos->x + 0.5f;
+		position.y = localPlayerPos->y + 0.5f;
+		position.z = localPlayerPos->z + 0.5f;
 	}
 	else
 	{
@@ -759,7 +757,7 @@ void CommandCollection::ObjectSpawn(datum object_idx, int count, const real_poin
 		{
 			object_placement_data new_object_placement;
 			datum localPlayerIdx = player_index_from_user_index(0);
-			real_point3d* localPlayerPos = s_player::get_unit_coords(localPlayerIdx);
+			real_point3d* localPlayerPos = &object_get_fast_unsafe(s_player::get(localPlayerIdx)->unit_index)->position;
 
 			if (object_idx != NONE)
 			{

--- a/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.cpp
+++ b/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.cpp
@@ -9,6 +9,7 @@
 #include "networking/NetworkMessageTypeCollection.h"
 #include "networking/Session/NetworkSession.h"
 #include "physics/physics_constants.h"
+#include "units/units.h"
 
 #include "H2MOD/Modules/EventHandler/EventHandler.hpp"
 

--- a/xlive/H2MOD/Modules/Shell/ServerConsole.cpp
+++ b/xlive/H2MOD/Modules/Shell/ServerConsole.cpp
@@ -2,6 +2,7 @@
 
 #include "ServerConsole.h"
 
+#include "cseries/cseries_strings.h"
 #include "H2MOD/Modules/EventHandler/EventHandler.hpp"
 #include "H2MOD/Utils/Utils.h"
 

--- a/xlive/H2MOD/Modules/SpecialEvents/Events/Christmas.cpp
+++ b/xlive/H2MOD/Modules/SpecialEvents/Events/Christmas.cpp
@@ -82,7 +82,8 @@ void christmas_event_map_load(void)
 		// Change/Add weather system to bsp
 		structure_bsp* bsp_definition = (structure_bsp*)tag_get_fast(get_global_scenario()->structure_bsps[0]->structure_bsp.index);
 		structure_weather_palette_entry* weat_block = MetaExtender::add_tag_block2<structure_weather_palette_entry>((unsigned long)std::addressof(bsp_definition->weather_palette));
-		weat_block->name.set("snow_cs");
+		const char new_name[] = "snow_cs";
+		csstrnzcpy(weat_block->name, new_name, NUMBEROF(new_name));
 		weat_block->weather_system.group.group = _tag_group_weather_system;
 		weat_block->weather_system.index = snow_datum;
 

--- a/xlive/H2MOD/Modules/SpecialEvents/Events/Halloween.cpp
+++ b/xlive/H2MOD/Modules/SpecialEvents/Events/Halloween.cpp
@@ -10,9 +10,10 @@
 #include "models/models.h"
 #include "objects/objects.h"
 #include "scenario/scenario_definitions.h"
+#include "structures/structure_bsp_definitions.h"
+#include "tag_files/tag_loader/tag_injection.h"
 
 #include "H2MOD/Modules/EventHandler/EventHandler.hpp"
-#include "tag_files/tag_loader/tag_injection.h"
 
 datum lbitm_datum = NONE;
 datum sky_datum = NONE;

--- a/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
+++ b/xlive/H2MOD/Modules/Tweaks/Tweaks.cpp
@@ -13,7 +13,7 @@
 #include "H2MOD/Modules/OnScreenDebug/OnscreenDebug.h"
 #include "H2MOD/Modules/Shell/Config.h"
 #include "H2MOD/Utils/Utils.h"
-#include "H2MOD/Variants/VariantMPGameEngine.h"
+//#include "H2MOD/Variants/VariantMPGameEngine.h"
 
 #pragma region Done_Tweaks
 
@@ -102,6 +102,7 @@ bool __cdecl is_remote_desktop()
 	return false;
 }
 
+/*
 class c_test_engine : public c_game_engine_base
 {
 	bool is_team_enemy(int team_a, int team_b)
@@ -120,6 +121,7 @@ class c_test_engine : public c_game_engine_base
 
 };
 c_test_engine g_test_engine;
+*/
 
 void __stdcall biped_ground_mode_update_hook(int thisx,
 	void* physics_output,

--- a/xlive/H2MOD/Variants/GraveRobber/GraveRobber.cpp
+++ b/xlive/H2MOD/Variants/GraveRobber/GraveRobber.cpp
@@ -7,7 +7,6 @@
 #include "game/game_engine_util.h"
 #include "game/game_statborg.h"
 #include "items/weapons.h"
-#include "networking/Session/NetworkSession.h"
 #include "simulation/game_interface/simulation_game_action.h"
 #include "H2MOD/Modules/HaloScript/HaloScript.h"
 

--- a/xlive/H2MOD/Variants/GunGame/GunGame.cpp
+++ b/xlive/H2MOD/Variants/GunGame/GunGame.cpp
@@ -3,6 +3,7 @@
 
 #include "game/game.h"
 #include "networking/Session/NetworkSession.h"
+#include "units/units.h"
 #include "H2MOD.h"
 
 using namespace NetworkSession;

--- a/xlive/H2MOD/Variants/VariantMPGameEngine.h
+++ b/xlive/H2MOD/Variants/VariantMPGameEngine.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "objects/objects.h"
-
 enum e_game_engine_types
 {
 	invalid = -1,

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -606,6 +606,7 @@
     <ClInclude Include="Blam\Engine\game\aim_assist.h" />
     <ClInclude Include="Blam\Engine\game\cheats.h" />
     <ClInclude Include="Blam\Engine\game\game.h" />
+    <ClInclude Include="Blam\Engine\game\game_allegiance.h" />
     <ClInclude Include="Blam\Engine\game\game_engine_simulation.h" />
     <ClInclude Include="Blam\Engine\game\game_engine_spawning.h" />
     <ClInclude Include="Blam\Engine\game\game_engine_territories.h" />
@@ -890,7 +891,6 @@
     <ClCompile Include="H2MOD\Variants\GunGame\GunGame.cpp" />
     <ClCompile Include="H2MOD\Variants\H2X\H2X.cpp" />
     <ClCompile Include="H2MOD\Variants\Infection\Infection.cpp" />
-    <ClCompile Include="H2MOD\Variants\VariantMPGameEngine.cpp" />
     <ClCompile Include="H2MOD\Variants\VariantSystem.cpp" />
     <ClCompile Include="util\filesys.cpp" />
     <ClCompile Include="Util\hash.cpp" />
@@ -1325,7 +1325,6 @@
     <ClInclude Include="H2MOD\Variants\GunGame\GunGame.h" />
     <ClInclude Include="H2MOD\Variants\H2X\H2X.h" />
     <ClInclude Include="H2MOD\Variants\Infection\Infection.h" />
-    <ClInclude Include="H2MOD\Variants\VariantMPGameEngine.h" />
     <ClInclude Include="H2MOD\Variants\VariantSystem.h" />
     <ClInclude Include="resources\resource.h" />
     <ClInclude Include="util\filesys.h" />

--- a/xlive/Project_Cartographer.vcxproj.filters
+++ b/xlive/Project_Cartographer.vcxproj.filters
@@ -36,7 +36,6 @@
     <ClCompile Include="H2MOD\Variants\GunGame\GunGame.cpp" />
     <ClCompile Include="H2MOD\Variants\H2X\H2X.cpp" />
     <ClCompile Include="H2MOD\Variants\Infection\Infection.cpp" />
-    <ClCompile Include="H2MOD\Variants\VariantMPGameEngine.cpp" />
     <ClCompile Include="H2MOD\Variants\VariantSystem.cpp" />
     <ClCompile Include="util\filesys.cpp" />
     <ClCompile Include="Util\hash.cpp" />
@@ -129,7 +128,6 @@
     <ClCompile Include="Blam\Engine\interface\motion_sensor.cpp" />
     <ClCompile Include="Blam\Engine\interface\new_hud.cpp" />
     <ClCompile Include="Blam\Engine\interface\first_person_weapons.cpp" />
-    <ClCompile Include="Blam\Engine\interface\first_person_camera.cpp" />
     <ClCompile Include="Blam\Engine\game\player_control.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_lens_flares.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_settings.cpp" />
@@ -409,6 +407,7 @@
     <ClCompile Include="Blam\Engine\rasterizer\dx9\rasterizer_dx9_weather.cpp" />
     <ClCompile Include="Blam\Engine\render\render_weather.cpp" />
     <ClCompile Include="Blam\Engine\rasterizer\rasterizer_fog.cpp" />
+    <ClCompile Include="Blam\Engine\camera\first_person_camera.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="3rdparty\miniupnpc\include\miniupnpc\codelength.h" />
@@ -494,7 +493,6 @@
     <ClInclude Include="3rdparty\spdlog\include\spdlog\version.h" />
     <ClInclude Include="3rdparty\tinyxml\tinyxml2.h" />
     <ClInclude Include="Blam\Cache\TagGroups\ai_mission_dialogue_definition.hpp" />
-    <ClInclude Include="Blam\Cache\TagGroups\camera_track_definition.hpp" />
     <ClInclude Include="Blam\Cache\TagGroups\crate_definition.hpp" />
     <ClInclude Include="Blam\Cache\TagGroups\creature_definition.hpp" />
     <ClInclude Include="Blam\Cache\TagGroups\device_control_definition.hpp" />
@@ -544,7 +542,6 @@
     <ClInclude Include="H2MOD\Variants\GunGame\GunGame.h" />
     <ClInclude Include="H2MOD\Variants\H2X\H2X.h" />
     <ClInclude Include="H2MOD\Variants\Infection\Infection.h" />
-    <ClInclude Include="H2MOD\Variants\VariantMPGameEngine.h" />
     <ClInclude Include="H2MOD\Variants\VariantSystem.h" />
     <ClInclude Include="resources\resource.h" />
     <ClInclude Include="util\filesys.h" />
@@ -680,7 +677,6 @@
     <ClInclude Include="Blam\Engine\interface\hud.h" />
     <ClInclude Include="Blam\Engine\interface\motion_sensor.h" />
     <ClInclude Include="Blam\Engine\interface\new_hud.h" />
-    <ClInclude Include="Blam\Engine\interface\first_person_camera.h" />
     <ClInclude Include="Blam\Engine\interface\first_person_weapons.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_lens_flares.h" />
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_settings.h" />
@@ -1090,6 +1086,10 @@
     <ClInclude Include="Blam\Engine\rasterizer\rasterizer_fog.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\shaders\compiled\weather_particle_generic.h" />
     <ClInclude Include="Blam\Engine\rasterizer\dx9\shaders\compiled\weather_particle_rain.h" />
+    <ClInclude Include="Blam\Engine\camera\camera_track_definition.h" />
+    <ClInclude Include="Blam\Engine\camera\first_person_camera.h" />
+    <ClInclude Include="Blam\Engine\camera\following_camera.h" />
+    <ClInclude Include="Blam\Engine\game\game_allegiance.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="resources\Resource.rc" />

--- a/xlive/XLive/XUser/XUserContext.cpp
+++ b/xlive/XLive/XUser/XUserContext.cpp
@@ -2,8 +2,11 @@
 #include "XUserContext.h"
 
 #include "cartographer/discord/discord_interface.h"
+#include "cseries/cseries_strings.h"
 #include "game/game.h"
 #include "networking/Session/NetworkSession.h"
+#include "text/unicode.h"
+
 #include "H2MOD/Modules/Shell/Config.h"
 #include "H2MOD/Modules/Shell/H2MODShell.h"
 #include "XLive/xbox/xbox.h"
@@ -59,9 +62,9 @@ void context_update_map_info_multiplayer(void)
 	wchar_string_to_utf8_string(wide_map_name, map_name, sizeof(map_name));
 
 	// Get scenario name and convert to utf8
-	c_static_wchar_string260* scenario_path = &game_options_get()->scenario_path;
-	int32 index = scenario_path->last_index_of(L"\\");
-	const wchar_t* scenario_name_wide = &scenario_path->get_string()[index + 1];
+	c_static_wchar_string<260> scenario_path(game_options_get()->scenario_path);
+	int32 index = scenario_path.last_index_of(L"\\");
+	const wchar_t* scenario_name_wide = &scenario_path.get_string()[index + 1];
 	utf8 scenario_name[MAX_PATH];
 	wchar_string_to_utf8_string(scenario_name_wide, scenario_name, sizeof(scenario_name));
 

--- a/xlive/stdafx.h
+++ b/xlive/stdafx.h
@@ -37,7 +37,6 @@ static_assert(EXECUTABLE_TYPE <= 7 && EXECUTABLE_TYPE >= 0, "EXECUTABLE_TYPE VAL
 #include <wincrypt.h>
 #include <mmsystem.h>
 #include <windef.h>
-#include <codecvt>
 #include <DbgHelp.h>
 #include <ShlObj.h>
 #include <psapi.h>


### PR DESCRIPTION
- improve build time by removing header dependencies and lowering amount of times certain headers are parsed count when compiling
- remove static string usage from some structures
- move k_number_of_users to players
- remove VariantMPGameEngine from build (never been used but we'll keep it for now)
- move e_game_team to game_allegiance