### PR TITLE
remove team switch packet

### DIFF
--- a/xlive/Blam/Engine/game/game_engine.cpp
+++ b/xlive/Blam/Engine/game/game_engine.cpp
@@ -1,7 +1,15 @@
 #include "stdafx.h"
 #include "game_engine.h"
 
+#include "game.h"
+#include "game_engine_util.h"
+
 /* public code */
+
+c_game_engine* current_game_engine()
+{
+	return get_game_mode_engines()[game_engine_globals_get()->game_engine_index];
+}
 
 s_game_engine_globals* game_engine_globals_get(void)
 {

--- a/xlive/Blam/Engine/game/game_engine.h
+++ b/xlive/Blam/Engine/game/game_engine.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "game/game_allegiance.h"
 #include "game_statborg.h"
 #include "math/color_math.h"
@@ -155,32 +156,33 @@ ASSERT_STRUCT_SIZE(s_game_engine_global_player_info, 24);
 
 struct s_game_engine_globals
 {
-	DWORD flags;
-	short team_flags;
-	WORD field_6;
-	WORD field_8;
+	uint32 flags;
+	int16 team_flags;
+	uint16 field_6;
+	uint16 field_8;
 	uint16 team_bitmask;
-	WORD field_C;
-	short field_E;
-	WORD field_10;
-	WORD field_12[8];
-	DWORD field_24;
-	DWORD field_28;
+	uint16 field_C;
+	int16 field_E;
+	uint16 field_10;
+	uint16 field_12[8];
+	uint32 field_24;
+	uint32 field_28;
 	int32 player_entity_index[k_maximum_players];
-	short field_6A;
-	short field_6C;
-	DWORD field_70;
-	DWORD gap_74[28];
+	int16 field_6C;
+	uint32 field_70;
+	uint32 gap_74[28];
 	real32 unk_local_player_hud_field[k_number_of_users];
-	byte field_F4;
-	byte pad_F5[4];
-	byte gapF9[523];
+	uint8 field_F4;
+	uint8 pad_F5[4];
+	uint8 gapF9[523];
 	c_game_statborg game_statborg;
 	s_game_engine_global_player_info player_info[k_maximum_players];
-	DWORD ticks;
-	BYTE gap71C[1336];
-	DWORD game_engine_index;
-	BYTE gapC58[132];
+	uint32 ticks;
+	uint8 gap71C[1320];
+	int32 field_C44;
+	uint8 gap_C48[12];
+	int32 game_engine_index;
+	uint8 gapC58[132];
 };
 ASSERT_STRUCT_SIZE(s_game_engine_globals, 0xCDC);
 
@@ -243,6 +245,8 @@ ASSERT_STRUCT_SIZE(s_multiplayer_event_response_definition, 0xA8);
 
 /* prototypes */
 
+c_game_engine* current_game_engine();
+
 s_game_engine_globals* game_engine_globals_get(void);
 
 bool __cdecl game_engine_get_change_colors(s_player_profile* player_profile, e_game_team team_index, real_rgb_color* change_colors);
@@ -254,3 +258,7 @@ void __cdecl game_engine_player_activated(datum player_index);
 bool __cdecl game_engine_team_is_enemy(e_game_team a, e_game_team b);
 
 void __cdecl game_engine_render(void);
+
+bool game_engine_in_round();
+
+c_game_engine** get_game_mode_engines();

--- a/xlive/Blam/Engine/game/game_engine_util.cpp
+++ b/xlive/Blam/Engine/game/game_engine_util.cpp
@@ -2,14 +2,15 @@
 #include "game_engine_util.h"
 
 #include "game/game.h"
+#include "game/game_engine.h"
 
 /* public code */
 
-int current_game_engine()
+bool game_engine_in_round()
 {
-	typedef int(__cdecl* get_game_mode_engine_t)();
-	auto p_get_game_mode_engine = Memory::GetAddress<get_game_mode_engine_t>(0x5B15E, 0x3CDBE);
-	return p_get_game_mode_engine();
+	return current_game_engine() != NULL
+		&& game_engine_globals_get()->field_6C == 1
+		&& (game_is_predicted() || game_engine_globals_get()->field_C44 == 1);
 }
 
 void game_engine_check_for_round_winner()

--- a/xlive/Blam/Engine/game/game_engine_util.h
+++ b/xlive/Blam/Engine/game/game_engine_util.h
@@ -2,7 +2,6 @@
 
 /* public code */
 
-int current_game_engine();
 void game_engine_check_for_round_winner();
 void game_engine_end_round_with_winner(int player_datum_or_team_index, bool go_to_next_round);
 bool game_engine_has_teams();

--- a/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.cpp
+++ b/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.cpp
@@ -97,9 +97,6 @@ void register_custom_network_message(void* network_messages)
 	register_network_message(network_messages, _custom_map_filename, "map-file-name", 0, sizeof(s_custom_map_filename), sizeof(s_custom_map_filename),
 		(void*)encode_map_file_name_message, (void*)decode_map_file_name_message, NULL);
 
-	register_network_message(network_messages, _team_change, "team-change", 0, sizeof(s_team_change), sizeof(s_team_change),
-		(void*)encode_team_change_message, (void*)decode_team_change_message, NULL);
-
 	register_network_message(network_messages, _rank_change, "rank-change", 0, sizeof(s_rank_change), sizeof(s_rank_change),
 		(void*)encode_rank_change_message, (void*)decode_rank_change_message, NULL);
 
@@ -210,18 +207,6 @@ void __stdcall handle_channel_message_hook(void* thisx, int network_channel_inde
 		break;
 	}
 
-	case _team_change:
-	{
-		if (peer_network_channel->is_channel_state_5())
-		{
-			s_team_change* received_data = (s_team_change*)packet;
-			LOG_TRACE_NETWORK(L"[H2MOD-CustomMessage] recieved on handle_channel_message_hook team_change: {}", (int16)received_data->team_index);
-			user_interface_controller_set_desired_team_index(_controller_index_0, received_data->team_index);
-			user_interface_controller_update_network_properties(_controller_index_0);
-		}
-		break;
-	}
-
 	case _rank_change:
 	{
 		if (peer_network_channel->is_channel_state_5())
@@ -325,26 +310,6 @@ void NetworkMessage::SendRequestMapFilename(int mapDownloadId)
 				observer_channel->observer_index,
 				observer_channel->field_1,
 				session->session_index);
-		}
-	}
-}
-
-void NetworkMessage::SendTeamChange(int peerIdx, e_game_team team)
-{
-	c_network_session* session = NetworkSession::GetActiveNetworkSession();
-	if (NetworkSession::LocalPeerIsSessionHost())
-	{
-		s_team_change data;
-		data.team_index = team;
-
-		c_network_observer* observer = session->p_network_observer;
-		s_session_observer_channel* observer_channel = NetworkSession::GetPeerObserverChannel(peerIdx);
-
-		if (peerIdx != NONE && !NetworkSession::IsPeerIndexLocal(peerIdx))
-		{
-			if (observer_channel->field_1) {
-				observer->send_message(session->session_index, observer_channel->observer_index, false, _team_change, sizeof(s_team_change), &data);
-			}
 		}
 	}
 }

