### PR TITLE
tag injection reserve memory.

### DIFF
--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
@@ -117,6 +117,11 @@ void* tag_injection_extend_block(void* block, uint32 entry_size, uint32 count)
 	return g_manager.extend_tag_block(block, entry_size, count);
 }
 
+void* tag_injection_reserve_cache_memory(uint32 size, uint32* out_data_offset)
+{
+	return g_manager.reserve_space_in_cache_memory(size, out_data_offset);
+}
+
 void tag_injection_apply_hooks()
 {
 }

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.h
@@ -30,5 +30,7 @@ void tag_injection_scenario_load_setup(uint32 allocation_size);
 
 void* tag_injection_extend_block(void* block, uint32 entry_size, uint32 count);
 
+void* tag_injection_reserve_cache_memory(uint32 size, uint32* out_data_offset);
+
 void tag_injection_apply_hooks();
 void tag_injection_initialize();

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
@@ -750,3 +750,14 @@ void* c_tag_injecting_manager::extend_tag_block(void* block, uint32 entry_size, 
 	// return the location in memory where the first newly added block exists
 	return (void*)(cache_get_tag_data() + injection_offset + base_block_total_size);
 }
+
+void* c_tag_injecting_manager::reserve_space_in_cache_memory(uint32 size, uint32* out_data_offset)
+{
+	const uint32 reserved_offset = this->m_base_tag_data_size + this->m_injectable_used_size;
+
+	this->m_injectable_used_size += size;
+
+	*out_data_offset = reserved_offset;
+
+	return (void*)(cache_get_tag_data() + reserved_offset);
+}

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.h
@@ -43,6 +43,7 @@ public:
 
 	void inject_tags();
 	void* extend_tag_block(void* block, uint32 entry_size, uint32 count);
+	void* reserve_space_in_cache_memory(uint32 size, uint32* out_data_offset);
 private:
 	c_tag_injection_table m_table;
 	c_static_flags<k_tag_group_count> m_agents_initialized;


### PR DESCRIPTION
function to reserve memory inside the cache memory region, returns a pointer to the location in memory.