### PR TITLE
adjust slot handler args

### DIFF
--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.cpp
@@ -359,7 +359,7 @@ void c_cartographer_account_manager_edit_list::update_list_items(c_list_item_wid
 	}
 }
 
-void c_cartographer_account_manager_edit_list::handle_item_pressed_event(s_event_record* pevent, int32* pitem_index)
+void c_cartographer_account_manager_edit_list::handle_item_pressed_event(s_event_record** pevent, int32* pitem_index)
 {
 	switch (m_cartographer_screen_type)
 	{
@@ -381,7 +381,7 @@ void c_cartographer_account_manager_edit_list::handle_item_pressed_event(s_event
 }
 
 
-void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_add_account(s_event_record* event_record, int32* a3)
+void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_add_account(s_event_record** event_record, int32* a3)
 {
 	int16 button_id = DATUM_INDEX_TO_ABSOLUTE_INDEX(*a3);
 
@@ -418,7 +418,7 @@ void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_add
 	}
 }
 
-void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_listed_accounts(s_event_record* event_record, int32* a3)
+void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_listed_accounts(s_event_record** event_record, int32* a3)
 {
 	const int32 button_id = DATUM_INDEX_TO_ABSOLUTE_INDEX(*a3);
 
@@ -507,7 +507,7 @@ void __cdecl create_account_xbox_task_progress_cb(c_screen_xbox_live_task_progre
 	}
 }
 
-void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_create_account(s_event_record* event_record, int32* a3)
+void c_cartographer_account_manager_edit_list::handle_item_pressed_event_for_create_account(s_event_record** event_record, int32* a3)
 {
 	const int32 button_id = DATUM_INDEX_TO_ABSOLUTE_INDEX(*a3);
 

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.h
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.h
@@ -56,11 +56,11 @@ private:
 		} m_account_add;
 	};
 	// button handler callback
-	void handle_item_pressed_event(s_event_record* pevent, int32* pitem_index);
+	void handle_item_pressed_event(s_event_record** pevent, int32* pitem_index);
 
-	void handle_item_pressed_event_for_add_account(s_event_record* pevent, int32* pitem_index);
-	void handle_item_pressed_event_for_listed_accounts(s_event_record* pevent, int32* pitem_index);
-	void handle_item_pressed_event_for_create_account(s_event_record* pevent, int32* pitem_index);
+	void handle_item_pressed_event_for_add_account(s_event_record** pevent, int32* pitem_index);
+	void handle_item_pressed_event_for_listed_accounts(s_event_record** pevent, int32* pitem_index);
+	void handle_item_pressed_event_for_create_account(s_event_record** pevent, int32* pitem_index);
 
 
 public:

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.cpp
@@ -236,7 +236,7 @@ void c_cartographer_guide_edit_list::update_list_items(c_list_item_widget* item,
 	}
 }
 
-void c_cartographer_guide_edit_list::handle_item_pressed_event(s_event_record* pevent, int32* pitem_index)
+void c_cartographer_guide_edit_list::handle_item_pressed_event(s_event_record** pevent, int32* pitem_index)
 {
 	int16 button_id = DATUM_INDEX_TO_ABSOLUTE_INDEX(*pitem_index);
 
@@ -357,7 +357,7 @@ void c_cartographer_credits_edit_list::update_list_items(c_list_item_widget* ite
 	}
 }
 
-void c_cartographer_credits_edit_list::handle_item_pressed_event(s_event_record* event_record, int32* a3)
+void c_cartographer_credits_edit_list::handle_item_pressed_event(s_event_record** event_record, int32* a3)
 {
 	return;
 }
@@ -505,7 +505,7 @@ void c_cartographer_update_edit_list::update_updater_status()
 }
 
 
-void c_cartographer_update_edit_list::handle_item_pressed_event(s_event_record* pevent, int32* pitem_index)
+void c_cartographer_update_edit_list::handle_item_pressed_event(s_event_record** pevent, int32* pitem_index)
 {
 	int32 button_id = DATUM_INDEX_TO_ABSOLUTE_INDEX(*pitem_index);
 
@@ -653,7 +653,7 @@ void c_cartographer_update_notice_edit_list::update_list_items(c_list_item_widge
 	}
 }
 
