### PR TITLE
fix crash when player 0 is not signed in

### DIFF
--- a/xlive/Blam/Engine/interface/new_hud.cpp
+++ b/xlive/Blam/Engine/interface/new_hud.cpp
@@ -112,7 +112,7 @@ bool __cdecl render_ingame_chat_check(void)
 	if (H2Config_hide_ingame_chat)
 	{
 		datum local_player_datum_index = player_index_from_user_index(0);
-		if (s_player::get(local_player_datum_index)->is_chatting == 2) 
+		if (local_player_datum_index != NONE && s_player::get(local_player_datum_index)->is_chatting == 2)
 		{
 			hotkeyFuncToggleHideIngameChat();
 		}


### PR DESCRIPTION
- it tried to access a player with the index of NONE, check that it's not NONE before grabbing the player