### PR TITLE
add debug_render_horizontal_splitscreen command

### DIFF
--- a/xlive/Blam/Engine/camera/camera.cpp
+++ b/xlive/Blam/Engine/camera/camera.cpp
@@ -1,14 +1,14 @@
 #include "stdafx.h"
 #include "camera.h"
 
-s_camera* get_global_camera()
+render_camera* get_global_camera()
 {
-	return Memory::GetAddress<s_camera*>(0x4E66C8);
+	return Memory::GetAddress<render_camera*>(0x4E66C8);
 }
 
-s_camera* get_effect_camera()
+render_camera* get_effect_camera()
 {
-	return Memory::GetAddress<s_camera*>(0xA3DF88);
+	return Memory::GetAddress<render_camera*>(0xA3DF88);
 }
 
 void camera_apply_patches(void)

--- a/xlive/Blam/Engine/camera/camera.h
+++ b/xlive/Blam/Engine/camera/camera.h
@@ -1,33 +1,9 @@
 #pragma once
-
-struct s_camera
-{
-	real_point3d point;
-	real_vector3d forward;
-	real_vector3d up;
-	bool bool_0;
-	int8 pad[3];
-	real32 vertical_field_of_view;
-	real32 scale;
-	rectangle2d viewport_bounds;
-	rectangle2d window_bounds;
-	real32 z_near;
-	real32 z_far;
-	real_point3d point1;
-	int8 gap_4C[4];
-	bool tiled;
-	int8 pad1[3];
-	real32 unk_floats[3];
-	bool bool_2;
-	int8 pad2[3];
-	real32 frustum_multiplier_x;
-	real32 frustum_multiplier_y;
-};
-ASSERT_STRUCT_SIZE(s_camera, 0x74);
+#include "render/render_cameras.h"
 
 // Get global camera data
-s_camera* get_global_camera(void);
+render_camera* get_global_camera(void);
 
-s_camera* get_effect_camera();
+render_camera* get_effect_camera();
 
 void camera_apply_patches(void);

--- a/xlive/Blam/Engine/camera/observer.cpp
+++ b/xlive/Blam/Engine/camera/observer.cpp
@@ -212,3 +212,8 @@ void observer_set_suggested_field_of_view(float fov)
 	}
 	*Memory::GetAddress<float*>(0x413780, 0x3B5300) = final_fov_rad;
 }
+
+s_observer_result* __cdecl observer_get_camera(int32 user_index)
+{
+	return INVOKE(0x81EBA, 0x0, observer_get_camera, user_index);
+}

