### PR TITLE
fix dedi assert and add exit popup if any maps or plugins are missing for tag injeciton

### DIFF
--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
@@ -2,7 +2,6 @@
 #include "tag_injection.h"
 
 #include "tag_injection_manager.h"
-#include "scenario/scenario_definitions.h"
 
 c_tag_injecting_manager g_manager;
 

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
@@ -12,6 +12,8 @@
 #include "render/weather_definitions.h"
 #include "units/biped_definitions.h"
 #include "units/vehicle_definitions.h"
+
+#include "H2MOD/Modules/Shell/H2MODShell.h"
 #include "Util/filesys.h"
 
 /* constants */
@@ -96,10 +98,20 @@ bool c_tag_injecting_manager::find_map(const wchar_t* map_name, c_static_wchar_s
 			}
 			return true;
 		}
+		// Exit and create a popup if a map is missing
 		else
 		{
-			// if map is found in neither location then return the function early
-			LOG_ERROR_GAME(L"[c_tag_injecting_manager::set_active_map] could not locate {}.map in any valid content location", map_name);
+			const wchar_t* format = L"[c_tag_injecting_manager::set_active_map] could not locate %s.map in any valid content location";
+			wchar_t output_wide[NUMBEROF(format) + MAX_PATH];
+			
+			usnzprintf(output_wide, NUMBEROF(output_wide), format, map_name);
+
+			char output[(NUMBEROF(format) + MAX_PATH) * 2];
+			wchar_string_to_utf8_string(output_wide, output, NUMBEROF(output));
+
+			LOG_ERROR_GAME(output_wide);
+			_Shell::OpenMessageBox(NULL, MB_ICONERROR, "Missing Map File", output);
+			exit(EXIT_FAILURE);
 			return false;
 		}
 	}
@@ -498,9 +510,20 @@ bool c_tag_injecting_manager::initialize_agent(tag_group group)
 	plugin_path.append(wide_tag_class);
 	plugin_path.append(L".xml");
 
+	// Exit and create a popup if a plugin is missing
 	if (!PathFileExists(plugin_path.get_string()))
 	{
-		LOG_ERROR_GAME(L"[c_tag_injecting_manager::initialize_agent] Plugin file could not be located {}", plugin_path.get_string());
+		const wchar_t* format = L"[c_tag_injecting_manager::initialize_agent] Plugin file could not be located %s";
+		wchar_t output_wide[NUMBEROF(format) + MAX_PATH];
+
+		usnzprintf(output_wide, NUMBEROF(output_wide), format, plugin_path.get_string());
+
+		char output[(NUMBEROF(format) + MAX_PATH) * 2];
+		wchar_string_to_utf8_string(output_wide, output, NUMBEROF(output));
+
+		LOG_ERROR_GAME(output_wide);
+		_Shell::OpenMessageBox(NULL, MB_ICONERROR, "Missing Plugin File", output);
+		exit(EXIT_FAILURE);
 		return false;
 	}
 	this->m_agents[tag_group_index].init(group, plugin_path.get_string());

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1176,14 +1176,8 @@ void H2MOD::Initialize()
 
 	h2mod_apply_tweaks();
 
-	// Apply patches for the hud that need to be applied before WinMain is called
-	hud_apply_pre_winmain_patches();
-
 	// Apply patches
 	game_apply_pre_winmain_patches();
-
-	// adds support for more monitor resolutions
-	rasterizer_settings_apply_hooks();
 
 	shell_apply_patches();
 	shell_windows_apply_patches();
@@ -1193,6 +1187,12 @@ void H2MOD::Initialize()
 
 	if (!Memory::IsDedicatedServer())
 	{
+		// Apply patches for the hud that need to be applied before WinMain is called
+		hud_apply_pre_winmain_patches();
+
+		// adds support for more monitor resolutions
+		rasterizer_settings_apply_hooks();
+
 		KeyboardInput::Initialize();
 		
 		RenderHooks::Initialize();


### PR DESCRIPTION
- add popups incase users do not have the required content
- hooks were being called that shouldn't have been called on dedicated servers after the tweaks move (https://github.com/pnill/cartographer/pull/715)