-void c_cartographer_update_notice_edit_list::handle_item_pressed_event(s_event_record* pevent, int32* pitem_index)
+void c_cartographer_update_notice_edit_list::handle_item_pressed_event(s_event_record** pevent, int32* pitem_index)
 {
 	int16 button_id = DATUM_INDEX_TO_ABSOLUTE_INDEX(*pitem_index);
 

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.h
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.h
@@ -37,7 +37,7 @@ protected:
 	c_list_item_widget m_list_item_widgets[k_no_of_visible_items_for_cartographer_guide_list];
 	c_slot2<c_cartographer_guide_edit_list, s_event_record*, int32> m_slot_2;
 
-	void handle_item_pressed_event(s_event_record* pevent, int32* pitem_index);
+	void handle_item_pressed_event(s_event_record** pevent, int32* pitem_index);
 public:
 	c_cartographer_guide_edit_list(uint16 _flags);
 
@@ -73,7 +73,7 @@ protected:
 	c_list_item_widget m_list_item_widgets[k_no_of_visible_items_for_cartographer_credits_list];
 	c_slot2<c_cartographer_credits_edit_list, s_event_record*, int32> m_slot_2;
 
-	void handle_item_pressed_event(s_event_record* pevent, int32* pitem_index);
+	void handle_item_pressed_event(s_event_record** pevent, int32* pitem_index);
 
 public:
 	c_cartographer_credits_edit_list(uint16 _flags);
@@ -111,7 +111,7 @@ protected:
 	int32 m_update_status;
 	bool m_keep_screen_open;
 
-	void handle_item_pressed_event(s_event_record* pevent, int32* pitem_index);
+	void handle_item_pressed_event(s_event_record** pevent, int32* pitem_index);
 
 public:
 	c_cartographer_update_edit_list(uint16 _flags);
@@ -153,7 +153,7 @@ protected:
 	c_list_item_widget m_list_item_widgets[k_no_of_visible_items_for_cartographer_update_notice_list];
 	c_slot2<c_cartographer_update_notice_edit_list, s_event_record*, int32> m_slot_2;
 
-	void handle_item_pressed_event(s_event_record* pevent, int32* pitem_index);
+	void handle_item_pressed_event(s_event_record** pevent, int32* pitem_index);
 
 public:
 	c_cartographer_update_notice_edit_list(uint16 _flags);

--- a/xlive/Blam/Engine/interface/screens/screen_main_menu.h
+++ b/xlive/Blam/Engine/interface/screens/screen_main_menu.h
@@ -13,7 +13,7 @@ class c_main_menu_list : protected c_list_widget
 {
 protected:
 	c_list_item_widget m_list_items[k_no_of_visible_items_for_main_menu];
-	c_slot2<c_main_menu_list, s_event_record**, datum> m_slot;
+	c_slot2<c_main_menu_list, s_event_record*, datum> m_slot;
 
 	void handle_item_pressed_event(s_event_record** pevent, datum* pitem_index);
 	void handle_item_campaign(s_event_record** pevent);

--- a/xlive/Blam/Engine/interface/screens/screen_press_start_introduction.h
+++ b/xlive/Blam/Engine/interface/screens/screen_press_start_introduction.h
@@ -9,7 +9,7 @@ class c_screen_press_start_introduction : protected c_screen_widget
 protected:
 	c_button_widget m_start_button;
 	int32 m_creation_time;
-	c_slot2<c_screen_press_start_introduction, s_event_record**, datum> m_slot;
+	c_slot2<c_screen_press_start_introduction, s_event_record*, datum> m_slot;
 	bool m_has_input_saved;
 	char gap[3];
 	s_event_record m_saved_input;

--- a/xlive/Blam/Engine/interface/screens/screen_settings.h
+++ b/xlive/Blam/Engine/interface/screens/screen_settings.h
@@ -20,7 +20,7 @@ class c_settings_list : public c_list_widget
 {
 protected:
 	c_list_item_widget m_list_items[k_no_of_visible_items_for_settings];
-	c_slot2<c_settings_list, s_event_record**, datum> m_slot;
+	c_slot2<c_settings_list, s_event_record*, datum> m_slot;
 	bool field_464; // probably for unlocking "unused" item
 
 	void handle_item_pressed_event(s_event_record** pevent, datum* pitem_index);

--- a/xlive/Blam/Engine/interface/screens/screen_squad_settings.h
+++ b/xlive/Blam/Engine/interface/screens/screen_squad_settings.h
@@ -14,7 +14,7 @@ class c_squad_settings_list : public c_list_widget
 {
 protected:
 	c_list_item_widget m_list_items[k_no_of_visible_items_for_squad_settings];
-	c_slot2<c_squad_settings_list,s_event_record**,datum> m_slot;
+	c_slot2<c_squad_settings_list,s_event_record*,datum> m_slot;
 	bool m_party_mgmt_item_deleted;
 
 	void handle_item_pressed_event(s_event_record** pevent, datum* pitem_index);

--- a/xlive/Blam/Engine/interface/signal_slot.h
+++ b/xlive/Blam/Engine/interface/signal_slot.h
@@ -1,7 +1,4 @@
 #pragma once
-#include "cseries/cseries.h"
-
-/* macro defines*/
 
 /* forward declarations */
 
@@ -78,7 +75,7 @@ public:
 template <class X = c_list_widget, typename Y = s_event_record*, typename type = int16>
 class c_slot2 : public _slot2<Y, type>
 {
-	typedef void(X::* handler_t)(Y, type*);
+	typedef void(X::* handler_t)(Y*, type*);
 
 	X* m_class_ptr;
 	handler_t m_handler;
@@ -94,7 +91,7 @@ public:
 		m_class_ptr = _class;
 		m_handler = handler;
 	}
-	virtual void event_handler(Y event, type* id)
+	virtual void event_handler(Y* event, type* id)
 	{
 		return INVOKE_CLASS_FN(m_class_ptr, m_handler) (event, id);
 	}


### PR DESCRIPTION
- make the handler take in a pointer to the Y type
- fixes type so the overloaded member functions take in a double pointer of s_event_record while the type declaration takes in a single pointer