--- a/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.h
+++ b/xlive/Blam/Engine/networking/NetworkMessageTypeCollection.h
@@ -58,7 +58,6 @@ enum e_network_message_type_collection : unsigned int
 	// custom network meesages below
 	_request_map_filename,
 	_custom_map_filename,
-	_team_change,
 	_rank_change,
 	_anti_cheat,
 	_custom_variant_settings,
@@ -178,7 +177,6 @@ namespace NetworkMessage
 {
 	void ApplyGamePatches();
 	void SendRequestMapFilename(int mapDownloadId);
-	void SendTeamChange(int peerIdx, e_game_team team);
 	void SendRankChange(int peerIdx, BYTE rank);
 	void SendAntiCheat(int peerIdx);
 }

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -312,11 +312,12 @@ void H2MOD::custom_sound_play(const wchar_t* soundName, int delay)
 typedef void(__cdecl* player_died_t)(datum player_index);
 player_died_t p_player_died;
 
-void __cdecl OnPlayerDeath(datum playerIdx)
+void __cdecl OnPlayerDeath(datum player_index)
 {
-	CustomVariantHandler::OnPlayerDeath(ExecTime::_preEventExec, playerIdx);
-	p_player_died(playerIdx);
-	CustomVariantHandler::OnPlayerDeath(ExecTime::_postEventExec, playerIdx);
+	CustomVariantHandler::OnPlayerDeath(ExecTime::_preEventExec, player_index);
+	//p_player_died(player_index);
+	INVOKE(0x5587B, 0x5DD73, OnPlayerDeath, player_index);
+	CustomVariantHandler::OnPlayerDeath(ExecTime::_postEventExec, player_index);
 }
 
 /* This is technically closer to object death than player-death as it impacts anything with health at all. */