--- a/xlive/Blam/Engine/camera/observer.h
+++ b/xlive/Blam/Engine/camera/observer.h
@@ -16,7 +16,7 @@ struct s_observer_result
 {
 	real_point3d position;
 	s_location location;
-	real_vector3d field_14;
+	real_vector3d velocity;
 	real_vector3d forward;
 	real_vector3d up;
 	real32 horizontal_field_of_view;
@@ -103,5 +103,7 @@ float observer_suggested_field_of_view();
 
 // Sets the FOV value for the observer camera
 void observer_set_suggested_field_of_view(float fov);
+
+s_observer_result* __cdecl observer_get_camera(int32 user_index);
 
 void observer_apply_patches(void);

--- a/xlive/Blam/Engine/effects/particle_emitter.cpp
+++ b/xlive/Blam/Engine/effects/particle_emitter.cpp
@@ -17,7 +17,7 @@ void c_particle_emitter::adjust_matrix_and_vector_to_effect_camera(bool use_effe
 {
 	if (use_effect_camera)
 	{
-		s_camera* effect_camera = get_effect_camera();
+		render_camera* effect_camera = get_effect_camera();
 		real_matrix3x3 effect_camera_matrix;
 
 		*out_matrix = this->m_matrix;

--- a/xlive/Blam/Engine/game/game.cpp
+++ b/xlive/Blam/Engine/game/game.cpp
@@ -108,6 +108,12 @@ bool game_in_progress(void)
 	return get_main_game_globals() && get_main_game_globals()->game_in_progress;
 }
 
+bool game_is_active(void)
+{
+    const s_main_game_globals* g_main_game_globals = get_main_game_globals();
+    return g_main_game_globals && g_main_game_globals->map_active && g_main_game_globals->active_structure_bsp_index != NONE;
+}
+
 bool game_is_authoritative(void)
 {
 	return game_options_get()->simulation_type != _game_simulation_distributed_client;

--- a/xlive/Blam/Engine/game/game.h
+++ b/xlive/Blam/Engine/game/game.h
@@ -80,6 +80,7 @@ bool game_is_multiplayer(void);
 bool game_is_ui_shell(void);
 void __cdecl game_shell_set_in_progress();
 bool game_in_progress(void);
+bool game_is_active(void);
 bool game_is_predicted(void);
 bool game_is_distributed(void);
 bool game_is_server(void);

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -620,7 +620,7 @@ int32 __cdecl first_person_weapon_build_models(int32 user_index, datum unit_inde
                         }
                     }
                     real_matrix4x3 camera_matrix;
-                    s_camera* global_camera = get_global_camera();
+                    render_camera* global_camera = get_global_camera();
                     matrix4x3_from_point_and_vectors(&camera_matrix, &global_camera->point, &global_camera->forward, &global_camera->up);
                     if (TEST_BIT(first_person_data->flags, 2))
                     {

--- a/xlive/Blam/Engine/interface/hud_draw.cpp
+++ b/xlive/Blam/Engine/interface/hud_draw.cpp
@@ -4,9 +4,9 @@
 #include "interface.h"
 
 #include "bitmaps/bitmap_group.h"
+#include "camera/camera.h"
 #include "cache/pc_texture_cache.h"
 #include "game/players.h"
-#include "render/render_cameras.h"
 #include "units/units.h"
 
 void hud_render_player_indicator(datum player_index)
@@ -22,7 +22,7 @@ void hud_render_player_indicator(datum player_index)
     render_projection* global_projection = global_projection_get();
     matrix4x3_transform_point(&global_projection->world_to_view, &head_position, &world_position);
 
-    const s_camera* global_camera = get_global_camera();
+    const render_camera* global_camera = get_global_camera();
     real_point2d screen_point;
     if (render_camera_world_to_screen(global_camera, global_projection, NULL, &world_position, &screen_point))
     {

--- a/xlive/Blam/Engine/interface/interface.cpp
+++ b/xlive/Blam/Engine/interface/interface.cpp
@@ -15,7 +15,7 @@
 
 /* prototypes */
 
-e_split_type get_splitscreen_split_type(void);
+e_screen_split_type get_splitscreen_split_type(void);
 void set_display_type(e_display_type display_type);
 void render_splitscreen_line(void);
 
@@ -93,9 +93,9 @@ void __cdecl interface_draw_bitmap(
 
 /* private code */
 
-e_split_type get_splitscreen_split_type(void)
+e_screen_split_type get_splitscreen_split_type(void)
 {
-	return *Memory::GetAddress<e_split_type*>(0x4E6970);
+	return *Memory::GetAddress<e_screen_split_type*>(0x4E6970);
 }
 
 void set_display_type(e_display_type display_type)
@@ -122,7 +122,7 @@ void render_splitscreen_line(void)
 	color.color = k_splitscreen_line_colour;
 	if (player_window_count > 1)
 	{
-		if (get_splitscreen_split_type() == _split_type_vertical)
+		if (get_splitscreen_split_type() == _screen_split_type_half)
 		{
 			line.top = (resolution_y / 2) - line_size;
 			line.left = 0;

--- a/xlive/Blam/Engine/interface/interface.cpp
+++ b/xlive/Blam/Engine/interface/interface.cpp
@@ -15,7 +15,7 @@
 
 /* prototypes */
 
-e_screen_split_type get_splitscreen_split_type(void);
+e_display_type get_display_split_type(void);
 void set_display_type(e_display_type display_type);
 void render_splitscreen_line(void);
 
@@ -93,9 +93,9 @@ void __cdecl interface_draw_bitmap(
 
 /* private code */
 
-e_screen_split_type get_splitscreen_split_type(void)
+e_display_type get_display_split_type(void)
 {
-	return *Memory::GetAddress<e_screen_split_type*>(0x4E6970);
+	return *Memory::GetAddress<e_display_type*>(0x4E6970);
 }
 
 void set_display_type(e_display_type display_type)
@@ -122,7 +122,7 @@ void render_splitscreen_line(void)
 	color.color = k_splitscreen_line_colour;
 	if (player_window_count > 1)
 	{
-		if (get_splitscreen_split_type() == _screen_split_type_half)
+		if (get_display_split_type() == _display_split_type_horizontal)
 		{
 			line.top = (resolution_y / 2) - line_size;
 			line.left = 0;

--- a/xlive/Blam/Engine/interface/interface.h
+++ b/xlive/Blam/Engine/interface/interface.h
@@ -25,12 +25,6 @@ enum e_interface_tag : uint8
     NUMBER_OF_INTERFACE_TAGS
 };
 
-enum e_split_type : int32
-{
-	_split_type_horizontal = 0,
-	_split_type_vertical = 1
-};
-
 /* public code */
 
 void apply_interface_hooks(void);

--- a/xlive/Blam/Engine/interface/motion_sensor.cpp
+++ b/xlive/Blam/Engine/interface/motion_sensor.cpp
@@ -133,7 +133,7 @@ void motion_sensor_update_with_delta(real32 delta)
 
 void motion_sensor_render_update(real_point2d* position, real32 pulse)
 {
-	s_camera* global_camera = get_global_camera();
+	render_camera* global_camera = get_global_camera();
 
 	position->x -= global_camera->viewport_bounds.left;
 	position->x -= global_camera->window_bounds.left;

--- a/xlive/Blam/Engine/interface/new_hud.cpp
+++ b/xlive/Blam/Engine/interface/new_hud.cpp
@@ -133,7 +133,7 @@ bool __cdecl render_ingame_chat_check(void)
 real_point2d* __cdecl ui_get_hud_element_position_hook(e_hud_anchor anchor, real_point2d* point)
 {
 	real32 safe_area = *Memory::GetAddress<real32*>(0x9770F0);
-	s_camera* global_camera = get_global_camera();
+	render_camera* global_camera = get_global_camera();
 
 	real32 scale_factor = *get_secondary_hud_scale();
 

--- a/xlive/Blam/Engine/main/main_render.cpp
+++ b/xlive/Blam/Engine/main/main_render.cpp
@@ -2,11 +2,31 @@
 #include "main_render.h"
 
 #include "main_screenshot.h"
+
+#include "cutscene/cinematics.h"
+#include "rasterizer/dx9/rasterizer_dx9_main.h"
+#include "rasterizer/rasterizer_main.h"
 #include "render/render_cartographer_ingame_ui.h"
+
+/* globals */
+
+window_bound g_window_bounds[6];
+
+bool g_debug_render_horizontal_splitscreen = false;
+bool g_debug_force_all_player_views_to_default = false;
 
 /*  prototypes */
 
-void main_render_hook(void);
+static void main_render_hook(void);
+
+static void compute_window_bounds_to_usercall(
+	window_bound* window,
+	int32 single_view,
+	int32 user_index,
+	int32 window_bound_index,
+	int32 window_count,
+	e_display_split_type display_split_type,
+	s_observer_result* observer_result);
 
 /* public code */
 
@@ -15,17 +35,179 @@ void main_render_apply_patches(void)
 	// this is replacing a nullsub
 	PatchCall(Memory::GetAddress(0x19228E), main_render_hook);
 
+	PatchCall(Memory::GetAddress(0x27009A), main_render);
+	PatchCall(Memory::GetAddress(0x2700A5), main_render_previous_backbuffer);
+	return;
+}
+
+void __cdecl main_render(void)
+{
+	uint32 player_window_count;
+	if (cinematic_in_progress())
+	{
+		player_window_count = 1;
+	}
+	else if (local_player_count() >= 1)
+	{
+		player_window_count = MIN(local_player_count(), MAXIMUM_PLAYER_WINDOWS);
+	}
+	else
+	{
+		player_window_count = 1;
+	}
+
+	uint32 window_count = player_window_count + 1;
+
+	ASSERT(player_window_count <= MAXIMUM_PLAYER_WINDOWS);
+	ASSERT(window_count <= MAXIMUM_RENDERED_WINDOWS);
+
+	e_display_split_type display_split_type;
+	if (player_window_count <= 1)
+	{
+		display_split_type = _display_split_type_none;
+	}
+	else
+	{
+		const bool use_horizontal_split = g_debug_render_horizontal_splitscreen || rasterizer_get_display_type() == _display_type_4_by_3;
+		display_split_type = use_horizontal_split ? _display_split_type_horizontal : _display_split_type_vertical;
+	}
+
+	int32 user_index = NONE;
+	window_bound* player_windows = &g_window_bounds[1];
+	for (uint32 window_num = 0; window_num < window_count; ++window_num)
+	{
+		s_observer_result* observer_result = NULL;
+		if (g_debug_force_all_player_views_to_default)
+		{
+			break;
+		}
+
+		// TODO: another debug global condition here:
+
+
+		if (++user_index < k_number_of_users)
+		{
+			while (!players_user_is_active(user_index))
+			{
+				if (++user_index >= 4)
+				{
+					user_index = NONE;
+				}
+			}
+		}
+		else
+		{
+			user_index = NONE;
+		}
+
+		if (user_index != NONE)
+		{
+			observer_result = observer_get_camera(user_index);
+		}
+
+		compute_window_bounds_to_usercall(&player_windows[window_num], 0, user_index, window_num, player_window_count, display_split_type, observer_result);
+	}
+
+	window_bound* window = &g_window_bounds[window_count];
+	window->window_bound_index = NONE;
+	window->user_index = NONE;
+	window->single_view = 1;
+	rasterizer_get_screen_and_frame_bounds(
+		&window->rasterizer_camera.viewport_bounds,
+		&window->rasterizer_camera.window_bounds);
+	set_window_camera_values(&window->rasterizer_camera, 0, 0, 0);
+
+	window->render_camera = window->rasterizer_camera;
+	if (screenshot_render(&g_window_bounds[1]))
+	{
+		render_frame(3, window_count, player_window_count, display_split_type, &g_window_bounds[1]);
+	}
+
+	return;
+}
+
+
+void __cdecl main_render_previous_backbuffer(int32 a1, int32 a2)
+{
+	g_window_bounds[0].single_view = 1;
+	g_window_bounds[0].window_bound_index = NONE;
+	g_window_bounds[0].user_index = NONE;
+	rasterizer_get_screen_and_frame_bounds(
+		&g_window_bounds[0].rasterizer_camera.viewport_bounds,
+		&g_window_bounds[0].rasterizer_camera.window_bounds);
+
+	set_window_camera_values(&g_window_bounds[0].rasterizer_camera, 0, 0, 0);
+	
+	g_window_bounds[0].render_camera = g_window_bounds[0].rasterizer_camera;
+	render_nonplayer_frame(g_window_bounds);
+
+
+	s_rasterizer_dx9_main_globals* rasterizer_dx9_globals = rasterizer_dx9_main_globals_get();
+	IDirect3DSurface9* backbuffer;
+	if (screenshot_in_progress())
+	{
+		backbuffer = rasterizer_dx9_globals->global_d3d_surface_screenshot;
+		rasterizer_dx9_globals->global_d3d_surface_screenshot->AddRef();
+	}
+	else
+	{
+		rasterizer_dx9_globals->global_d3d_device->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &backbuffer);
+	}
+
+	rasterizer_dx9_globals->global_d3d_device->StretchRect(
+		rasterizer_dx9_globals->global_d3d_surface_render_primary,
+		NULL,
+		backbuffer,
+		NULL,
+		D3DTEXF_NONE);
+
+	if (backbuffer)
+	{
+		backbuffer->Release();
+	}
+
+	return;
+}
+
+void __cdecl set_window_camera_values(render_camera* camera, s_observer_result* result, int16* a3, int16* a4)
+{
+	INVOKE(0x194E75, 0x0, set_window_camera_values, camera, result, a3, a4);
 	return;
 }
 
 /* private code */
 
-void main_render_hook(void)
+static void main_render_hook(void)
 {
 	if (!cubemap_screenshot_in_progress())
 	{
 		render_cartographer_ingame_ui();
 	}
 
+	return;
+}
+
+static void compute_window_bounds_to_usercall(
+	window_bound* window,
+	int32 single_view,
+	int32 user_index,
+	int32 window_bound_index,
+	int32 window_count,
+	e_display_split_type display_split_type,
+	s_observer_result* observer_result)
+{
+	void* compute_window_bounds = (void*)Memory::GetAddress(0x26FA84);
+	__asm
+	{
+		push observer_result
+		push display_split_type
+		push window_count
+		push window_bound_index
+		push window
+		mov ecx, user_index
+		mov eax, single_view
+		call compute_window_bounds
+		add esp, 20
+	}
 	return;
 }

--- a/xlive/Blam/Engine/main/main_render.h
+++ b/xlive/Blam/Engine/main/main_render.h
@@ -1,5 +1,23 @@
 #pragma once
+#include "camera/observer.h"
+#include "render/render_cameras.h"
+
+/* constants */
+
+#define MAXIMUM_PLAYER_WINDOWS 4
+#define MAXIMUM_RENDERED_WINDOWS 9
+
+/* globals */
+
+extern bool g_debug_render_horizontal_splitscreen;
+extern bool g_debug_force_all_player_views_to_default;
 
 /* prototypes */
 
 void main_render_apply_patches(void);
+
+void __cdecl main_render(void);
+
+void __cdecl main_render_previous_backbuffer(int32 a1, int32 a2);
+
+void __cdecl set_window_camera_values(render_camera* camera, s_observer_result* result, int16* a3, int16* a4);

--- a/xlive/Blam/Engine/main/main_screenshot.cpp
+++ b/xlive/Blam/Engine/main/main_screenshot.cpp
@@ -52,9 +52,9 @@ static void screenshot_cubemap_retrieve_rotation_info(
 	int32 width);
 
 /* dumps camera info to a text file */
-static void __cdecl dump_camera_to_file(const char* camera_name, const s_camera* camera);
+static void __cdecl dump_camera_to_file(const char* camera_name, const render_camera* camera);
 
-static void __cdecl screenshot_cubemap_set_camera_rotation(int32 face_index, int32 resolution, const real_point3d* location, s_camera* camera);
+static void __cdecl screenshot_cubemap_set_camera_rotation(int32 face_index, int32 resolution, const real_point3d* location, render_camera* camera);
 
 static void screenshot_calculate_bloom(bitmap_data* bitmap, int32 horizontal_tile, int32 vertical_tile);
 
@@ -649,13 +649,13 @@ static void screenshot_cubemap_retrieve_rotation_info(
 	return;
 }
 
-static void __cdecl dump_camera_to_file(const char* camera_name, const s_camera* camera)
+static void __cdecl dump_camera_to_file(const char* camera_name, const render_camera* camera)
 {
 	INVOKE(0x2735CA, 0x0, dump_camera_to_file, camera_name, camera);
 	return;
 }
 
-static void __cdecl screenshot_cubemap_set_camera_rotation(int32 face_index, int32 resolution, const real_point3d* location, s_camera* camera)
+static void __cdecl screenshot_cubemap_set_camera_rotation(int32 face_index, int32 resolution, const real_point3d* location, render_camera* camera)
 {
 	INVOKE(0x2788CB, 0x0, screenshot_cubemap_set_camera_rotation, face_index, resolution, location, camera);
 	return;

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
@@ -693,7 +693,7 @@ bool __cdecl rasterizer_dx9_device_initialize(s_rasterizer_parameters* parameter
 
 void __cdecl rasterizer_dx9_initialize_camera_projection(
     bool is_texture_camera,
-    const s_camera* camera,
+    const render_camera* camera,
     const render_projection* projection,
     e_rasterizer_target rasterizer_target)
 {

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.h
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.h
@@ -123,7 +123,7 @@ bool __cdecl rasterizer_dx9_device_initialize(s_rasterizer_parameters* parameter
 
 void __cdecl rasterizer_dx9_initialize_camera_projection(
     bool is_texture_camera,
-    const s_camera* camera,
+    const render_camera* camera,
     const render_projection* projection,
     e_rasterizer_target rasterizer_target);
 

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_targets.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_targets.cpp
@@ -166,7 +166,7 @@ bool __cdecl rasterizer_dx9_set_render_target_internal(IDirect3DSurface9* target
 
 void __cdecl rasterizer_set_render_target_internal_hook_set_viewport(IDirect3DSurface9* target, IDirect3DSurface9* z_stencil, bool a3)
 {
-	const s_camera* global_camera = get_global_camera();
+	const render_camera* global_camera = get_global_camera();
 
     // NOTE: *ONLY* use this function for entire screen surfaces (e.g the backbuffer, a render target)
 

--- a/xlive/Blam/Engine/rasterizer/rasterizer_globals.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_globals.cpp
@@ -34,3 +34,10 @@ void rasterizer_get_frame_bounds(rectangle2d* frame_bounds)
 	*frame_bounds = rasterizer_globals_get()->frame_bounds;
 	return;
 }
+
+void rasterizer_get_screen_and_frame_bounds(rectangle2d* screen_bounds, rectangle2d* frame_bounds)
+{
+	rasterizer_get_screen_bounds(screen_bounds);
+	rasterizer_get_frame_bounds(frame_bounds);
+	return;
+}

--- a/xlive/Blam/Engine/rasterizer/rasterizer_globals.h
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_globals.h
@@ -16,8 +16,8 @@ enum e_rasterizer_window_mode : uint32
 
 enum e_display_type : uint8
 {
-	_display_type_widescreen = 0,
-	_display_type_4_by_3 = 1
+	_display_type_4_by_3 = 0,
+	_display_type_widescreen = 1,
 };
 
 /* structures */
@@ -132,3 +132,5 @@ uint32 rasterizer_get_height(void);
 void rasterizer_get_screen_bounds(rectangle2d* screen_bounds);
 
 void rasterizer_get_frame_bounds(rectangle2d* frame_bounds);
+
+void rasterizer_get_screen_and_frame_bounds(rectangle2d* screen_bounds, rectangle2d* frame_bounds);

--- a/xlive/Blam/Engine/rasterizer/rasterizer_main.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_main.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "rasterizer_main.h"
 
+#include "game/game.h"
 #include "rasterizer/dx9/rasterizer_dx9_main.h"
 #include "shell/shell_windows.h"
 
@@ -30,6 +31,12 @@ void rasterizer_present_frame_screenshot_wrapper(bitmap_data* bitmap)
 {
 	rasterizer_dx9_present(bitmap, true);
 	return;
+}
+
+e_display_type rasterizer_get_display_type(void)
+{
+	const bool ui_shell = game_is_active() && game_is_ui_shell();
+	return ui_shell ? _display_type_4_by_3 : rasterizer_globals_get()->display_parameters.display_type;
 }
 
 /* private code */

--- a/xlive/Blam/Engine/rasterizer/rasterizer_main.h
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_main.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "rasterizer_globals.h"
+
 #include "bitmaps/bitmap_group.h"
 
 /* prototypes */
@@ -8,3 +10,5 @@ void rasterizer_main_apply_patches(void);
 void rasterizer_present_frame_wrapper(bitmap_data* bitmap);
 
 void rasterizer_present_frame_screenshot_wrapper(bitmap_data* bitmap);
+
+e_display_type rasterizer_get_display_type(void);

--- a/xlive/Blam/Engine/rasterizer/rasterizer_settings.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_settings.cpp
@@ -188,7 +188,7 @@ void rasterizer_settings_set_default_settings(void)
 	rasterizer_globals->display_parameters.backbuffer_format = D3DFMT_A8R8G8B8;
 	rasterizer_globals->display_parameters.depthstencil_format = D3DFMT_D24S8;
 	rasterizer_globals->display_parameters.window_mode = _rasterizer_window_mode_funky_fullscreen;
-	rasterizer_globals->display_parameters.display_type = _display_type_widescreen;
+	rasterizer_globals->display_parameters.display_type = _display_type_4_by_3;
 	rasterizer_globals->sun_width_scale = 1.f;
 	rasterizer_globals->frame_bounds = rasterizer_globals->screen_bounds;
 	rasterizer_globals->fullscreen_parameters.gamma = 1.f;

--- a/xlive/Blam/Engine/render/render.cpp
+++ b/xlive/Blam/Engine/render/render.cpp
@@ -277,10 +277,10 @@ void __cdecl render_frame(
     uint32 frame_render_type,
     int32 window_count,
     int32 player_count,
-    int32 screen_split_type,
+    int32 display_split_type,
     window_bound* window)
 {
-    INVOKE(0x192140, 0x0, render_frame, frame_render_type, window_count, player_count, screen_split_type, window);
+    INVOKE(0x192140, 0x0, render_frame, frame_render_type, window_count, player_count, display_split_type, window);
     return;
 }
 

--- a/xlive/Blam/Engine/render/render.cpp
+++ b/xlive/Blam/Engine/render/render.cpp
@@ -102,9 +102,9 @@ bool __cdecl render_ingame_user_interface_hud_indicators_element_hook(
 
 void render_view(
     real_rectangle2d* frustum_bounds,
-    s_camera* rasterizer_camera,
+    render_camera* rasterizer_camera,
     int32 window_bound_index,
-    s_camera* render_camera,
+    render_camera* render_camera,
     bool is_texture_camera,
     int32 cluster_index,
     int32 leaf_index,
@@ -123,7 +123,7 @@ void render_view(
 
 void __cdecl render_scene_bitflags_set(void);
 void render_scene_wrapper(bool is_texture_camera);
-void __cdecl render_camera(
+void __cdecl render_camera_scene(
     int32 render_layer_debug_view,
     bool render_transparent_geo,
     bool lens_flare_occlusion_test,
@@ -582,7 +582,7 @@ render_postprocess:
                         list_type->m_field_C = 0;
                         list_type->m_render_layer_flags.clear();
                         rasterizer_transparent_geometry_reset_counts();
-                        render_camera(
+                        render_camera_scene(
                             render_layer_debug_view,
                             render_transparent_geo,
                             lens_flare_occlusion_test,
@@ -739,6 +739,11 @@ render_scene_end:
     return;
 }
 
+void __cdecl render_nonplayer_frame(window_bound* window_bounds)
+{
+    INVOKE(0x191FF9, 0x0, render_nonplayer_frame, window_bounds);
+    return;
+}
 
 /* private code */
 
@@ -810,7 +815,7 @@ void rasterizer_setup_2d_vertex_shader_user_interface_constants()
 	real_vector4d vc[5];
 	int16 width, height;
 
-	s_camera* global_camera = get_global_camera();
+	render_camera* global_camera = get_global_camera();
 
 	rectangle2d screen_bounds = global_camera->viewport_bounds;
 	width = rectangle2d_width(&screen_bounds);
@@ -877,9 +882,9 @@ bool __cdecl render_ingame_user_interface_hud_indicators_element_hook(int32* a1,
 
 void render_view(
     real_rectangle2d* frustum_bounds,
-    s_camera* rasterizer_camera,
+    render_camera* rasterizer_camera,
     int32 window_bound_index,
-    s_camera* render_camera,
+    render_camera* render_camera,
     bool is_texture_camera,
     int32 cluster_index,
     int32 leaf_index,
@@ -897,7 +902,7 @@ void render_view(
     s_screen_flash* screen_flash) 
 {
     ASSERT(render_camera);
-    s_camera* camera = (rasterizer_camera ? rasterizer_camera : render_camera);
+    struct render_camera* camera = (rasterizer_camera ? rasterizer_camera : render_camera);
 
     ++*global_view_frame_num_get();
 
@@ -914,7 +919,7 @@ void render_view(
     *global_fog_result_get() = *fog;
     *global_byte_4E6938_get() = false;
 
-    s_camera* global_camera = get_global_camera();
+    struct render_camera* global_camera = get_global_camera();
     *global_camera = *render_camera;
 
     render_camera_build_projection(global_camera, frustum_bounds, global_projection_get());
@@ -1044,7 +1049,7 @@ void render_scene_wrapper(bool is_texture_camera)
     return;
 }
 
-void __cdecl render_camera(
+void __cdecl render_camera_scene(
     int32 render_layer_debug_view,
     bool render_transparent_geo,
     bool lens_flare_occlusion_test,
@@ -1052,7 +1057,7 @@ void __cdecl render_camera(
     int32 hologram_flag,
     int32 effect_flag)
 {
-    INVOKE(0x1912B3, 0x0, render_camera,
+    INVOKE(0x1912B3, 0x0, render_camera_scene,
         render_layer_debug_view,
         render_transparent_geo,
         lens_flare_occlusion_test,

--- a/xlive/Blam/Engine/render/render.h
+++ b/xlive/Blam/Engine/render/render.h
@@ -10,7 +10,7 @@
 
 /* enums */
 
-enum e_screen_split_type : int8
+enum e_screen_split_type : uint32
 {
 	_screen_split_type_full = 0,
 	_screen_split_type_half = 1,
@@ -37,7 +37,7 @@ struct s_frame
 	int16 alpha;
 	int16 pad;
 	real_rgb_color color;
-	s_camera camera;
+	render_camera camera;
 	render_projection projection;
 	s_scenario_fog_result fog_result;
 	bool render_fog;
@@ -65,8 +65,8 @@ struct window_bound
 	int32 single_view;
 	int32 window_bound_index;
 	int32 user_index;
-	s_camera render_camera;
-	s_camera rasterizer_camera;
+	struct render_camera render_camera;
+	struct render_camera rasterizer_camera;
 	s_bloom_window_data bloom_data;
 };
 ASSERT_STRUCT_SIZE(window_bound, 280);
@@ -165,3 +165,5 @@ void __cdecl render_scene(
 	int32 hologram_flag,
 	int32 effect_flag,
 	real32 depth_range);
+
+void __cdecl render_nonplayer_frame(window_bound* window_bounds);

--- a/xlive/Blam/Engine/render/render.h
+++ b/xlive/Blam/Engine/render/render.h
@@ -4,13 +4,19 @@
 #include "render_layers.h"
 #include "render_visibility_collection.h"
 
-#include "camera/camera.h"
 #include "effects/player_effects.h"
 #include "scenario/scenario_fog.h"
 
 /* enums */
 
-enum e_screen_split_type : uint32
+enum e_display_split_type : uint32
+{
+	_display_split_type_none = 0,
+	_display_split_type_horizontal = 1,
+	_display_split_type_vertical = 2
+};
+
+enum e_screen_split_type : uint8
 {
 	_screen_split_type_full = 0,
 	_screen_split_type_half = 1,
@@ -151,7 +157,7 @@ void __cdecl render_frame(
 	uint32 frame_render_type,
 	int32 window_count,
 	int32 player_count,
-	int32 screen_split_type,
+	int32 display_split_type,
 	window_bound* window);
 
 // Render window

--- a/xlive/Blam/Engine/render/render_cameras.cpp
+++ b/xlive/Blam/Engine/render/render_cameras.cpp
@@ -8,7 +8,7 @@
 
 /* prototypes */
 
-void __cdecl render_camera_build_projection_static(s_camera* camera, real_rectangle2d* frustum_bounds, render_projection* out_projection);
+void __cdecl render_camera_build_projection_static(render_camera* camera, real_rectangle2d* frustum_bounds, render_projection* out_projection);
 
 /* public code */
 
@@ -23,7 +23,7 @@ render_projection* global_projection_get(void)
 	return Memory::GetAddress<render_projection*>(0x4E673C);
 }
 
-void __cdecl render_camera_build_projection(s_camera* camera,
+void __cdecl render_camera_build_projection(render_camera* camera,
 	real_rectangle2d* frustum_bounds,
 	render_projection* projection)
 {
@@ -31,7 +31,7 @@ void __cdecl render_camera_build_projection(s_camera* camera,
 	return;
 }
 
-void __cdecl render_camera_build_projection_static(s_camera* camera, real_rectangle2d* frustum_bounds, render_projection* out_projection)
+void __cdecl render_camera_build_projection_static(render_camera* camera, real_rectangle2d* frustum_bounds, render_projection* out_projection)
 {
 	real32 old_camera_field_of_view = camera->vertical_field_of_view;
 	s_saved_game_cartographer_player_profile* profile_settings = cartographer_player_profile_get_by_user_index(global_render_current_user_index());
@@ -49,7 +49,7 @@ void __cdecl render_camera_build_projection_static(s_camera* camera, real_rectan
 	return;
 }
 
-void __cdecl render_camera_build_viewport_frustum_bounds(const s_camera* camera, real_rectangle2d* frustum_bounds)
+void __cdecl render_camera_build_viewport_frustum_bounds(const render_camera* camera, real_rectangle2d* frustum_bounds)
 {
 	INVOKE(0x194FBD, 0x180EB6, render_camera_build_viewport_frustum_bounds, camera, frustum_bounds);
 	return;
@@ -116,7 +116,7 @@ bool render_projection_point_to_screen(
 }
 
 bool render_camera_world_to_screen(
-	const s_camera* camera,
+	const render_camera* camera,
 	const render_projection* projection,
 	const rectangle2d* viewport_bounds,
 	const real_point3d* view_point,

--- a/xlive/Blam/Engine/render/render_cameras.h
+++ b/xlive/Blam/Engine/render/render_cameras.h
@@ -1,6 +1,29 @@
 #pragma once
-#include "camera/camera.h"
 #include "math/matrix_math.h"
+
+struct render_camera
+{
+	real_point3d point;
+	real_vector3d forward;
+	real_vector3d up;
+	bool mirrored;
+	int8 pad[3];
+	real32 vertical_field_of_view;
+	real32 scale;
+	rectangle2d viewport_bounds;
+	rectangle2d window_bounds;
+	real32 z_near;
+	real32 z_far;
+	real_plane3d mirror_plane;
+	bool tiled;
+	int8 pad1[3];
+	real32 unk_floats[3];
+	bool bool_2;
+	int8 pad2[3];
+	real32 frustum_multiplier_x;
+	real32 frustum_multiplier_y;
+};
+ASSERT_STRUCT_SIZE(render_camera, 0x74);
 
 struct s_oriented_bounding_box
 {
@@ -24,12 +47,12 @@ void render_cameras_apply_patches(void);
 
 render_projection* global_projection_get(void);
 
-void __cdecl render_camera_build_projection(s_camera* camera,
+void __cdecl render_camera_build_projection(render_camera* camera,
 	real_rectangle2d* frustum_bounds,
 	render_projection* projection);
 
 // Builds frustum bounds from render camera
-void __cdecl render_camera_build_viewport_frustum_bounds(const s_camera* camera, real_rectangle2d* frustum_bounds);
+void __cdecl render_camera_build_viewport_frustum_bounds(const render_camera* camera, real_rectangle2d* frustum_bounds);
 
 bool render_projection_point_to_screen(
 	const real_point3d* camera_position,
@@ -38,7 +61,7 @@ bool render_projection_point_to_screen(
 	real_bounds* bounds);
 
 bool render_camera_world_to_screen(
-	const s_camera* camera,
+	const render_camera* camera,
 	const render_projection* projection,
 	const rectangle2d* viewport_bounds,
 	const real_point3d* view_point,

--- a/xlive/Blam/Engine/scenario/scenario_fog.cpp
+++ b/xlive/Blam/Engine/scenario/scenario_fog.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "scenario_fog.h"
 
-bool __cdecl render_scenario_fog(int32 cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result)
+bool __cdecl render_scenario_fog(int32 cluster_index, render_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result)
 {
     return INVOKE(0xBA3EA, 0x0, render_scenario_fog, cluster_index, camera_position, camera_forward, a4, render_fog, result);
 }

--- a/xlive/Blam/Engine/scenario/scenario_fog.h
+++ b/xlive/Blam/Engine/scenario/scenario_fog.h
@@ -165,4 +165,4 @@ ASSERT_STRUCT_SIZE(s_scenario_planar_fog_palette_entry, 16);
 
 // CLIENT ONLY
 // Renders the fog defined in the scenario
-bool __cdecl render_scenario_fog(int32 cluster_index, s_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result);
+bool __cdecl render_scenario_fog(int32 cluster_index, render_camera* camera_position, real_vector3d* camera_forward, bool a4, bool render_fog, s_scenario_fog_result* result);

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
@@ -8,6 +8,7 @@
 #include "game/game.h"
 #include "main/main_game.h"
 #include "main/main_game_time.h"
+#include "main/main_render.h"
 #include "main/main_screenshot.h"
 #include "networking/Session/NetworkSession.h"
 #include "networking/NetworkMessageTypeCollection.h"
@@ -44,6 +45,9 @@ extern real32 g_rumble_factor;
 ComVarFromPtr(rumble_var_cmd, real32, &g_rumble_factor,
 	"var_rumble_scale", "change controller vibration strength (0.0 to 1.0), 1 parameter(s): <float>", 1, 1, CommandCollection::RumbleScaleCmd);
 
+ComVarFromPtr(debug_render_horizontal_splitscreen, bool, &g_debug_render_horizontal_splitscreen,
+	"debug_render_horizontal_splitscreen", "force horizontal spliscreen split", 1, 1, CommandCollection::BoolVarHandlerCmd);
+
 // don't forget to add '_cmd' after the name, 
 // if you add a variable command created using `DECL_ComVarCommandPtr` macro
 std::vector<ConsoleCommand*> CommandCollection::commandTable;
@@ -58,6 +62,7 @@ void CommandCollection::InitializeCommands()
 	InsertCommand(new ConsoleCommand(og_frame_limiter_var_cmd));
 	InsertCommand(new ConsoleCommand(display_xyz_var_cmd));
 	InsertCommand(new ConsoleCommand(rumble_var_cmd));
+	InsertCommand(new ConsoleCommand(debug_render_horizontal_splitscreen));
 	InsertCommand(new ConsoleCommand("help", "outputs all commands, 0 - 1 parameter(s): <string>(optional): command name", 0, 1, CommandCollection::HelpCmd));
 	InsertCommand(new ConsoleCommand("log_peers", "logs all peers to console, 0 parameter(s)", 0, 0, CommandCollection::LogPeersCmd));
 	InsertCommand(new ConsoleCommand("log_players", "logs all players to console, 0 parameter(s)", 0, 0, CommandCollection::LogPlayersCmd));

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandHandler.h
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandHandler.h
@@ -102,7 +102,7 @@ public:
 protected:
 
     CommandFlags m_flags;
-    char m_name[32];
+    char m_name[64];
     char m_command_description[256];
     size_t m_min_parameter_count;
     size_t m_max_parameter_count;

--- a/xlive/H2MOD/Modules/Shell/Config.cpp
+++ b/xlive/H2MOD/Modules/Shell/Config.cpp
@@ -68,6 +68,7 @@ char H2Config_stats_authkey[32 + 1] = { "" };
 bool H2Config_vip_lock = false;
 bool H2Config_even_shuffle_teams = false;
 bool H2Config_koth_random = true;
+bool H2Config_intel_sky_hack = false;
 H2Config_Experimental_Rendering_Mode H2Config_experimental_fps = _rendering_mode_none;
 
 // ### TODO FIXME remove CSimpleIniA garbage
@@ -383,6 +384,7 @@ void SaveH2Config() {
 			ini.SetBoolValue(k_h2config_version_section, "force_off_sm3", H2Config_force_off_sm3);
 			ini.SetBoolValue(k_h2config_version_section, "use_d3d9on12", g_rasterizer_dx9on12_enabled);
 			ini.SetBoolValue(k_h2config_version_section, "disable_amd_or_ati_patches", g_rasterizer_dx9_driver_globals.disable_amd_or_ati_patches);
+			ini.SetBoolValue(k_h2config_version_section, "intel_sky_hack", H2Config_intel_sky_hack);
 		}
 
 		ini.SetBoolValue(k_h2config_version_section, "enable_xdelay", H2Config_xDelay);
@@ -629,7 +631,7 @@ void ReadH2Config() {
 					k_h2config_version_section,
 					"disable_amd_or_ati_patches",
 					g_rasterizer_dx9_driver_globals.disable_amd_or_ati_patches);
-
+				*Memory::GetAddress<bool*>(0x41F6A9) = !ini.GetBoolValue(k_h2config_version_section, "intel_sky_hack", H2Config_intel_sky_hack);
 			}
 
 			// dedicated server only


### PR DESCRIPTION
- debug_render_horizontal_splitscreen forces the display split type to horizontal
- add intel sky hack to disable skybox rendering (newer intel cards crash when rendering the sky)
- rename s_camera to render_camera