### PR TITLE
split object type/object type mask enum

### DIFF
--- a/xlive/Blam/Engine/game/players.cpp
+++ b/xlive/Blam/Engine/game/players.cpp
@@ -447,14 +447,14 @@ void __cdecl players_update_activation(void)
 
 void __cdecl player_examine_nearby_biped(datum biped_datum, datum player_datum, s_player_interaction_context* out_action_context)
 {
-    void* player_build_biped_interaction_usercall = Memory::GetAddress<void*>(0x53E43);
+    void* player_examine_nearby_biped_usercall = Memory::GetAddress<void*>(0x53E43);
     __asm
     {
         push out_action_context
         push player_datum
         mov ebx, biped_datum
 
-        call player_build_biped_interaction_usercall
+        call player_examine_nearby_biped_usercall
 
         add esp, 2 * 4
     }
@@ -462,14 +462,14 @@ void __cdecl player_examine_nearby_biped(datum biped_datum, datum player_datum, 
 
 void __cdecl player_examine_nearby_vehicle(datum vehicle_datum, datum player_datum, s_player_interaction_context* out_action_context)
 {
-    void* player_build_biped_interaction_usercall = Memory::GetAddress<void*>(0x53CC7);
+    void* player_examine_nearby_vehicle_usercall = Memory::GetAddress<void*>(0x53CC7);
     __asm
     {
         push out_action_context
         push player_datum
         mov eax, vehicle_datum
 
-        call player_build_biped_interaction_usercall
+        call player_examine_nearby_vehicle_usercall
 
         add esp, 2 * 4
     }
@@ -498,14 +498,14 @@ void player_examine_nearby_weapon(datum weapon_datum, datum player_datum, s_play
         if (!TEST_BIT(g_user_weapon_interactions_mask, player->user_index))
             return;
 
-    void* player_build_biped_interaction_usercall = Memory::GetAddress<void*>(0x53F17);
+    void* player_examine_nearby_weapon_usercall = Memory::GetAddress<void*>(0x53F17);
     __asm
     {
         push weapon_datum
         push player_datum
         mov eax, out_action_context
 
-        call player_build_biped_interaction_usercall
+        call player_examine_nearby_weapon_usercall
 
         add esp, 2 * 4
     }
@@ -513,14 +513,14 @@ void player_examine_nearby_weapon(datum weapon_datum, datum player_datum, s_play
 
 void __cdecl player_examine_nearby_control(datum control_datum, datum player_datum, s_player_interaction_context* out_action_context)
 {
-    void* player_build_biped_interaction_usercall = Memory::GetAddress<void*>(0x53E43);
+    void* player_examine_nearby_control_usercall = Memory::GetAddress<void*>(0x51FB2);
     __asm
     {
         push out_action_context
         push player_datum
         mov ebx, control_datum
 
-        call player_build_biped_interaction_usercall
+        call player_examine_nearby_control_usercall
 
         add esp, 2 * 4
     }

--- a/xlive/Blam/Engine/networking/Session/NetworkSession.cpp
+++ b/xlive/Blam/Engine/networking/Session/NetworkSession.cpp
@@ -305,8 +305,7 @@ void network_session_membership_update_local_players_teams()
 	c_network_session* active_session;
 	if (network_life_cycle_in_squad_session(&active_session))
 	{
-		if ((active_session->local_state_established() || active_session->local_state_joining_session())
-			&& !active_session->local_state_session_host())
+		if (active_session->local_state_established() || active_session->local_state_joining_session())
 		{
 			int32 local_peer_index = active_session->get_local_peer_index();
 
@@ -354,4 +353,17 @@ bool network_life_cycle_in_squad_session(c_network_session** out_active_session)
 		*out_active_session = NetworkSession::GetActiveNetworkSession();
 
 	return true;
+}
+
+void c_network_session::switch_players_to_teams(datum* player_indexes, int32 player_count, e_game_team* team_indexes)
+{
+	if (local_state_session_host())
+	{
+		for (int32 i = 0; i < player_count; i++)
+		{
+			get_player_membership(player_indexes[i])->properties[0].team_index = team_indexes[i];
+		}
+		request_membership_update();
+		network_session_membership_update_local_players_teams();
+	}
 }

--- a/xlive/Blam/Engine/networking/Session/NetworkSession.h
+++ b/xlive/Blam/Engine/networking/Session/NetworkSession.h
@@ -470,17 +470,7 @@ struct c_network_session
 	}
 
 	// switch multiple players with a single membership update
-	void switch_players_to_teams(datum* player_indexes, int32 player_count, e_game_team* team_indexes)
-	{
-		if (local_state_session_host())
-		{
-			for (int32 i = 0; i < player_count; i++)
-			{
-				get_player_membership(player_indexes[i])->properties[0].team_index = team_indexes[i];
-			}
-			request_membership_update();
-		}
-	}
+	void switch_players_to_teams(datum* player_indexes, int32 player_count, e_game_team* team_indexes);
 
 	const char* describe_network_protocol_type() const
 	{
@@ -491,7 +481,7 @@ struct c_network_session
 			"LIVE",
 		};
 
-		return this->m_session_class < k_network_session_class_count ? network_protocols_str[this->m_session_class] : "<unknown>";
+		return IN_RANGE(this->m_session_class, _network_session_class_offline, k_network_session_class_count - 1) ? network_protocols_str[this->m_session_class] : "<unknown>";
 	}
 };
 ASSERT_STRUCT_SIZE(c_network_session, 31624);

--- a/xlive/Blam/Engine/objects/object_definition.h
+++ b/xlive/Blam/Engine/objects/object_definition.h
@@ -6,6 +6,7 @@
 #include "math/color_math.h"
 #include "math/function_definitions.h"
 
+#include "objects/object_types.h"
 #include "tag_files/string_id.h"
 
 #define k_maximum_object_functions 256
@@ -187,7 +188,7 @@ ASSERT_STRUCT_SIZE(object_change_color_definition, 16);
 
 struct object_definition
 {
-	int16/*e_object_type*/ object_type;
+	e_object_type object_type;
 	e_object_definition_flags flags;
 	real32 bounding_radius;				// World Units
 	real_point3d bounding_offset;

--- a/xlive/Blam/Engine/objects/object_identifier.cpp
+++ b/xlive/Blam/Engine/objects/object_identifier.cpp
@@ -4,7 +4,7 @@
 
 void c_object_identifier::clear()
 {
-	this->m_object_type = (e_object_type)NONE;
+	this->m_object_type = _object_type_none;
 	this->m_source = (e_object_source)NONE;
 	this->m_origin_bsp_index = NONE;
 	this->m_unique_id = NONE;
@@ -41,7 +41,7 @@ e_object_source c_object_identifier::get_source() const
 
 e_object_type c_object_identifier::get_type() const
 {
-	return (e_object_type)this->m_object_type;
+	return this->m_object_type;
 }
 
 int32 c_object_identifier::get_unique_id() const

--- a/xlive/Blam/Engine/objects/object_identifier.h
+++ b/xlive/Blam/Engine/objects/object_identifier.h
@@ -14,7 +14,7 @@ class c_object_identifier
 private:
 	int32 m_unique_id;
 	int16 m_origin_bsp_index;
-	int8/*e_object_type*/ m_object_type;
+	e_object_type m_object_type;
 	e_object_source m_source;
 
 public:

--- a/xlive/Blam/Engine/objects/object_type_list.h
+++ b/xlive/Blam/Engine/objects/object_type_list.h
@@ -3,8 +3,9 @@
 // TODO move this into object_types.h but currently getting issues
 // Has to do with header recursion and errors that pop up with tag definitions?
 
-enum e_object_type : int32
+enum e_object_type : int8
 {
+	_object_type_none = NONE,
 	_object_type_biped = 0,
 	_object_type_vehicle = 1,
 	_object_type_weapon = 2,
@@ -19,8 +20,11 @@ enum e_object_type : int32
 	_object_type_crate = 11,
 	_object_type_creature = 12,
 	k_object_types_count,
+};
 
-	_object_mask_all = NONE,
+enum e_object_mask : uint32
+{
+	_object_mask_all = (uint32)NONE,
 	_object_mask_unit = FLAG(_object_type_biped) | FLAG(_object_type_vehicle),
 	_object_mask_biped = FLAG(_object_type_biped),
 	_object_mask_vehicle = FLAG(_object_type_vehicle),
@@ -45,6 +49,5 @@ enum e_object_type : int32
 
 	_object_mask_sightblocking = FLAG(_object_type_vehicle) | FLAG(_object_type_scenery) | FLAG(_object_type_machine),
 	_object_mask_cannot_interpolate = FLAG(_object_type_sound_scenery) | FLAG(_object_type_light_fixture) | FLAG(_object_type_control) | FLAG(_object_type_machine) | FLAG(_object_type_scenery) | FLAG(_object_type_projectile)
-
 };
 

--- a/xlive/Blam/Engine/objects/objects.h
+++ b/xlive/Blam/Engine/objects/objects.h
@@ -98,7 +98,7 @@ struct object_header_datum
 {
 	int16 identifier;
 	c_flags<e_object_header_flags, uint8, k_object_header_flags> flags;
-	int8/*e_object_type*/ type;
+	e_object_type type;
 	int16 cluster_index;
 	int16 data_size;
 	void* datum;


### PR DESCRIPTION
- make the type mask unsigned integral type
- fixed nearby control interaction caused by wrong function offset