@@ -1022,7 +1023,9 @@ void H2MOD::ApplyHooks() {
 
 	// server/client detours 
 	DETOUR_ATTACH(p_player_spawn, Memory::GetAddress<player_spawn_t>(0x55952, 0x5DE4A), OnPlayerSpawn);
-	DETOUR_ATTACH(p_player_died, Memory::GetAddress<player_died_t>(0x5587B, 0x5DD73), OnPlayerDeath);
+	PatchCall(Memory::GetAddress(0x144919, 0x133769), OnPlayerDeath);
+	// ### FIXME: this detours all cases where a player dies, including after a new round/teleporting (pseudo-kill)
+	//DETOUR_ATTACH(p_player_died, Memory::GetAddress<player_died_t>(0x5587B, 0x5DD73), OnPlayerDeath);
 	DETOUR_ATTACH(p_map_cache_load, Memory::GetAddress<map_cache_load_t>(0x8F62, 0x1F35C), OnMapLoad);
 	DETOUR_ATTACH(p_object_deplete_body_internal, Memory::GetAddress<object_deplete_body_internal_t>(0x17B674, 0x152ED4), OnObjectDamage);
 	DETOUR_ATTACH(p_get_enabled_teams_flags, Memory::GetAddress<get_enabled_teams_flags_t>(0x1B087B, 0x19698B), get_enabled_team_flags);

--- a/xlive/H2MOD/Variants/Infection/Infection.cpp
+++ b/xlive/H2MOD/Variants/Infection/Infection.cpp
@@ -83,9 +83,6 @@ void Infection::sendTeamChange()
 						player_indexes[player_array_index] = i;
 						player_teams[player_array_index++] = team;
 
-						// ### TODO FIXME remove SendTeamChange() and team change packet before release !!!! !!!! !!!! !!!! 
-						NetworkMessage::SendTeamChange(NetworkSession::GetPeerIndex(i), team);
-
 						LOG_TRACE_GAME(L"[h2mod-infection] sent team change packet to player index: {}, with name: {}, infected?: {}", 
 							i, 
 							NetworkSession::GetPlayerName(i), 
@@ -221,9 +218,6 @@ void Infection::preSpawnServerSetup() {
 				if (NetworkSession::LocalPeerIsSessionHost())
 				{
 					// prevent the fucks from switching to humans in the pre-game lobby after joining
-
-					// ### TODO FIXME remove SendTeamChange() and team change packet before release !!!! !!!! !!!!
-					NetworkMessage::SendTeamChange(NetworkSession::GetPeerIndex(currentPlayerIndex), k_zombie_team); 
 					NetworkSession::GetActiveNetworkSession()->switch_player_team(player_it.get_current_player_datum_index(), k_zombie_team);
 				}
 			}

--- a/xlive/H2MOD/Variants/Infection/Infection.cpp
+++ b/xlive/H2MOD/Variants/Infection/Infection.cpp
@@ -65,9 +65,9 @@ void Infection::sendTeamChange()
 	{
 		int32 player_count = NetworkSession::GetPlayerCount();
 
+		int32 player_array_index = 0;
 		if (player_count > 0)
 		{
-			int32 player_array_index = 0;
 			datum player_indexes[k_maximum_players] = {};
 			e_game_team player_teams[k_maximum_players] = {};
 
@@ -78,7 +78,7 @@ void Infection::sendTeamChange()
 					e_game_team team = zombiePlayerIndex == i ? k_zombie_team : k_humans_team;
 					bool is_current_player_zombie = zombiePlayerIndex == i;
 
-					if (!NetworkSession::IsPlayerLocal(i))
+					//if (!NetworkSession::IsPlayerLocal(i))
 					{
 						player_indexes[player_array_index] = i;
 						player_teams[player_array_index++] = team;
@@ -89,7 +89,7 @@ void Infection::sendTeamChange()
 							is_current_player_zombie
 						);
 					}
-					else 
+					/*else 
 					{
 						if (!Memory::IsDedicatedServer())
 						{
@@ -99,10 +99,11 @@ void Infection::sendTeamChange()
 							user_interface_controller_update_network_properties(local_player->controller_index);
 							LOG_TRACE_GAME(L"[h2mod-infection] setting local player team index, infected?: {}", is_current_player_zombie);
 						}
-					}
+					}*/
 				}
 			}
-			NetworkSession::GetActiveNetworkSession()->switch_players_to_teams(player_indexes, NetworkSession::GetPlayerCount(), player_teams);
+
+			NetworkSession::GetActiveNetworkSession()->switch_players_to_teams(player_indexes, player_array_index, player_teams);
 		}
 	}
 }


### PR DESCRIPTION
- fixed infection team switch when all players are local players 
- hook `player_died()` only during `unit_kill()`