### PR TITLE
dedi offset changes

### DIFF
--- a/xlive/Util/Memory.h
+++ b/xlive/Util/Memory.h
@@ -28,15 +28,27 @@ public:
 		return GetBaseAddress();
 	}
 
-	static DWORD GetAddress(DWORD client, DWORD server = 0)
+	static DWORD GetAddress(DWORD client)
+	{
+		ASSERT(client != 0);
+		return GetBaseAddress() + client;
+	}
+
+	static DWORD GetAddress(DWORD client, DWORD server)
 	{
 		ASSERT( Memory::IsDedicatedServer() || client != 0);
 		ASSERT(!Memory::IsDedicatedServer() || server != 0);
 		return GetBaseAddress() + (IsDedicatedServer() ? server : client);
 	}
+	
+	template <typename T = void*>
+	static T GetAddress(DWORD client)
+	{
+		return reinterpret_cast<T>((DWORD)GetAddress(client));
+	}
 
 	template <typename T = void*>
-	static T GetAddress(DWORD client, DWORD server = 0)
+	static T GetAddress(DWORD client, DWORD server)
 	{
 		return reinterpret_cast<T>((DWORD)GetAddress(client, server));
 	}


### PR DESCRIPTION
- add conditional check in INVOKE_BY_TYPE macro. optimizes out a cmov or related instruction when building release whenever we call a function that doesn't have a dedi address specified
- add GetAddress functions that don't include the server address as a parameter.