### PR TITLE
fix build warnings + other misc changes

### DIFF
--- a/xlive/Blam/Engine/animations/animation_definitions.cpp
+++ b/xlive/Blam/Engine/animations/animation_definitions.cpp
@@ -265,9 +265,9 @@ string_id c_model_animation::get_string_id(void) const
 int32 c_model_animation_graph::find_node(string_id string) const
 {
 	int16 node_count = this->get_node_count();
-	for (int16 i = 0; i < node_count; ++i)
+	for (int32 i = 0; i < node_count; ++i)
 	{
-		if (string == this->get_node(i)->name)
+		if (string == this->get_node((uint8)i)->name)
 		{
 			return i;
 		}
@@ -281,7 +281,7 @@ int32 c_model_animation_graph::find_node_with_flags(e_node_model_flags flags) co
 	int16 node_count = this->get_node_count();
 	for (int32 i = 0; i < node_count; ++i)
 	{
-		if ((this->get_node(i)->model_flags & flags) == flags)
+		if ((this->get_node((uint8)i)->model_flags & flags) == flags)
 		{
 			return i;
 		}

--- a/xlive/Blam/Engine/cache/cache_files.cpp
+++ b/xlive/Blam/Engine/cache/cache_files.cpp
@@ -170,7 +170,7 @@ bool scenario_tags_load_process_shared_tags()
 	const uint32 aligned_data_offset = cache_file_align_read_size_to_cache_page(shared_header.data_offset);
 	const uint32 aligned_data_size = cache_file_align_read_size_to_cache_page(shared_header.data_size);
 
-	if (aligned_tag_size > cache_header->tag_offset_mask)
+	if (aligned_tag_size > (uint32)cache_header->tag_offset_mask)
 		return false;
 
 	// Read tags header

--- a/xlive/Blam/Engine/cseries/cseries.h
+++ b/xlive/Blam/Engine/cseries/cseries.h
@@ -128,9 +128,7 @@ Memory::GetAddress<_type>(_addr_client, _addr_server)(__VA_ARGS__)
 #define PAD128 unsigned __int64 : 64; unsigned __int64 : 64;
 
 // Use this for setting up enum bitfields
-// TODO: (uint64) cast is done as a hack to avoid warnings when doing the left shift on the final bit of a type
-// Find a better way of dealing with this
-#define FLAG(bit)( (uint64)1 << (uint64)(bit) )
+#define FLAG(bit) ( (unsigned)1 << (unsigned)(bit) )
 #define TEST_BIT(flags, bit)( ((flags) & FLAG(bit)) != 0 )
 #define TEST_FLAG(flag, flags)( ((flag) & (flags)) != 0 )
 #define SET_FLAG(flags, bit, value)( (value) ? ((flags) |= FLAG(bit)) : ((flags) &= ~FLAG(bit)) )
@@ -142,8 +140,11 @@ Memory::GetAddress<_type>(_addr_client, _addr_server)(__VA_ARGS__)
 #define BIT_VECTOR_TEST_FLAG(BIT_VECTOR, BIT) (TEST_BIT(BIT_VECTOR[(BIT) / LONG_BITS], ((BIT) & (LONG_BITS - 1))))
 #define BIT_VECTOR_SET_FLAG(BIT_VECTOR, BIT, ENABLE) (SET_FLAG(BIT_VECTOR[(BIT) / LONG_BITS], ((BIT) & (LONG_BITS - 1)), ENABLE))
 
-/// Creates a mask out of a count number of flags
-#define MASK(count) ( (unsigned)FLAG(count) - (unsigned)1 )
+// Creates a bitmask that sets every bit between (bit) - 1 and bit 0 to 1
+// It does this by taking the FLAG value of bit - 1 and using logical OR on it with one of two choices:
+// 0 if the bit passed is less than or equal to 1, otherwise 1 minus the FLAG value of bit - 1
+// Ex. MASK(12) sets bit 11 to bit 0 to 1
+#define MASK(bit) ( (FLAG(bit-1)) | (bit <= 1 ? 0 : ( (FLAG(bit-1) - 1) )) )
 
 #define ASSERT_STRUCT_SIZE(STRUCT, _SIZE)\
 static_assert (sizeof(STRUCT) == (_SIZE), "Invalid size for struct ("#STRUCT") expected size (" #_SIZE")");

--- a/xlive/Blam/Engine/cseries/cseries.h
+++ b/xlive/Blam/Engine/cseries/cseries.h
@@ -127,8 +127,10 @@ Memory::GetAddress<_type>(_addr_client, _addr_server)(__VA_ARGS__)
 /// Add an anonymous 128-bit (16 byte) field to a structure.
 #define PAD128 unsigned __int64 : 64; unsigned __int64 : 64;
 
-/// Use this for setting up enum bitfields
-#define FLAG(bit)( 1<<(bit) )
+// Use this for setting up enum bitfields
+// TODO: (uint64) cast is done as a hack to avoid warnings when doing the left shift on the final bit of a type
+// Find a better way of dealing with this
+#define FLAG(bit)( (uint64)1 << (uint64)(bit) )
 #define TEST_BIT(flags, bit)( ((flags) & FLAG(bit)) != 0 )
 #define TEST_FLAG(flag, flags)( ((flag) & (flags)) != 0 )
 #define SET_FLAG(flags, bit, value)( (value) ? ((flags) |= FLAG(bit)) : ((flags) &= ~FLAG(bit)) )
@@ -179,7 +181,7 @@ ASSERT_EXCEPTION(STATEMENT, true);	\
 (void)0
 
 #else
-#define ASSERT_EXCEPTION()									(void)(0)
+#define ASSERT_TRIGGER_EXCEPTION()							(void)(0)
 #define DISPLAY_ASSERT_EXCEPTION(STATEMENT, IS_EXCEPTION)   (void)(#STATEMENT)
 #define DISPLAY_ASSERT(STATEMENT)                           (void)(#STATEMENT)
 #define ASSERT_EXCEPTION(STATEMENT, IS_EXCEPTION)           (void)(#STATEMENT)

--- a/xlive/Blam/Engine/cseries/cseries_errors.cpp
+++ b/xlive/Blam/Engine/cseries/cseries_errors.cpp
@@ -13,7 +13,7 @@ void error(int32 priority, const char* format, ...)
 	va_list va_args;
 	va_start(va_args, format);
 	char string[1024];
-	csnprintf(string, NUMBEROF(string), NUMBEROF(string), format, va_args);
+	vsnprintf(string, NUMBEROF(string), NUMBEROF(string), format, va_args);
 	error_internal(0, priority, string/*, va_args*/);
 	va_end(va_args);
 #endif
@@ -26,7 +26,7 @@ void error(int32 category, int32 priority, const char* format, ...)
 	va_list va_args;
 	va_start(va_args, format);
 	char string[1024];
-	csnprintf(string, NUMBEROF(string), NUMBEROF(string), format, va_args);
+	vsnprintf(string, NUMBEROF(string), NUMBEROF(string), format, va_args);
 	error_internal(category, priority, string/*, va_args*/);
 	va_end(va_args);
 #endif

--- a/xlive/Blam/Engine/effects/particle_system.cpp
+++ b/xlive/Blam/Engine/effects/particle_system.cpp
@@ -157,7 +157,7 @@ bool __stdcall c_particle_system::frame_advance(c_particle_system* thisx, real32
 			else
 			{
 				string_id marker_name = location_definitions[current_particle_system->definition_location_index].marker_name;
-				switch (marker_name.get_id())
+				switch (marker_name)
 				{
 				case _string_id_up:
 					marker_matrix.vectors.forward = *global_up3d;

--- a/xlive/Blam/Engine/effects/particle_update.cpp
+++ b/xlive/Blam/Engine/effects/particle_update.cpp
@@ -12,7 +12,7 @@ void __cdecl particle_update_points_interpolate_hook(const real_point3d* previou
 	// this can be fired before the initial position of the emitter is set in some situations
 	// there for instead of rendering the particle at the root origin do it at the target (initial) position instead
 	// this is only really noticeable on 30 tick gameplay
-	if (memcmp(previous_point, &global_zero_vector3d, sizeof(real_point3d)) == 0)
+	if (memcmp(previous_point, global_zero_vector3d, sizeof(real_point3d)) == 0)
 		csmemcpy(out, target_point, sizeof(real_point3d));
 	else
 		csmemcpy(out, previous_point, sizeof(real_point3d));

--- a/xlive/Blam/Engine/game/players.cpp
+++ b/xlive/Blam/Engine/game/players.cpp
@@ -3,7 +3,6 @@
 
 #include "game/game.h"
 #include "game/game_engine.h"
-#include "game/game_engine_util.h"
 #include "game/game_globals.h"
 #include "simulation/game_interface/simulation_game_action.h"
 #include "units/units.h"
@@ -546,7 +545,7 @@ void __cdecl player_find_action_context(datum player_datum, s_player_interaction
         {
             // Search 1 includes weapons
             // Search 2 excludes weapons
-            const uint32 search_types[2]
+            const int32 search_types[2]
             {
                 _object_mask_weapon,
                 ~_object_mask_weapon
@@ -559,16 +558,16 @@ void __cdecl player_find_action_context(datum player_datum, s_player_interaction
             };
 
             // Perform the two searches
-            for (uint8 search_num = 0; search_num < 2; ++search_num)
+            for (uint8 search_num = 0; search_num < NUMBEROF(search_types); ++search_num)
             {
-                const uint32 search_type = search_types[search_num];
+                const int32 search_type = search_types[search_num];
                 const real32 search_radius = search_radius_types[search_num];
 
-                const uint32 objects_to_ignore = _object_mask_garbage | _object_mask_projectile | _object_mask_sound_scenery | _object_mask_creature;
+                const int32 objects_to_ignore = _object_mask_garbage | _object_mask_projectile | _object_mask_sound_scenery | _object_mask_creature;
 
                 datum nearby_objects[64];
 
-                const int16 number_of_initial_objects = object_search_for_objects_in_radius(
+                const int16 number_of_initial_objects = (int16)object_search_for_objects_in_radius(
                     0,
                     (search_type & ~objects_to_ignore),
                     &player_unit->unit.object.location,

--- a/xlive/Blam/Engine/hs/hs_unit_seats.h
+++ b/xlive/Blam/Engine/hs/hs_unit_seats.h
@@ -2,7 +2,7 @@
 
 #define k_maximum_hs_unit_seat_mappings 65536
 
-enum e_seat_mapping_bitfield : int
+enum e_seat_mapping_bitfield : uint32
 {
 	seat_mapping_bitfield_seat_0 = FLAG(0),
 	seat_mapping_bitfield_seat_1 = FLAG(1),

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -100,11 +100,11 @@ uint32 input_abstraction_get_stick_type_for_function(e_button_functions function
 }
 
 
-void input_abstraction_update_default_throttle(point2d* thumb, real_euler_angles2d* out_stick_euler_angles)
+void input_abstraction_update_default_throttle(const point2d* thumb, real_euler_angles2d* out_stick_euler_angles)
 {
-	constexpr real32 normalize_scale = 1.0f / INT16_MAX;
+	constexpr real32 normalize_scale = 1.f / INT16_MAX;
 
-	real_point2d thumbstick_points = { thumb->x, thumb->y };
+	real_point2d thumbstick_points = { (real32)thumb->x, (real32)thumb->y };
 	real_angle angle = atan2(thumbstick_points.y, thumbstick_points.x);
 
 	real32 magnitude = MAX(fabs(sin(angle)), fabs(cos(angle)));
@@ -113,9 +113,11 @@ void input_abstraction_update_default_throttle(point2d* thumb, real_euler_angles
 	out_stick_euler_angles->yaw = (real32)(thumbstick_points.x * inverse_magnitude) * normalize_scale;
 	out_stick_euler_angles->pitch = (real32)(thumbstick_points.y * inverse_magnitude) * normalize_scale;
 
-	out_stick_euler_angles->yaw = PIN(out_stick_euler_angles->yaw, -1.0f, 1.0f);
-	out_stick_euler_angles->pitch = PIN(out_stick_euler_angles->pitch, -1.0f, 1.0f);
+	out_stick_euler_angles->yaw = PIN(out_stick_euler_angles->yaw, -1.f, 1.f);
+	out_stick_euler_angles->pitch = PIN(out_stick_euler_angles->pitch, -1.f, 1.f);
+	return;
 }
+
 void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_angle angle, bool right_stick)
 {
 	real_angle flt_7B9F78[] =
@@ -259,8 +261,8 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_axial 
 		|| profile_settings->controller_deadzone_type == _controller_deadzone_type_combined) 
 	{
-		preference->gamepad_axial_deadzone_right.x = THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_axial.x);
-		preference->gamepad_axial_deadzone_right.y = THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_axial.y);
+		preference->gamepad_axial_deadzone_right.x = (uint16)THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_axial.x);
+		preference->gamepad_axial_deadzone_right.y = (uint16)THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_axial.y);
 	}
 	else
 	{
@@ -271,7 +273,7 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_radial 
 		|| profile_settings->controller_deadzone_type == _controller_deadzone_type_combined)
 	{
-		g_controller_radial_deadzones[controller] = THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_radial);
+		g_controller_radial_deadzones[controller] = (uint16)THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_radial);
 	}
 	else
 	{

--- a/xlive/Blam/Engine/input/input_windows.cpp
+++ b/xlive/Blam/Engine/input/input_windows.cpp
@@ -4,14 +4,13 @@
 #include "input_abstraction.h"
 #include "controllers.h"
 
-#include "game/game.h"
-#include "shell/shell_windows.h"
-
 #include "interface/user_interface_controller.h"
-#include "render/render.h"
+#include "shell/shell_windows.h"
 
 extern input_device** g_xinput_devices;
 extern s_input_abstraction_globals* input_abstraction_globals;
+
+/* globals */
 
 bool g_should_offset_gamepad_indices = false;
 bool g_notified_to_change_mapping = false;
@@ -19,10 +18,13 @@ uint32 input_device_change_delay_timer = NULL;
 s_input_globals* input_globals;
 bool* g_input_windows_request_terminate;
 
+/* constants */
+
 XINPUT_VIBRATION g_vibration_state[k_number_of_controllers]{};
 real32 g_rumble_factor = 1.0f;
 
-/* forward declarations*/
+/* prototypes */
+
 int compare_device_compatibility(const void* p1, const void* p2);
 int compare_device_ports(const void* p1, const void* p2);
 void input_windows_update_device_mapping();
@@ -254,10 +256,10 @@ void __cdecl input_set_gamepad_rumbler_state(int16 gamepad_index, uint16 left, u
 	ASSERT(VALID_INDEX(gamepad_index, k_number_of_controllers));
 
 	XINPUT_VIBRATION state = { left, right };
-	XINPUT_VIBRATION state_none = { 0, 0 };
+	const XINPUT_VIBRATION state_none = { 0, 0 };
 
-	state.wLeftMotorSpeed *= g_rumble_factor;
-	state.wRightMotorSpeed *= g_rumble_factor;
+	state.wLeftMotorSpeed = (WORD)(state.wLeftMotorSpeed * g_rumble_factor);
+	state.wRightMotorSpeed = (WORD)(state.wRightMotorSpeed * g_rumble_factor);
 
 	bool enabled = user_interface_controller_get_rumble_enabled((e_controller_index)gamepad_index);
 	g_vibration_state[gamepad_index] = (enabled ? state : state_none);

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -420,7 +420,7 @@ void __cdecl first_person_weapons_update_nodes(int32 user_index, int32 weapon_sl
                             rounds_total = magazine->rounds_loaded_maximum;
                         }
 
-                        ammunition_frame_position = ((rounds_total - rounds_loaded_maximum) * v1) + rounds_loaded_maximum;
+                        ammunition_frame_position = (int16)(((rounds_total - rounds_loaded_maximum) * v1) + rounds_loaded_maximum);
                     }
                     weapon_channel.set_frame_position((real32)ammunition_frame_position);
                     weapon_channel.apply_node_orientations(0.0f, 0.0f, weapon_data->node_orientations_count, fp_orientations->weapon_orientations, 0, 0);
@@ -448,7 +448,11 @@ void __cdecl first_person_weapons_update_nodes(int32 user_index, int32 weapon_sl
             if (TEST_BIT(fp_data->flags, 1) && weapon_data->animation_manager.interpolator_controls[1].enabled())
             {
                 ASSERT(weapon_data->node_orientations_count == weapon_data->animation_manager.get_node_count());
-                weapon_data->animation_manager.interpolate_node_orientations(weapon_data->node_orientations_count, NULL, fp_orientations->hand_orientations, fp_orientations->weapon_orientations);
+                weapon_data->animation_manager.interpolate_node_orientations(
+                    (int16)weapon_data->node_orientations_count,
+                    NULL,
+                    fp_orientations->hand_orientations,
+                    fp_orientations->weapon_orientations);
             }
             SET_FLAG(fp_data->flags, 1, true);
             

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -778,7 +778,7 @@ void first_person_weapon_apply_ik(int32 user_index, s_first_person_model_data* f
                     while (fp_data->weapons[0].animation_manager.find_next_weapon_ik_point(&iterator))
                     {
                         if (iterator.attach_to_marker != NONE 
-                            && iterator.attach_to_marker.get_packed() 
+                            && iterator.attach_to_marker 
                             && IN_RANGE(fp_data->character_type, _character_type_masterchief, globals->player_representation.count - 1) )
                         {
                             const s_game_globals_player_representation* player_rep = globals->player_representation[fp_data->character_type];

--- a/xlive/Blam/Engine/interface/interface.cpp
+++ b/xlive/Blam/Engine/interface/interface.cpp
@@ -115,7 +115,7 @@ void render_splitscreen_line(void)
 	const int16 resolution_y = (int16)rasterizer_globals->resolution_y;
 
 	// We calculate the size of the line by dividing our resolution by the height the original game ran at
-	const int32 line_size = resolution_y / 480;		
+	const int16 line_size = resolution_y / 480;		
 	
 	rectangle2d line;
 	pixel32 color = k_splitscreen_line_colour;

--- a/xlive/Blam/Engine/interface/new_hud_draw.cpp
+++ b/xlive/Blam/Engine/interface/new_hud_draw.cpp
@@ -467,8 +467,8 @@ void __cdecl draw_hud_bitmap_widget(int32 local_render_user_index, s_new_hud_tem
 			render_ingame_user_interface_hud_element_hook(
 				final_location.x,
 				final_location.y,
-				bitmap_size.x,
-				bitmap_size.y,
+				(int16)bitmap_size.x,
+				(int16)bitmap_size.y,
 				hud_scale,
 				theta_result,
 				bitmap_widget->bitmap.index,
@@ -487,8 +487,8 @@ void __cdecl draw_hud_bitmap_widget(int32 local_render_user_index, s_new_hud_tem
 			render_ingame_user_interface_hud_element_hook(
 				(bitmap_size.x * hud_scale) + final_location.x,
 				final_location.y,
-				bitmap_size.x,
-				bitmap_size.y,
+				(int16)bitmap_size.x,
+				(int16)bitmap_size.y,
 				hud_scale,
 				theta_result,
 				bitmap_widget->bitmap.index,
@@ -509,8 +509,8 @@ void __cdecl draw_hud_bitmap_widget(int32 local_render_user_index, s_new_hud_tem
 			render_ingame_user_interface_hud_element_hook(
 				final_location.x,
 				bitmap_size.y * hud_scale + final_location.y,
-				bitmap_size.x,
-				bitmap_size.y,
+				(int16)bitmap_size.x,
+				(int16)bitmap_size.y,
 				hud_scale,
 				theta_result,
 				bitmap_widget->bitmap.index,
@@ -529,8 +529,8 @@ void __cdecl draw_hud_bitmap_widget(int32 local_render_user_index, s_new_hud_tem
 			render_ingame_user_interface_hud_element_hook(
 				(bitmap_size.x * hud_scale) + final_location.x,
 				bitmap_size.y * hud_scale + final_location.y,
-				bitmap_size.x,
-				bitmap_size.y,
+				(int16)bitmap_size.x,
+				(int16)bitmap_size.y,
 				hud_scale,
 				theta_result,
 				bitmap_widget->bitmap.index,
@@ -712,8 +712,8 @@ void __cdecl draw_hud_text_widget(uint32 local_render_user_index, s_new_hud_temp
 		int32 text_height = rectangle2d_height(&draw_string_bounds);
 		real32 calc_text_height = (text_height * *get_primary_hud_scale()) * scale_result.y;
 
-		int32 ceil_text_width = ceil(calc_text_width);
-		int32 ceil_text_height = ceil(calc_text_height);
+		int32 ceil_text_width = (int32)ceil(calc_text_width);
+		int32 ceil_text_height = (int32)ceil(calc_text_height);
 
 		draw_string_set_player_color(global_real_argb_white);
 		draw_string_set_shadow_color(global_real_argb_black);
@@ -724,7 +724,7 @@ void __cdecl draw_hud_text_widget(uint32 local_render_user_index, s_new_hud_temp
 			text_bounds.left = (int16)(final_location.x - (real32)(ceil_text_width >> 1));
 			text_bounds.top = (int16)final_location.y;
 			text_bounds.right = (int16)(final_location.x + (real32)(ceil_text_width - (ceil_text_width >> 1)));
-			text_bounds.bottom = (int16)ceil_text_height + final_location.y;
+			text_bounds.bottom = (int16)(ceil_text_height + final_location.y);
 			break;
 		case text_justification_right:
 			text_bounds.left = (int16)(final_location.x - ceil_text_width);

--- a/xlive/Blam/Engine/interface/new_hud_draw.cpp
+++ b/xlive/Blam/Engine/interface/new_hud_draw.cpp
@@ -653,7 +653,7 @@ void draw_hud_text_get_string(s_draw_hud_widget_input_results* widget_function_r
 
 void __cdecl draw_hud_text_widget(uint32 local_render_user_index, s_new_hud_temporary_user_state* user_state, s_hud_text_widget_definition* text_widget, s_draw_hud_widget_input_results* widget_function_results)
 {
-	if (!text_widget->string.is_valid() || text_widget->shader.index == NONE)
+	if (!text_widget->string != 0 || text_widget->shader.index == NONE)
 		return;
 
 	wchar_t widget_string[512]{};

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_account_manager.cpp
@@ -125,7 +125,7 @@ const wchar_t *const *const k_screen_label_table_eng[k_cartographer_account_mana
 	k_screen_type_list_add_account_eng
 };
 
-const wchar_t const* const* const* k_screen_label_table[k_language_count] =
+const wchar_t *const *const *const k_screen_label_table[k_language_count] =
 {
 	k_screen_label_table_eng,
 	k_screen_label_table_eng,

--- a/xlive/Blam/Engine/interface/screens/screen_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_settings.cpp
@@ -410,7 +410,7 @@ void c_screen_settings::apply_patches_on_map_load()
 	csmemcpy(main_widget_tag->panes[_settings_pane_guide], main_widget_tag->panes[_settings_pane_about], sizeof(s_window_pane_reference));
 	
 	// updating the new number of visible items in each pane
-	for (size_t i = 0; i < main_widget_tag->panes.count; ++i)
+	for (int32 i = 0; i < main_widget_tag->panes.count; ++i)
 	{
 		main_widget_tag->panes[i]->list_block[0]->num_visible_items = k_no_of_visible_items_for_settings;
 	}

--- a/xlive/Blam/Engine/interface/user_interface_utilities.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_utilities.cpp
@@ -53,19 +53,21 @@ void __cdecl user_interface_get_cursor_position_scaled(point2d* out_position)
 
 		window_bound* bounds = get_user_window_bounds(0);
 
-		temp_position.x -= bounds->rasterizer_camera.viewport_bounds.right / 2.0f;
-		temp_position.y = (bounds->rasterizer_camera.viewport_bounds.bottom / 2.0f) - temp_position.y;
+		temp_position.x = (int16)(temp_position.x - bounds->rasterizer_camera.viewport_bounds.right / 2.f);
+		temp_position.y = (int16)((bounds->rasterizer_camera.viewport_bounds.bottom / 2.f) - temp_position.y);
 
-		temp_position.x /= *get_ui_scale();
-		temp_position.y /= *get_ui_scale();
+		temp_position.x = (int16)(temp_position.x / *get_ui_scale());
+		temp_position.y = (int16)(temp_position.y / *get_ui_scale());
 
 		// Convert to integer coordinates
 		out_position->x = temp_position.x;
 		out_position->y = temp_position.y;
 	}
+	return;
 }
 
 void user_interface_utilities_apply_patches()
 {
 	DETOUR_ATTACH(p_user_interface_get_cursor_position, Memory::GetAddress<user_interface_get_cursor_position_scale_t>(0x21D620), user_interface_get_cursor_position_scaled);
+	return;
 }

--- a/xlive/Blam/Engine/main/main_game_time.cpp
+++ b/xlive/Blam/Engine/main/main_game_time.cpp
@@ -75,7 +75,7 @@ real32 __cdecl main_time_update_hook(bool fixed_time_step, real32 fixed_time_del
 	else
 	{
 		time_now_msec = main_time_get_absolute_milliseconds();
-		dt_sec = (double)(time_now_msec - main_time_globals->last_milliseconds) / 1000.;
+		dt_sec = (real32)((real64)(time_now_msec - main_time_globals->last_milliseconds) / 1000.);
 
 		// don't run the frame limiter when time step is fixed, because the code doesn't support it
 		// in case of fixed time step, frame limiter should be handled by the other frame limiter
@@ -90,7 +90,7 @@ real32 __cdecl main_time_update_hook(bool fixed_time_step, real32 fixed_time_del
 				while (frame_time > dt_sec)
 				{
 					uint32 yield_time_msec = 0;
-					real32 fMsSleep = (real32)(frame_time - dt_sec) * 1000.;
+					real32 fMsSleep = (real32)(frame_time - dt_sec) * 1000.f;
 
 					if (fMsSleep >= 1.0f)
 					{
@@ -103,7 +103,7 @@ real32 __cdecl main_time_update_hook(bool fixed_time_step, real32 fixed_time_del
 
 
 					time_now_msec = main_time_get_absolute_milliseconds();
-					dt_sec = (double)(time_now_msec - main_time_globals->last_milliseconds) / 1000.;
+					dt_sec = (real32)((real64)(time_now_msec - main_time_globals->last_milliseconds) / 1000.);
 				}
 			}
 			else
@@ -111,7 +111,7 @@ real32 __cdecl main_time_update_hook(bool fixed_time_step, real32 fixed_time_del
 				Sleep(15u);
 
 				time_now_msec = main_time_get_absolute_milliseconds();
-				dt_sec = (double)(time_now_msec - main_time_globals->last_milliseconds) / 1000.;
+				dt_sec = (real32)((real64)(time_now_msec - main_time_globals->last_milliseconds) / 1000.);
 			}
 		}
 	}

--- a/xlive/Blam/Engine/main/main_screenshot.cpp
+++ b/xlive/Blam/Engine/main/main_screenshot.cpp
@@ -383,10 +383,10 @@ bool __cdecl screenshot_render(window_bound* window)
 											ASSERT(rotated_x >= 0 && rotated_x < screen_width);
 											ASSERT(rotated_y >= 0 && rotated_y < screen_height);
 
-											const int16 final_x = is_horizontal_tile ? horizontal_tile_x : rotated_x;
-											const int16 final_y = is_vertical_tile ? vertical_tile_y : rotated_y;
+											const int32 final_x = is_horizontal_tile ? horizontal_tile_x : rotated_x;
+											const int32 final_y = is_vertical_tile ? vertical_tile_y : rotated_y;
 											uint32* address_0 = bitmap_2d_address(bitmap_0, x, y, 0);
-											uint32* address_1 = bitmap_2d_address(bitmap_1, final_x, final_y, 0);
+											uint32* address_1 = bitmap_2d_address(bitmap_1, (int16)final_x, (int16)final_y, 0);
 											*address_1 = *address_0;	// Copy data from bitmap 0 to 1
 
 											rotated_x += cube_y[0];
@@ -423,8 +423,8 @@ bool __cdecl screenshot_render(window_bound* window)
 									uint32* address_0 = bitmap_2d_address(bitmap_0, x, y, 0);
 									uint32* address_1 = bitmap_2d_address(
 										bitmap_1,
-										horizontal_tile_num + (screenshot_globals->resolution_multiplier * x),
-										vertical_tile_num + (screenshot_globals->resolution_multiplier * y),
+										(int16)(horizontal_tile_num + (screenshot_globals->resolution_multiplier * x)),
+										(int16)(vertical_tile_num + (screenshot_globals->resolution_multiplier * y)),
 										0);
 									*address_1 = *address_0;
 								}

--- a/xlive/Blam/Engine/main/main_screenshot.h
+++ b/xlive/Blam/Engine/main/main_screenshot.h
@@ -27,7 +27,7 @@ struct s_movie_globals
 	bool in_progress;
 	int8 pad[3];
 	int32 recording_start_tick;
-	int32 recording_stop_tick;
+	uint32 recording_stop_tick;
 	int32 recording_frame_index;
 	int32 field_10;
 	int32 field_14;

--- a/xlive/Blam/Engine/main/map_repository.cpp
+++ b/xlive/Blam/Engine/main/map_repository.cpp
@@ -360,8 +360,8 @@ void __thiscall c_custom_map_manager::load_custom_map_data_cache()
 	if (m_custom_map_file_data_cache != nullptr)
 		delete[] m_custom_map_file_data_cache;
 
-	this->m_custom_map_file_data_cache		= custom_map_cache_file_header;
-	this->m_map_count					= custom_map_cache_file_header->entry_count;
+	this->m_custom_map_file_data_cache = custom_map_cache_file_header;
+	this->m_map_count = (uint16)custom_map_cache_file_header->entry_count;
 	this->m_new_custom_map_entry_list_buffer	
 		= get_custom_map_entry_list_from_header(custom_map_cache_file_header);
 

--- a/xlive/Blam/Engine/memory/static_arrays.h
+++ b/xlive/Blam/Engine/memory/static_arrays.h
@@ -48,7 +48,7 @@ public:
 		return VALID_INDEX(bit, k_count);
 	}
 
-	// Checks if current value set for the bitflag is valud
+	// Checks if current value set for the bitflag is valid
 	bool valid(void) const
 	{
 		return !TEST_FLAG(m_storage, ~MASK(k_count));
@@ -132,7 +132,7 @@ public:
 	}
 
 protected:
-	t_storage_type m_storage : k_count;
+	t_storage_type m_storage;
 };
 
 template<typename t_type, typename t_storage_type, size_t k_count>

--- a/xlive/Blam/Engine/networking/replication/replication_entity.cpp
+++ b/xlive/Blam/Engine/networking/replication/replication_entity.cpp
@@ -4,7 +4,7 @@
 void replication_entity_index_decode(c_bitstream* bitstream, int32* replication_entity_index)
 {
 	uint32 entity_abs_index = bitstream->read_integer("entity-absolute-index", 10);
-	uint8 seed = bitstream->read_integer("entity-seed", 4);
+	uint8 seed = (uint8)bitstream->read_integer("entity-seed", 4);
 
 	*replication_entity_index = entity_abs_index | (seed << 28);
 	return;
@@ -13,7 +13,7 @@ void replication_entity_index_decode(c_bitstream* bitstream, int32* replication_
 void replication_entity_index_decode_get_abs_entity_index(c_bitstream* bitstream, int32* replication_entity_index, uint32* entity_abs_index)
 {
 	*entity_abs_index = bitstream->read_integer("entity-absolute-index", 10);
-	uint8 seed = bitstream->read_integer("entity-seed", 4);
+	uint8 seed = (uint8)bitstream->read_integer("entity-seed", 4);
 
 	*replication_entity_index = *entity_abs_index | (seed << 28);
 	return;

--- a/xlive/Blam/Engine/objects/objects.cpp
+++ b/xlive/Blam/Engine/objects/objects.cpp
@@ -504,22 +504,22 @@ datum object_new_internal(datum object_index, object_placement_data* data)
 	object_datum* object = object_get_fast_unsafe(object_index);
 
 	object_header->flags.set(_object_header_post_update_bit, true);
-	object_header->type = object_def->object.object_type;
+	object_header->type = (int8)object_def->object.object_type;
 	object->tag_definition_index = data->tag_index;
 
 	if (data->object_identifier.get_source() == NONE)
 	{
 		object->object_identifier.create_dynamic((e_object_type)object_def->object.object_type);
 		object->placement_index = NONE;
-		object->structure_bsp_index = get_global_structure_bsp_index();
+		object->structure_bsp_index = (uint8)get_global_structure_bsp_index();
 	}
 	else
 	{
 		ASSERT(data->scenario_datum_index != NONE);
 		ASSERT(data->object_identifier.get_type() == object_def->object.object_type);
 		object->object_identifier = data->object_identifier;
-		object->placement_index = data->scenario_datum_index;
-		object->structure_bsp_index = data->object_identifier.get_origin_bsp();
+		object->placement_index = (int16)data->scenario_datum_index;
+		object->structure_bsp_index = (uint8)data->object_identifier.get_origin_bsp();
 	}
 
 	object->position = data->position;
@@ -646,17 +646,17 @@ datum object_new_internal(datum object_index, object_placement_data* data)
 	}
 
 
-	int16 orientation_size = (!allow_interpolation ? 0 : 32 * node_count);
+	const int16 orientation_size = (int16)(!allow_interpolation ? 0 : 32 * node_count);
 
 	// TODO: header asserts here
 
 	// Allocate object header blocks
 	bool can_create_object =
 		object_header_block_allocate(object_index, offsetof(object_datum, object_attachments_block), (uint16)8 * (uint16)object_def->object.attachments.count, 0)
-		&& object_header_block_allocate(object_index, offsetof(object_datum, damage_sections_block), 8 * damage_info_damage_sections_size, 0)
+		&& object_header_block_allocate(object_index, offsetof(object_datum, damage_sections_block), (int16)(8 * damage_info_damage_sections_size), 0)
 		&& object_header_block_allocate(object_index, offsetof(object_datum, change_color_block), (uint16)24 * (uint16)object_def->object.change_colors.count, 0)
-		&& object_header_block_allocate(object_index, offsetof(object_datum, nodes_block), sizeof(real_matrix4x3) * node_count, 0)
-		&& object_header_block_allocate(object_index, offsetof(object_datum, collision_regions_block), 10 * collision_regions_count, 0)
+		&& object_header_block_allocate(object_index, offsetof(object_datum, nodes_block), (int16)(sizeof(real_matrix4x3) * node_count), 0)
+		&& object_header_block_allocate(object_index, offsetof(object_datum, collision_regions_block), (int16)(10 * collision_regions_count), 0)
 		&& object_header_block_allocate(object_index, offsetof(object_datum, original_orientation_block), orientation_size, 4)
 		&& object_header_block_allocate(object_index, offsetof(object_datum, node_orientation_block), orientation_size, 4)
 		&& object_header_block_allocate(object_index, offsetof(object_datum, animation_manager_block), (valid_animation_manager ? 144 : 0), 0)
@@ -1076,7 +1076,7 @@ int16 __cdecl internal_object_get_markers_by_string_id(datum object_index, strin
 
 			if (marker_index)
 			{
-				return marker_index;
+				return (int16)marker_index;
 			}
 		}
 	}
@@ -1096,7 +1096,7 @@ int16 __cdecl internal_object_get_markers_by_string_id(datum object_index, strin
 		scale_vector3d(&marker_object->matrix.vectors.left, -1.0f, &marker_object->matrix.vectors.left);
 	}
 
-	return (marker != 0 ? marker_index : 1);
+	return (marker != 0 ? (int16)marker_index : 1);
 }
 
 int16 __cdecl object_get_markers_by_string_id(datum object_index, string_id marker, object_marker* marker_object, int16 count)

--- a/xlive/Blam/Engine/physics/character_physics_mode_melee.cpp
+++ b/xlive/Blam/Engine/physics/character_physics_mode_melee.cpp
@@ -5,8 +5,6 @@
 #include "game/game_time.h"
 #include "math/math.h"
 
-FLOATING_POINT_ENV_ACCESS();
-
 extern bool g_xbox_tickrate_enabled;
 
 bool melee_lunge_hook_enabled = true;
@@ -137,8 +135,8 @@ void c_character_physics_mode_melee_datum::melee_deceleration_fixup
 		real32 real_time_to_target = ((remaining_distance_from_player_position / max_speed_per_tick_2) - 0.5f);
 
 		// field_28 is always the same after the first melee tick
-		real32 unk1 = m_field_28 * 1.5;
-		double unk2 = MAX(MIN(unk1, 3.5), 0.75);
+		real32 unk1 = m_field_28 * 1.5f;
+		real32 unk2 = MAX(MIN(unk1, 3.5f), 0.75f);
 
 		real32 maybe_minimum_velocity = game_tick_length() * unk2;
 
@@ -227,7 +225,7 @@ void c_character_physics_mode_melee_datum::melee_deceleration_fixup
 
 				real32 deceleration = m_velocity_to_decelerate / k_deceleration_ticks_real;
 
-				m_time_to_target_in_ticks = (current_velocity_per_tick / deceleration) - 0.5f;
+				m_time_to_target_in_ticks = (int)((current_velocity_per_tick / deceleration) - 0.5f);
 				
 				if (deceleration > current_velocity_per_tick)
 				{
@@ -456,7 +454,7 @@ void __thiscall c_character_physics_mode_melee_datum::update_internal
 
 					// not entirely sure if this is actually min_velocity_after_deceleration_per_tick
 					// but it looks like it
-					double temp = MAX(MIN(unk3, 3.5), 0.75);
+					real32 temp = MAX(MIN(unk3, 3.5f), 0.75f);
 
 					real32 min_velocity_after_deceleration_per_tick = game_tick_length() * temp;
 

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_fullscreen_passes.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_fullscreen_passes.cpp
@@ -73,8 +73,8 @@ void rasterizer_dx9_fullscreen_calculate_texcoords(const real_rectangle2d* bound
 
     // texcoords normalized device coordinates (origin in 0,0 bottom left, max 1,1 top right)
     // set the tex coords based on the texture set to be drawn on the screen
-    const uint32 bounds_width = bounds->x1 - bounds->x0;
-    const uint32 bounds_height = bounds->y1 - bounds->y0;
+	const uint32 bounds_width = (uint32)(bounds->x1 - bounds->x0);
+	const uint32 bounds_height = (uint32)(bounds->y1 - bounds->y0);
 
     uint32 tex_width;
     uint32 tex_height;

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
@@ -436,7 +436,7 @@ bool __cdecl rasterizer_dx9_create_texture(uint32 width, uint32 height, int32 le
     return INVOKE(0x260820, 0x0, rasterizer_dx9_create_texture, width, height, levels, usage, format, linear, texture);
 }
 
-void rasterizer_dx9_texture_stage_dimensions(uint8 stage, uint32 width, uint32 height)
+void rasterizer_dx9_texture_stage_dimensions(int16 stage, uint32 width, uint32 height)
 {
     s_rasterizer_globals* rasterizer_globals = rasterizer_globals_get();
     rasterizer_globals->bitmaps.textures_staged_width[stage] = width;

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.h
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.h
@@ -113,7 +113,7 @@ bool rasterizer_dx9_draw_primitive_up(
 
 bool __cdecl rasterizer_dx9_create_texture(uint32 width, uint32 height, int32 levels, uint32 usage, e_bitmap_data_format format, bool linear, IDirect3DTexture9** texture);
 
-void rasterizer_dx9_texture_stage_dimensions(uint8 stage, uint32 width, uint32 height);
+void rasterizer_dx9_texture_stage_dimensions(int16 stage, uint32 width, uint32 height);
 
 bool __cdecl rasterizer_dx9_device_set_texture(uint32 stage, IDirect3DTexture9* texture);
 

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.cpp
@@ -282,7 +282,7 @@ void c_shader_submission_interface_new::stage_texture(
             }
 
             bitmap = pp_def->bitmap_get(bitmap_index);
-            rasterizer_dx9_set_texture_direct(stage, bitmap->bitmap_group, bitmap->bitmap_index, 0.f);
+            rasterizer_dx9_set_texture_direct(stage, bitmap->bitmap_group, (int16)bitmap->bitmap_index, 0.f);
             continue_staging = false;
             break;
 
@@ -314,9 +314,10 @@ void __cdecl rasterizer_shader_level_of_detail_bias_update(void)
 	return;
 }
 
-void __cdecl rasterizer_shader_submit(datum shader_index, int32 a2, int32 a3, int32 a4, int32 a5, int32 a6)
+void __cdecl rasterizer_shader_submit(datum shader_index, int32 a2, int32 render_layer, int32 a4, int32 a5, real32 z_far)
 {
-    INVOKE(0x269E9A, 0, rasterizer_shader_submit, shader_index, a2, a3, a4, a5, a6);
+    INVOKE(0x269E9A, 0, rasterizer_shader_submit, shader_index, a2, render_layer, a4, a5, z_far);
+    return;
 }
 
 void rasterizer_flags_unknown_function_1()

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.h
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_shader_submit_new.h
@@ -78,7 +78,7 @@ int32* convolution_targets_get(void);
 
 void __cdecl rasterizer_shader_level_of_detail_bias_update(void);
 
-void __cdecl rasterizer_shader_submit(datum shader_index, int32 a2, int32 a3, int32 a4, int32 a5, int32 a6);
+void __cdecl rasterizer_shader_submit(datum shader_index, int32 a2, int32 render_layer, int32 a4, int32 a5, real32 a6);
 
 // these functions modify some flags but cannot ascertain what they do.
 void __cdecl rasterizer_flags_unknown_function_1();

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_targets.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_targets.cpp
@@ -408,7 +408,7 @@ void __cdecl rasterizer_dx9_set_target(e_rasterizer_target rasterizer_target, in
         d3d_surface = rasterizer_dx9_target_get_main_mip_surface(rasterizer_target);
         break;
     case _rasterizer_target_shadow_alias_swizzled:
-        d3d_surface = rasterizer_dx9_get_target_mip_surface(_rasterizer_target_shadow_alias_swizzled, mipmap_index);
+        d3d_surface = rasterizer_dx9_get_target_mip_surface(_rasterizer_target_shadow_alias_swizzled, (int16)mipmap_index);
         break;
     case _rasterizer_target_dynamic_gamma:
         DISPLAY_ASSERT("_rasterizer_target_dynamic_gamma is no longer available");
@@ -525,10 +525,10 @@ void __cdecl rasterizer_dx9_set_target(e_rasterizer_target rasterizer_target, in
             else if (global_window_parameters->is_texture_camera && !*hs_texture_camera_view_get())
             {
                 viewport_scale = PIN(*hs_texture_camera_scale_get(), 0.0625f, 1.f);
-                viewport.X = global_window_parameters->camera.viewport_bounds.left * viewport_scale;
-                viewport.Y = global_window_parameters->camera.viewport_bounds.top * viewport_scale;
-                viewport.Width = viewport_width * viewport_scale;
-                viewport.Height = viewport_height * viewport_scale;
+                viewport.X = (DWORD)(global_window_parameters->camera.viewport_bounds.left * viewport_scale);
+                viewport.Y = (DWORD)(global_window_parameters->camera.viewport_bounds.top * viewport_scale);
+                viewport.Width = (DWORD)(viewport_width * viewport_scale);
+                viewport.Height = (DWORD)(viewport_height * viewport_scale);
             }
             else
             {
@@ -779,8 +779,8 @@ bool __cdecl rasterizer_dx9_secondary_targets_initialize(void)
     D3DVIEWPORT9 d3d_viewport;
     dx9_globals->global_d3d_device->GetViewport(&d3d_viewport);
 
-    dx9_globals->global_d3d_sun_width = (d3d_viewport.Height * g_sun_size) * rasterizer_globals->sun_width_scale;
-    dx9_globals->global_d3d_sun_height = (d3d_viewport.Height * g_sun_size);
+    dx9_globals->global_d3d_sun_width = (uint32)((d3d_viewport.Height * g_sun_size) * rasterizer_globals->sun_width_scale);
+    dx9_globals->global_d3d_sun_height = (uint32)(d3d_viewport.Height * g_sun_size);
 
     result &=
         rasterizer_dx9_create_texture(

--- a/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
+++ b/xlive/Blam/Engine/render/render_cartographer_ingame_ui.cpp
@@ -282,10 +282,10 @@ void render_netdebug_text(void)
 				{
 					observer_channel = &session->m_network_observer->m_observer_channels[observer_channel_index];
 
-					netdebug_data->client_rtt_msec = observer_channel->net_rtt;
-					netdebug_data->client_packet_rate = observer_channel->stream_packet_rate * 10.f;
-					netdebug_data->client_throughput = (observer_channel->throughput_bps * 10.f) / 1024.f;
-					netdebug_data->client_packet_loss_percentage = observer_channel->field_440.average_values_in_window() * 100.f;
+					netdebug_data->client_rtt_msec = (int16)observer_channel->net_rtt;
+					netdebug_data->client_packet_rate = (int16)(observer_channel->stream_packet_rate * 10.f);
+					netdebug_data->client_throughput = (int16)((observer_channel->throughput_bps * 10.f) / 1024.f);
+					netdebug_data->client_packet_loss_percentage = (int16)(observer_channel->field_440.average_values_in_window() * 100.f);
 
 					// NOT UPDATED IN REAL-TIME
 					//for (int32 i = 0; i < k_number_of_users; i++)
@@ -306,8 +306,8 @@ void render_netdebug_text(void)
 			wchar_t netdebug_text[512];
 			
 			rasterizer_get_frame_bounds(&bounds);
-			bounds.top = (8 * rasterizer_globals->ui_scale);
-			bounds.left = bounds.right - (1070 * rasterizer_globals->ui_scale);
+			bounds.top = (int16)(8 * rasterizer_globals->ui_scale);
+			bounds.left = bounds.right - (int16)(1070 * rasterizer_globals->ui_scale);
 			bounds.bottom = bounds.top + line_height;
 
 			real_argb_color text_color_console = *global_real_argb_white;

--- a/xlive/Blam/Engine/render/render_lod_new.cpp
+++ b/xlive/Blam/Engine/render/render_lod_new.cpp
@@ -242,7 +242,7 @@ void __cdecl object_build_render_cache_and_info(
         object_get_model_node_data(
             object_index,
             info->first_person,
-            render_model_storage_index,
+            (int16)render_model_storage_index,
             &flags,
             &info->object_index[render_model_storage_index],
             &info->render_model_tag_defs[render_model_storage_index],
@@ -300,7 +300,7 @@ void __cdecl object_build_render_cache_and_info(
             &info->field_75[16 * render_model_storage_index]
             );
 
-        info->field_2C[render_model_storage_index] = unk_count1;
+        info->field_2C[render_model_storage_index] = (uint8)unk_count1;
         info->rasterizer_pool_offsets[render_model_storage_index] = NONE;
 
         if (!object_is_cached || info->first_person)

--- a/xlive/Blam/Engine/render/render_lod_new.h
+++ b/xlive/Blam/Engine/render/render_lod_new.h
@@ -42,7 +42,7 @@ struct s_render_object_info
     uint8 gap_16D[3];
     uint32 field_170;
     int32 field_174;
-    int32 field_178;
+    datum shader_tag_index;
     int32 field_17C;
     int32 field_180;
     int32 field_184;

--- a/xlive/Blam/Engine/render/render_submit.cpp
+++ b/xlive/Blam/Engine/render/render_submit.cpp
@@ -137,7 +137,7 @@ void __cdecl render_submit_transparent_hologram_geometry(uint32* a1)
 			D3DTEXF_LINEAR);
 	}
 
-	render_section_visibility_compute(0, flags | 0xFFFFFFCF, model_group_index, NONE, 0, NONE, 0, true);
+	render_section_visibility_compute(0, flags | ~48, (uint8)model_group_index, NONE, 0, NONE, 0, true);
 
 	render_scene_geometry(_collection_type_0, _render_layer_texture_accumulate);
 	render_scene_geometry(_collection_type_0, _render_layer_lightmap_indirect);

--- a/xlive/Blam/Engine/shell/shell_windows.cpp
+++ b/xlive/Blam/Engine/shell/shell_windows.cpp
@@ -179,14 +179,14 @@ void shell_windows_throttle_framerate(int desired_framerate)
 		return;
 	}
 
-	auto min_frametime_usec = (long long)(1000000.0 / (double)desired_framerate);
-	auto dt_usec = shell_time_diff(last_counter, k_shell_time_usec_denominator);
+	unsigned long long min_frametime_usec = (long long)(1000000.0 / (double)desired_framerate);
+	unsigned long long dt_usec = shell_time_diff(last_counter, k_shell_time_usec_denominator);
 
 	const int min_time_to_suspend_exec_usec = 3000;
 
 	if (dt_usec < min_frametime_usec)
 	{
-		auto sleep_time_usec = min_frametime_usec - dt_usec;
+		unsigned long long sleep_time_usec = min_frametime_usec - dt_usec;
 
 		// sleep threadWaitTimePercentage out of the target render time using thread sleep or timer wait
 		long long system_yield_time_usec = (threadWaitTimePercentage * sleep_time_usec) / 100;

--- a/xlive/Blam/Engine/simulation/game_interface/simulation_game_objects.cpp
+++ b/xlive/Blam/Engine/simulation/game_interface/simulation_game_objects.cpp
@@ -67,7 +67,7 @@ bool __stdcall c_simulation_object_entity_definition__object_creation_decode(voi
 {
     if (packet->read_bool("model-variant-index-exists"))
     {
-        creation_data->model_variant_index = packet->read_integer("model-variant-index", 6);    // 6 bits since k_maximum_variants_per_model is 64
+        creation_data->model_variant_index = (int8)packet->read_integer("model-variant-index", 6);    // 6 bits since k_maximum_variants_per_model is 64
     }
     else
     {

--- a/xlive/Blam/Engine/simulation/simulation_entity_database.cpp
+++ b/xlive/Blam/Engine/simulation/simulation_entity_database.cpp
@@ -180,11 +180,11 @@ uint32 c_simulation_entity_database::read_creation_from_packet(int32 entity_inde
 
                         // copy the block, allow the process function to use this
                         blocks[*block_count + _entity_creation_block_order_simulation_entity_creation].block_type = _network_memory_block_simulation_entity_creation;
-                        blocks[*block_count + _entity_creation_block_order_simulation_entity_creation].block_size = creation_data_size;
+                        blocks[*block_count + _entity_creation_block_order_simulation_entity_creation].block_size = (int16)creation_data_size;
                         blocks[*block_count + _entity_creation_block_order_simulation_entity_creation].block_data = creation_data;
 
                         blocks[*block_count + _entity_creation_block_order_simulation_entity_state].block_type = _network_memory_block_simulation_entity_state;
-                        blocks[*block_count + _entity_creation_block_order_simulation_entity_state].block_size = state_data_size;
+                        blocks[*block_count + _entity_creation_block_order_simulation_entity_state].block_size = (int16)state_data_size;
                         blocks[*block_count + _entity_creation_block_order_simulation_entity_state].block_data = state_data;
 
                         blocks[*block_count + _entity_creation_block_order_forward_memory_queue_element].block_type = _network_memory_block_forward_simulation_queue_element;
@@ -327,7 +327,7 @@ int32 c_simulation_entity_database::read_update_from_packet(
                 *out_update_mask = update_mask;
 
                 blocks[*block_count + _entity_update_block_order_simulation_entity_state].block_type = _network_memory_block_simulation_entity_state;
-                blocks[*block_count + _entity_update_block_order_simulation_entity_state].block_size = game_entity->state_data_size;
+                blocks[*block_count + _entity_update_block_order_simulation_entity_state].block_size = (int16)game_entity->state_data_size;
                 blocks[*block_count + _entity_update_block_order_simulation_entity_state].block_data = state_data;
 
                 blocks[*block_count + _entity_update_block_order_forward_memory_queue_element].block_type = _network_memory_block_forward_simulation_queue_element;

--- a/xlive/Blam/Engine/simulation/simulation_queue_entities.cpp
+++ b/xlive/Blam/Engine/simulation/simulation_queue_entities.cpp
@@ -547,7 +547,7 @@ void simulation_queue_entity_deletion_apply(const s_simulation_queue_element* el
 	c_bitstream stream(element->data, element->data_size);
 	stream.begin_reading();
 
-	int32 entity_index;
+	// int32 entity_index;
 	datum gamestate_index;
 	e_simulation_entity_type entity_type;
 	if (simulation_queue_entity_decode_header(&stream, &entity_type, &gamestate_index))

--- a/xlive/Blam/Engine/simulation/simulation_queue_global_events.cpp
+++ b/xlive/Blam/Engine/simulation/simulation_queue_global_events.cpp
@@ -124,7 +124,7 @@ void simulation_queue_player_event_apply(const s_simulation_queue_element* eleme
 	c_bitstream stream(element->data, element->data_size);
 	stream.begin_reading();
 
-	uint16 abs_player_index = stream.read_integer("player-index", k_player_index_bit_count);
+	const uint16 abs_player_index = (uint16)stream.read_integer("player-index", k_player_index_bit_count);
 	bool active = stream.read_bool("active");
 
 	if (!stream.error_occured())

--- a/xlive/Blam/Engine/tag_files/string_id.cpp
+++ b/xlive/Blam/Engine/tag_files/string_id.cpp
@@ -1,7 +1,8 @@
 #include "stdafx.h"
 #include "string_id.h"
 
-void user_interface_global_string_get(string_id id, wchar_t* dest)
+void __cdecl user_interface_global_string_get(string_id id, wchar_t* dest)
 {
 	INVOKE(0x21DC38, 0x6AA91, user_interface_global_string_get, id, dest);
+	return;
 }

--- a/xlive/Blam/Engine/tag_files/string_id.h
+++ b/xlive/Blam/Engine/tag_files/string_id.h
@@ -5,84 +5,10 @@
 /*********************************************************************
 * string_id
 * 4 BYTE Special Tag Structure for String Values
-* Index 3 Bytes
-* Length 1 Byte
+* Index 3 Bytes (first 24 bits)
+* Length 1 Byte (upper 8 bits)
 **********************************************************************/
 
-struct string_id
-{
-	string_id() = default;
+typedef uint32 string_id;
 
-	constexpr string_id(uint32_t _value) :
-		value(_value)
-	{};
-
-	constexpr string_id(uint32_t id, uint8_t length) :
-		value(id | (length << 24))
-	{
-	};
-
-	constexpr uint8_t get_length() const
-	{
-		return (value >> 24) & 0xFFu;
-	}
-
-	constexpr uint32_t get_id() const
-	{
-		return value & ~(0xffu << 24);
-	}
-
-	constexpr uint32_t get_packed() const
-	{
-		return value;
-	}
-	constexpr bool is_valid() const
-	{
-		return get_packed() != 0;
-	}
-
-	static const uint32_t Invalid = 0xFFFFFFFF;
-	static const uint32_t Empty = 0;
-	static const uint32_t MaxLength = 0xFF;
-	static const uint32_t MaxIndex = 0xFFFFFF;
-	
-
-	void operator = (const uint32_t &Value);
-	void operator = (const string_id &string_id);
-	bool operator == (const uint32_t &Value) const;
-	bool operator == (const string_id &string_id) const;
-	bool operator != (const uint32_t &Value) const;
-	bool operator != (const string_id &string_id) const;
-private:
-	uint32_t value;
-
-};
-ASSERT_STRUCT_SIZE(string_id, 4);
-
-
-inline void string_id::operator= (const uint32_t &Value)
-{
-	this->value = Value;
-}
-inline void string_id::operator=(const string_id &string_id)
-{
-	this->value = string_id.value;
-}
-inline bool string_id::operator== (const uint32_t &Value) const
-{
-	return this->value == Value;
-}
-inline bool string_id::operator== (const string_id &string_id) const
-{
-	return this->value == string_id.value;
-}
-inline bool string_id::operator!= (const uint32_t &Value) const
-{
-	return this->value != Value;
-}
-inline bool string_id::operator!= (const string_id &string_id) const
-{
-	return this->value != string_id.value;
-}
-
-void  user_interface_global_string_get(string_id id, wchar_t* dest);
+void __cdecl user_interface_global_string_get(string_id id, wchar_t* dest);

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
@@ -14,14 +14,12 @@
 #include "units/biped_definitions.h"
 #include "units/vehicle_definitions.h"
 
-#include "Util/filesys.h"
-
 extern bool g_force_cartographer_update;
 
 /* constants */
 
-#define k_relative_maps_directory L"\\maps\\"
-#define k_relative_mods_directory L"\\mods\\"
+#define k_relative_maps_directory L".\\maps\\"
+#define k_relative_mods_directory L".\\mods\\"
 #define k_relative_mods_maps_directory k_relative_mods_directory L"maps\\"
 #define k_relative_mods_plugin_directory k_relative_mods_directory L"plugins\\"
 
@@ -37,14 +35,9 @@ c_tag_injecting_manager::c_tag_injecting_manager():
 
 void c_tag_injecting_manager::init_directories()
 {
-	this->m_base_map_directory.set(GetExeDirectoryWide().c_str());
-	this->m_base_map_directory.append(k_relative_maps_directory);
-
-	this->m_mods_map_directory.set(GetExeDirectoryWide().c_str());
-	this->m_mods_map_directory.append(k_relative_mods_maps_directory);
-
-	this->m_plugins_directory.set(GetExeDirectoryWide().c_str());
-	this->m_plugins_directory.append(k_relative_mods_plugin_directory);
+	this->m_base_map_directory.set(k_relative_maps_directory);
+	this->m_mods_map_directory.set(k_relative_mods_maps_directory);
+	this->m_plugins_directory.set(k_relative_mods_plugin_directory);
 }
 
 void c_tag_injecting_manager::set_base_map_tag_data_size(const uint32 size)
@@ -103,7 +96,7 @@ bool c_tag_injecting_manager::find_map(const wchar_t* map_name, c_static_wchar_s
 		// Exit and create a popup if a map is missing
 		else
 		{
-			const wchar_t* format = L"[c_tag_injecting_manager::find_map] could not locate %s.map in any valid content location";
+			const wchar_t format[] = L"[c_tag_injecting_manager::find_map] could not locate %s.map in any valid content location";
 			wchar_t output_wide[NUMBEROF(format) + MAX_PATH];
 			
 			usnzprintf(output_wide, NUMBEROF(output_wide), format, map_name);
@@ -510,7 +503,7 @@ bool c_tag_injecting_manager::initialize_agent(tag_group group)
 	// Exit and create a popup if a plugin is missing
 	if (!PathFileExists(plugin_path.get_string()))
 	{
-		const wchar_t* format = L"[c_tag_injecting_manager::initialize_agent] Plugin file could not be located %s";
+		const wchar_t format[] = L"[c_tag_injecting_manager::initialize_agent] Plugin file could not be located %s";
 		wchar_t output_wide[NUMBEROF(format) + MAX_PATH];
 
 		usnzprintf(output_wide, NUMBEROF(output_wide), format, plugin_path.get_string());

--- a/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_loader.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_loader.cpp
@@ -150,8 +150,10 @@ void c_xml_definition_loader::initialize_arrays_internal(c_xml_definition_loader
 		for (uint32 i = 0; i < definition->get_string_id_count(); i++)
 		{
 			file_seek_and_read(loader->m_file_handle, base_offset + definition->get_string_id_offset(i), sizeof(string_id), 1, &t_string_id);
-			if (t_string_id.is_valid())
+			if (t_string_id != 0)
+			{
 				loader->m_string_id_offset_count++;
+			}
 		}
 
 		for (uint32 i = 0; i < definition->get_tag_block_count(); i++)
@@ -307,7 +309,7 @@ void c_xml_definition_loader::load_tag_data_internal(c_xml_definition_loader* lo
 			uint32 calc_offset = definition->get_string_id_offset(i) + definition->get_size() * block_index;
 
 			file_seek_and_read(loader->m_file_handle, file_offset + calc_offset, sizeof(string_id), 1, &t_string_id);
-			if (t_string_id.is_valid())
+			if (t_string_id != 0)
 			{
 				loader->m_string_id_offsets[loader->m_string_id_offset_count].cache_offset = file_offset + calc_offset;
 				loader->m_string_id_offsets[loader->m_string_id_offset_count].memory_offset = (uint32)buffer + calc_offset;

--- a/xlive/Blam/Engine/units/bipeds.cpp
+++ b/xlive/Blam/Engine/units/bipeds.cpp
@@ -57,12 +57,12 @@ void __cdecl biped_offset_first_person_camera(const real_vector3d* camera_forwar
             }
             else
             {
-                v1 = M_PI_2 - acosf(-camera_forward->k);
+                v1 = (real32)M_PI_2 - acosf(-camera_forward->k);
             }
         }
         else
         {
-            v1 = M_PI_2;
+            v1 = (real32)M_PI_2;
         }
 
         ASSERT(angle_range > 0.f);

--- a/xlive/Blam/Engine/units/units.h
+++ b/xlive/Blam/Engine/units/units.h
@@ -34,7 +34,7 @@ enum e_unit_weapons
 	unit_weapons_dual_weild_weapon
 };
 
-enum e_unit_data_flags : int32
+enum e_unit_data_flags : uint32
 {
 	_unit_is_actively_controlled = FLAG(1),
 	_unit_is_alive = FLAG(2),

--- a/xlive/H2MOD/EngineHooks/EngineHooks.cpp
+++ b/xlive/H2MOD/EngineHooks/EngineHooks.cpp
@@ -64,7 +64,7 @@ namespace EngineHooks
 	bool __stdcall xlocator_parse_search_result(void* thisx, int a2, s_session_live_result* session_out)
 	{
 		bool result = p_xlocator_parse_search_result(thisx, a2, session_out);
-		return result && verify_game_version_on_join_hook(session_out->executable_type, session_out->executable_version, session_out->compatible_version);
+		return result && verify_game_version_on_join_hook((uint8)session_out->executable_type, (uint16)session_out->executable_version, (uint16)session_out->compatible_version);
 	}
 #pragma endregion
 

--- a/xlive/H2MOD/GUI/imgui_integration/AdvancedSettings.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/AdvancedSettings.cpp
@@ -22,7 +22,6 @@
 
 #ifndef NDEBUG
 #include "H2MOD/Modules/RenderHooks/RenderHooks.h"
-#include "H2MOD/Utils/Utils.h"
 #endif
 
 /* constants */

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
@@ -12,7 +12,6 @@
 #include "main/main_screenshot.h"
 #include "networking/logic/life_cycle_manager.h"
 #include "networking/NetworkMessageTypeCollection.h"
-#include "render/render_cartographer_ingame_ui.h"
 #include "objects/objects.h"
 #include "simulation/game_interface/simulation_game_action.h"
 #include "text/unicode.h"

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandsUtil.h
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandsUtil.h
@@ -108,7 +108,7 @@ public:
 		m_line_buf_size = _max_buffer_size_per_line;
 
 		// allocate once we know the size
-		m_buf = new char[GetBufferSize()];
+		m_buf = (char*)malloc(GetBufferSize());
 		csmemset(m_buf, 0, GetBufferSize());
 		m_buffer_idx = 0;
 		m_strings_headers.reserve(m_line_count);
@@ -122,7 +122,7 @@ public:
 	~CircularStringBuffer()
 	{
 		m_strings_headers.clear();
-		delete[] m_buf;
+		free(m_buf);
 		m_buf = NULL;
 		m_buffer_idx = 0;
 	}
@@ -147,7 +147,7 @@ public:
 		if (m_buf != NULL)
 		{
 			csmemcpy(new_buffer, m_buf, GetBufferSize());
-			delete[] m_buf;
+			free(m_buf);
 		}
 		m_buf = new_buffer;
 	}

--- a/xlive/H2MOD/Modules/Accounts/AccountCreate.cpp
+++ b/xlive/H2MOD/Modules/Accounts/AccountCreate.cpp
@@ -13,6 +13,8 @@
 #define ERROR_CODE_TAKEN_USERNAME -6
 #define ERROR_CODE_BANNED_EMAIL_DOMAIN -7
 
+const char k_user_name_string[] = "username=";
+
 // TODO (Carefully) Cleanup and move
 
 static int InterpretMasterCreate(char* response_content) {
@@ -36,8 +38,8 @@ static int InterpretMasterCreate(char* response_content) {
 			addDebugText("Return code is: %d", tempint1);
 			result = tempint1;
 		}
-		else if (strstr(fileLine, "username=")) {
-			char* tempName = fileLine + strlen("username=");
+		else if (strstr(fileLine, k_user_name_string)) {
+			char* tempName = fileLine + NUMBEROF(k_user_name_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}

--- a/xlive/H2MOD/Modules/Accounts/AccountLogin.cpp
+++ b/xlive/H2MOD/Modules/Accounts/AccountLogin.cpp
@@ -10,6 +10,14 @@
 #include "XLive/xnet/upnp.h"
 
 #define MASTER_STATE_STR_SIZE 256
+
+const char k_login_code_secondary_string[] = "login_code_secondary=";
+const char k_login_external_addr_string[] = "login_external_addr=";
+const char k_login_master_relay_ip_string[] = "login_master_relay_ip=";
+const char k_login_token_string[] = "login_token=";
+const char k_login_username_string[] = "login_username=";
+const char k_login_ab_online_string[] = "login_abOnline=";
+
 int masterState = -1;
 char* masterStateStr = NULL;
 bool AccountEdit_remember = true;
@@ -159,8 +167,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 			addDebugText("Login code is: %d", tempint1);
 			result = tempint1;
 		}
-		else if (strstr(fileLine, "login_code_secondary=")) {
-			char* tempName = fileLine + strlen("login_code_secondary=");
+		else if (strstr(fileLine, k_login_code_secondary_string)) {
+			char* tempName = fileLine + NUMBEROF(k_login_code_secondary_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}
@@ -177,8 +185,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 				addDebugText("Login Code Secondary is: %s", tempstr1);
 			}
 		}
-		else if (strstr(fileLine, "login_external_addr=")) {
-			char* tempName = fileLine + strlen("login_external_addr=");
+		else if (strstr(fileLine, k_login_external_addr_string)) {
+			char* tempName = fileLine + NUMBEROF(k_login_external_addr_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}
@@ -200,8 +208,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 				xnaddr = resolvedAddr;
 			}
 		}
-		else if (strstr(fileLine, "login_master_relay_ip=")) {
-			char* tempName = fileLine + strlen("login_master_relay_ip=");
+		else if (strstr(fileLine, k_login_master_relay_ip_string)) {
+			char* tempName = fileLine + NUMBEROF(k_login_master_relay_ip_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}
@@ -226,8 +234,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 				H2Config_master_port_relay = tempint1;
 			}
 		}
-		else if (strstr(fileLine, "login_token=")) {
-			char* tempName = fileLine + strlen("login_token=");
+		else if (strstr(fileLine, k_login_token_string)) {
+			char* tempName = fileLine + NUMBEROF(k_login_token_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}
@@ -245,8 +253,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 				strncpy(login_token, tempstr1, 32 + 1);
 			}
 		}
-		else if (strstr(fileLine, "login_username=")) {
-			char* tempName = fileLine + strlen("login_username=");
+		else if (strstr(fileLine, k_login_username_string)) {
+			char* tempName = fileLine + NUMBEROF(k_login_username_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}
@@ -289,8 +297,8 @@ static int InterpretMasterLogin(char* response_content, char* prev_login_token) 
 				strncpy(machineUID, tempstr1, 12 + 1);
 			}
 		}
-		else if (strstr(fileLine, "login_abOnline=")) {
-			char* tempName = fileLine + strlen("login_abOnline=");
+		else if (strstr(fileLine, k_login_ab_online_string)) {
+			char* tempName = fileLine + NUMBEROF(k_login_ab_online_string) - 1;
 			while (isspace(*tempName)) {
 				tempName++;
 			}

--- a/xlive/H2MOD/Modules/Achievements/Achievements.cpp
+++ b/xlive/H2MOD/Modules/Achievements/Achievements.cpp
@@ -79,7 +79,7 @@ void GetAchievements(unsigned long long xuid)
 		achievementList.clear();
 		for (auto& achievement : document["achievements"].GetArray())
 		{
-			int id = std::stoll(achievement.GetString());
+			int id = (int)std::stoll(achievement.GetString());
 			achievementList[id] = 1;
 		}
 	}

--- a/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.cpp
+++ b/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.cpp
@@ -31,7 +31,7 @@ namespace CustomVariantSettings
 	}
 	bool __cdecl DecodeVariantSettings(c_bitstream* stream, int a2, s_variant_settings* data)
 	{
-		double gravity, gamespeed;
+		real32 gravity, gamespeed;
 		stream->read_raw_data("gravity", &gravity, sizeof(gravity) * CHAR_BIT);
 		data->gravity = gravity;
 		stream->read_raw_data("game speed", &gamespeed, sizeof(gamespeed) * CHAR_BIT);
@@ -41,7 +41,7 @@ namespace CustomVariantSettings
 		data->explosionPhysics = stream->read_bool("explosion physics");
 		data->hillRotation = (e_hill_rotation)stream->read_integer("hill rotation", 8);
 		data->infiniteGrenades = stream->read_bool("infinite grenades");
-		data->forced_fov = stream->read_integer("forced field of view", sizeof(data->forced_fov) * CHAR_BIT);
+		data->forced_fov = (uint8)stream->read_integer("forced field of view", sizeof(data->forced_fov) * CHAR_BIT);
 		return stream->error_occured() == false;
 	}
 

--- a/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.h
+++ b/xlive/H2MOD/Modules/CustomVariantSettings/CustomVariantSettings.h
@@ -20,17 +20,17 @@ namespace CustomVariantSettings
 	};
 	struct s_variant_settings
 	{
-		double gravity = 1.0f;
+		real32 gravity = 1.0f;
 		bool infiniteAmmo = false;
 		bool explosionPhysics = false;
 		e_hill_rotation hillRotation = _random;
-		double gameSpeed = 1.0f;
+		real32 gameSpeed = 1.0f;
 		bool infiniteGrenades = false;
 		bool spawnProtection = 1;
-		byte predefinedHillSet[16];
+		byte predefinedHillSet[16] = {};
 		uint8 forced_fov = 0;
 
-		double ComputedGravity() const
+		real32 ComputedGravity() const
 		{
 			return gravity * s_physics_constants::get_default_gravity();
 		}

--- a/xlive/H2MOD/Modules/GamePhysics/Patches/MeleeFix.cpp
+++ b/xlive/H2MOD/Modules/GamePhysics/Patches/MeleeFix.cpp
@@ -6,10 +6,6 @@
 #include "tag_files/global_string_ids.h"
 #include "physics/character_physics_mode_melee.h"
 
-#include "H2MOD/Modules/Shell/Config.h"
-
-FLOATING_POINT_ENV_ACCESS();
-
 namespace MeleeFix
 {
 	//////////////////////////////////////////////////////
@@ -105,7 +101,7 @@ namespace MeleeFix
 
 				if (currentFrame >= actionFrame - leeway && currentFrame <= actionFrame + leeway)
 				{
-					p_melee_damage(object_index, melee_type, biped_melee_info->field_30, (float)(unsigned __int8)biped_melee_info->field_31 * 0.0039215689);
+					p_melee_damage(object_index, melee_type, biped_melee_info->field_30, (real32)(uint8)biped_melee_info->field_31 * 0.003921569f);
 					if (MeleeHit) 
 					{
 						LOG_TRACE_GAME("[MeleeFix] Melee Hit!");
@@ -125,8 +121,8 @@ namespace MeleeFix
 			// this is used only for sword
 			if (melee_type == _string_id_melee_dash || melee_type == _string_id_melee_dash_airborne)
 			{
-				float melee_max_duration = melee_type == _string_id_melee_dash_airborne ? 0.22 : 0.15000001;
-				int melee_max_ticks = time_globals::seconds_to_ticks_round(melee_max_duration);
+				real32 melee_max_duration = melee_type == _string_id_melee_dash_airborne ? 0.22f : 0.15f;
+				int32 melee_max_ticks = time_globals::seconds_to_ticks_round(melee_max_duration);
 				if (melee_max_ticks < 0 || p_melee_get_time_to_target(object_index) <= melee_max_ticks)
 					abort_melee_action = true;
 			}
@@ -134,7 +130,7 @@ namespace MeleeFix
 				&& !melee_next_animation_hook(object_index, 0, -1, biped_melee_info->field_30))
 			{
 				biped_melee_info->melee_flags &= 0xF7FFFFFF;
-				biped_melee_info->melee_type_string_id = -1;
+				biped_melee_info->melee_type_string_id = NONE;
 				MeleeHit = false;
 			}
 		}

--- a/xlive/H2MOD/Modules/Input/KeyboardInput.cpp
+++ b/xlive/H2MOD/Modules/Input/KeyboardInput.cpp
@@ -120,14 +120,14 @@ void hotkeyFuncAlignWindow() {
 	int interval_height = monitor_height / 2;
 	D3DVIEWPORT9 pViewport;
 	device->GetViewport(&pViewport);
-	int width = interval_width * round(pViewport.Width / (double)interval_width);
-	int height = interval_height * round(pViewport.Height / (double)interval_height);
+	int width = (int)(interval_width * round(pViewport.Width / (double)interval_width));
+	int height = (int)(interval_height * round(pViewport.Height / (double)interval_height));
 	RECT gameWindowRect;
 	GetWindowRect(H2hWnd, &gameWindowRect);
 	int monitorXOffset = gameWindowRect.left - info.rcMonitor.left;
 	int monitorYOffset = gameWindowRect.top - info.rcMonitor.top;
-	int padX = interval_width * round(monitorXOffset / (double)interval_width);
-	int padY = interval_height * round(monitorYOffset / (double)interval_height);
+	int padX = (int)(interval_width * round(monitorXOffset / (double)interval_width));
+	int padY = (int)(interval_height * round(monitorYOffset / (double)interval_height));
 	int posX = info.rcMonitor.left + padX;
 	int posY = info.rcMonitor.top + padY;
 

--- a/xlive/H2MOD/Modules/MapManager/MapManager.cpp
+++ b/xlive/H2MOD/Modules/MapManager/MapManager.cpp
@@ -355,7 +355,7 @@ size_t map_download_curl_write_data_cb(void* ptr, size_t size, size_t nmemb, FIL
 
 static int32 map_download_curl_xferinfo_cb(void* p, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
 	MapDownloadQuery* mapDownloadQuery = (MapDownloadQuery*)p;
-	mapDownloadQuery->SetDownloadPercentage(((float)dlnow / (float)dltotal) * 100.f);
+	mapDownloadQuery->SetDownloadPercentage((int)(((float)dlnow / (float)dltotal) * 100.f));
 	return mapDownloadQuery->ShouldStopDownload();
 }
 
@@ -486,7 +486,7 @@ void MapDownloadQuery::SetMapNameToDownload(const wchar_t* _mapNameToDownload)
 	SetMapNameToDownload(std::wstring(_mapNameToDownload));
 }
 
-int MapDownloadQuery::GetDownloadPercentage()
+int MapDownloadQuery::GetDownloadPercentage(void) const
 {
 	return m_downloadPercentage;
 }

--- a/xlive/H2MOD/Modules/MapManager/MapManager.h
+++ b/xlive/H2MOD/Modules/MapManager/MapManager.h
@@ -12,7 +12,7 @@ public:
 	void SetMapNameToDownload(const std::wstring& mapNameToDownload);
 	void SetMapNameToDownload(const wchar_t* mapNameToDownload);
 
-	int GetDownloadPercentage();
+	int GetDownloadPercentage(void) const;
 	void SetDownloadPercentage(int _downloadPercentage);
 
 	void StartMapDownload();

--- a/xlive/H2MOD/Modules/OnScreenDebug/OnscreenDebug.cpp
+++ b/xlive/H2MOD/Modules/OnScreenDebug/OnscreenDebug.cpp
@@ -89,8 +89,9 @@ void addDebugText(const char* format, ...)
 
 void InitOnScreenDebugText() {
 	initialisedDebugText = true;
-	const std::wstring string(L"h2onscreendebug");
-	const std::wstring processed = prepareLogFileName(string);
-	onscreendebug_log = h2log::create("OnScreenDebug", processed, true, 0); // we always create onscreendebuglog, which logs everything (log level 0)
+
+	c_static_wchar_string<MAX_PATH> path;
+	prepareLogFileName(L"h2onscreendebug", &path);
+	onscreendebug_log = h2log::create("OnScreenDebug", path.get_string(), true, 0); // we always create onscreendebuglog, which logs everything (log level 0)
 	addDebugText("Initialized onscreendebug log");
 }

--- a/xlive/H2MOD/Modules/PlaylistLoader/PlaylistLoader.cpp
+++ b/xlive/H2MOD/Modules/PlaylistLoader/PlaylistLoader.cpp
@@ -60,10 +60,10 @@ namespace playlist_loader
 
 		return false;
 	}
-	double custom_settings_real_check(playlist_entry* playlist_entry, wchar_t* value)
+	real32 custom_settings_real_check(playlist_entry* playlist_entry, wchar_t* value)
 	{
 		if (isFloat(value))
-			return std::stod(value);
+			return std::stof(value);
 
 		p_playlist_loader_invalid_entry(
 			playlist_entry,

--- a/xlive/H2MOD/Modules/Shell/ServerConsole.cpp
+++ b/xlive/H2MOD/Modules/Shell/ServerConsole.cpp
@@ -30,8 +30,6 @@ void* __cdecl DediCommandHook(wchar_t** command_line_split_wide, int split_count
 
 		for (int i = 0; i < split_count; i++)
 		{
-			std::wstring tokenWide;
-
 			if (i > 0)
 			{
 				token_wide.set(command_line_split_wide[i]);

--- a/xlive/H2MOD/Modules/Shell/Startup/Startup.cpp
+++ b/xlive/H2MOD/Modules/Shell/Startup/Startup.cpp
@@ -156,7 +156,12 @@ bool configureXinput() {
 				}
 
 				int len_to_write = 2;
-				BYTE assmXinputDuraznoNameEdit[] = { 0x30 + (_Shell::GetInstanceId() / 10), 0x30 + (_Shell::GetInstanceId() % 10), 0x30 + (_Shell::GetInstanceId() % 10) };
+				uint8 assmXinputDuraznoNameEdit[] = 
+				{ 
+					(uint8)(0x30 + (_Shell::GetInstanceId() / 10)),
+					(uint8)(0x30 + (_Shell::GetInstanceId() % 10)),
+					(uint8)(0x30 + (_Shell::GetInstanceId() % 10))
+				};
 				if (xinput_unicode[xinput_index]) {
 					assmXinputDuraznoNameEdit[1] = 0x00;
 					len_to_write = 3;

--- a/xlive/H2MOD/Modules/Shell/Startup/Startup.cpp
+++ b/xlive/H2MOD/Modules/Shell/Startup/Startup.cpp
@@ -74,8 +74,8 @@ bool configureXinput() {
 
 			char xinputName[_MAX_PATH];
 			char xinputdir[_MAX_PATH];
-			sprintf(xinputdir, "xinput/p%02d", _Shell::GetInstanceId());
-			sprintf(xinputName, "%s/xinput9_1_0.dll", xinputdir);
+			csprintf(xinputdir, NUMBEROF(xinputdir), "xinput/p%02d", _Shell::GetInstanceId());
+			csprintf(xinputName, NUMBEROF(xinputdir), "%s/xinput9_1_0.dll", xinputdir);
 
 			/* Creates a directory and displays error if it fails */
 			auto create_dir = [=](const std::string &path) -> bool {

--- a/xlive/H2MOD/Modules/Shell/Startup/Startup.h
+++ b/xlive/H2MOD/Modules/Shell/Startup/Startup.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "cseries/cseries_strings.h"
 
 void InitH2Startup();
 void H2DedicatedServerStartup();
@@ -7,7 +7,7 @@ void DeinitH2Startup();
 
 // use only after initLocalAppData has been called
 // by default useAppDataLocalPath is set to true, if not specified
-inline std::wstring prepareLogFileName(const std::wstring& logFileName, bool useAppDataLocalPath = true);
+inline void prepareLogFileName(const wchar_t* logFileName, c_static_wchar_string<MAX_PATH>* path, bool useAppDataLocalPath = true);
 
 extern wchar_t* H2ProcessFilePath;
 extern wchar_t* H2AppDataLocal;

--- a/xlive/H2MOD/Modules/SpecialEvents/Events/Christmas.cpp
+++ b/xlive/H2MOD/Modules/SpecialEvents/Events/Christmas.cpp
@@ -90,7 +90,7 @@ void christmas_event_map_load(void)
 		weat_block->weather_system.group.group = _tag_group_weather_system;
 		weat_block->weather_system.index = snow_datum;
 
-		for (size_t i = 0; i < bsp_definition->clusters.count; ++i)
+		for (int32 i = 0; i < bsp_definition->clusters.count; ++i)
 		{
 			bsp_definition->clusters[i]->weather_index = (int16)bsp_definition->weather_palette.count - 1;
 		}
@@ -103,12 +103,12 @@ void christmas_event_map_load(void)
 
 		sword_model->render_model.index = candy_cane_datum;
 
-		for (size_t i = 0; i < sword_weapon->weapon.player_interface.first_person.count; ++i)
+		for (int32 i = 0; i < sword_weapon->weapon.player_interface.first_person.count; ++i)
 		{
 			sword_weapon->weapon.player_interface.first_person[i]->model.index = candy_cane_datum;
 		}
 
-		for (size_t i = 0; i < sword_weapon->object.attachments.count; ++i)
+		for (int32 i = 0; i < sword_weapon->object.attachments.count; ++i)
 		{
 			object_attachment_definition* attachment = sword_weapon->object.attachments[i];
 			attachment->type.index = NONE;

--- a/xlive/H2MOD/Modules/SpecialEvents/Events/Halloween.cpp
+++ b/xlive/H2MOD/Modules/SpecialEvents/Events/Halloween.cpp
@@ -41,7 +41,7 @@ void halloween_game_life_cycle_update(e_game_life_cycle state)
 				{
 				case 0:
 					object_placement_data_new(&placement, pump_datum, -1, 0);
-					placement.variant_name = pump_hmlt->variants[scen_place.variant_id]->name.get_packed();
+					placement.variant_name = pump_hmlt->variants[scen_place.variant_id]->name;
 					break;
 				case 1:
 					object_placement_data_new(&placement, candle_datum, -1, 0);
@@ -70,7 +70,7 @@ void halloween_game_life_cycle_update(e_game_life_cycle state)
 				{
 				case 0:
 					object_placement_data_new(&placement, pump_datum, -1, 0);
-					placement.variant_name = pump_hmlt->variants[scen_place.variant_id]->name.get_packed();
+					placement.variant_name = pump_hmlt->variants[scen_place.variant_id]->name;
 					break;
 				case 1:
 					object_placement_data_new(&placement, candle_datum, -1, 0);

--- a/xlive/H2MOD/Modules/TagFixes/TagFixes.cpp
+++ b/xlive/H2MOD/Modules/TagFixes/TagFixes.cpp
@@ -65,34 +65,6 @@ namespace TagFixes
 				1
 			);
 		}
-		void fix_dynamic_lights()
-		{
-			// TODO FIXME: this breaks other shadows
-			return;
-
-			datum cinematic_shadow_datum = tag_loaded(_tag_group_vertex_shader, "rasterizer\\vertex_shaders_dx9\\shadow_buffer_generation_cinematic");
-			datum shadow_datum = tag_loaded(_tag_group_shader_pass, "shaders\\shader_passes\\shadow\\shadow_generate");
-			char* shadow_tag = (char*)tag_get_fast(shadow_datum);
-			if(shadow_tag != nullptr)
-			{
-				tag_block<int> *shadow_pp = reinterpret_cast<tag_block<int>*>(shadow_tag + 0x1C);
-				if(shadow_pp->count > 0 && shadow_pp->data != NONE)
-				{
-					auto shadow_pp_data = cache_get_tag_data(shadow_pp->data);
-					tag_block<int>*shadow_impl_block = reinterpret_cast<tag_block<int>*>(shadow_pp_data);
-					if(shadow_pp->count > 0 && shadow_impl_block->data != NONE)
-					{
-						auto shadow_impl = cache_get_tag_data(shadow_impl_block->data);
-						tag_reference* impl_1 = reinterpret_cast<tag_reference*>(shadow_impl + (0x14A) + 0xFC);
-						tag_reference* impl_2 = reinterpret_cast<tag_reference*>(shadow_impl + (0x14A*2) + 0xFC);
-
-						impl_1->index = cinematic_shadow_datum;
-						//TODO: Re-enable this once the vertex shaders for shadows are fixed.
-						//impl_2->TagIndex = cinematic_shadow_datum.data;
-					}
-				}
-			}
-		}
 
 		void font_table_fix()
 		{
@@ -149,7 +121,6 @@ namespace TagFixes
 		if (!Memory::IsDedicatedServer()) 
 		{
 			fix_shaders_nvidia();
-			fix_dynamic_lights();
 			font_table_fix();
 			if (H2Config_shader_lod_max)
 			{

--- a/xlive/H2MOD/Utils/Utils.cpp
+++ b/xlive/H2MOD/Utils/Utils.cpp
@@ -385,11 +385,11 @@ bool ComputeFileCrc32Hash(wchar_t* filepath, DWORD &rtncrc32) {
 		}
 	}
 
+	CloseHandle(hFile);
+
 	if (!bResult) {
 		return false;
 	}
-
-	CloseHandle(hFile);
 
 	rtncrc32 = ~oldcrc32;
 

--- a/xlive/H2MOD/Variants/GunGame/GunGame.cpp
+++ b/xlive/H2MOD/Variants/GunGame/GunGame.cpp
@@ -2,13 +2,13 @@
 #include "GunGame.h"
 
 #include "game/game.h"
-#include "networking/logic/life_cycle_manager.h"
+#include "game/players.h"
 #include "units/units.h"
 #include "H2MOD.h"
 
 // TODO(PermaNull): Add additional levels with dual weilding
 
-datum k_level_weapons[15] =
+e_weapons_datum_index k_level_weapons[15] =
 {
 	e_weapons_datum_index::energy_blade_useless,
 	e_weapons_datum_index::needler,
@@ -148,7 +148,7 @@ void GunGame::OnPlayerSpawn(ExecTime execTime, datum playerIdx)
 
 				LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - player index: {}, player name: {1} - Level: {2}", __FUNCTIONW__, absPlayerIdx, s_player::get_name(playerIdx), level);
 
-				datum currentWeapon = k_level_weapons[level];
+				const datum currentWeapon = (datum)k_level_weapons[level];
 
 				if (level == 15)
 				{
@@ -196,7 +196,7 @@ bool GunGame::c_game_statborg__adjust_player_stat(ExecTime execTime, c_game_stat
 		{
 			LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - player index: {}, player name: {}", __FUNCTIONW__, absPlayerIdx, s_player::get_name(player_datum));
 
-			int level = GunGame::gungamePlayers[playerId];
+			int32 level = GunGame::gungamePlayers[playerId];
 			level++;
 
 			if (level > 16)
@@ -206,24 +206,24 @@ bool GunGame::c_game_statborg__adjust_player_stat(ExecTime execTime, c_game_stat
 
 			LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - player index: {} - new level: {} ", __FUNCTIONW__, absPlayerIdx, level);
 
-			if (level < 15) {
-				LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - {} on level {} giving them weapon...", __FUNCTIONW__, s_player::get_name(player_datum), level);
-
-				datum LevelWeapon = k_level_weapons[level];
-				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_human_fragmentation, 0, true);
-				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_covenant_plasma, 0, true);
-				call_give_player_weapon(absPlayerIdx, LevelWeapon, 1);
-			}
-
-			else if (level == 15) {
+			if (level == 15)
+			{
 				LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - {} Level 15 - Frag Grenades!", __FUNCTIONW__, s_player::get_name(player_datum));
 				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_human_fragmentation, 99, true);
 			}
-
-			else if (level == 16) {
+			else if (level == 16)
+			{
 				LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - {} Level 16 - Plasma Grenades!", __FUNCTIONW__, s_player::get_name(player_datum));
 				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_human_fragmentation, 0, true);
 				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_covenant_plasma, 99, true);
+			}
+			else
+			{
+				LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - {} on level {} giving them weapon...", __FUNCTIONW__, s_player::get_name(player_datum), level);
+				const datum weapon = (datum)k_level_weapons[level];
+				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_human_fragmentation, 0, true);
+				s_player::set_player_unit_grenade_count(player_datum, _unit_grenade_covenant_plasma, 0, true);
+				call_give_player_weapon(absPlayerIdx, weapon, 1);
 			}
 		}
 

--- a/xlive/H2MOD/Variants/GunGame/GunGame.cpp
+++ b/xlive/H2MOD/Variants/GunGame/GunGame.cpp
@@ -150,16 +150,19 @@ void GunGame::OnPlayerSpawn(ExecTime execTime, datum playerIdx)
 
 				datum currentWeapon = k_level_weapons[level];
 
-				if (level < 15) {
-					call_give_player_weapon(absPlayerIdx, currentWeapon, 1);
-				}
-				else if (level == 15) {
+				if (level == 15)
+				{
 					LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - {} on frag grenade level!", __FUNCTIONW__, s_player::get_name(playerIdx));
 					s_player::set_player_unit_grenade_count(playerIdx, _unit_grenade_human_fragmentation, 99, true);
 				}
-				else if (level == 16) {
+				else if (level == 16)
+				{
 					LOG_TRACE_GAME(L"[H2Mod-GunGame]: {} - {} on plasma grenade level!", __FUNCTIONW__, s_player::get_name(playerIdx));
 					s_player::set_player_unit_grenade_count(playerIdx, _unit_grenade_covenant_plasma, 99, true);
+				}
+				else
+				{
+					call_give_player_weapon(absPlayerIdx, currentWeapon, 1);
 				}
 			}
 		}

--- a/xlive/H2MOD/Variants/Infection/Infection.cpp
+++ b/xlive/H2MOD/Variants/Infection/Infection.cpp
@@ -259,7 +259,7 @@ void Infection::onGameTick()
 
 			// check the difference between game time now
 			// if the time wasn't updated for more than 5 seconds, end the game
-			if (game_ticks_to_seconds(get_game_time_ticks() - last_time_at_game_should_not_end) > 5.0f)
+			if (game_ticks_to_seconds((real32)(get_game_time_ticks() - last_time_at_game_should_not_end)) > 5.f)
 			{
 				NetworkSession::EndGame();
 			}

--- a/xlive/Util/Memory.cpp
+++ b/xlive/Util/Memory.cpp
@@ -1,6 +1,20 @@
 #include "stdafx.h"
 #include "Memory.h"
 
+enum H2Type : int
+{
+	Invalid = -1,
+	UnsupportedVersion,
+	H2Game,
+	H2Server,
+};
+
+struct ProcessInfo
+{
+	HMODULE base;
+	H2Type process_type;
+};
+
 DWORD Memory::baseAddress;
 bool Memory::dedicatedServer;
 

--- a/xlive/Util/Memory.h
+++ b/xlive/Util/Memory.h
@@ -3,21 +3,6 @@
 #define BASE_IMAGE_ADDRESS_HALO2 0x00400000
 #define BASE_IMAGE_ADDRESS_H2SERVER 0x00400000
 
-enum H2Type : int
-{
-	Invalid = -1,
-	UnsupportedVersion,
-	H2Game,
-	H2Server,
-};
-
-class ProcessInfo
-{
-public:
-	HMODULE base;
-	H2Type process_type = H2Type::Invalid;
-};
-
 class Memory
 {
 public:

--- a/xlive/Util/hash.cpp
+++ b/xlive/Util/hash.cpp
@@ -25,7 +25,7 @@ bool hash_do_file_hashing(HANDLE file, HCRYPTHASH hash, DWORD flags, long long l
 		len = LONG_MAX;
 	}
 	BYTE file_chunk[file_chunk_size];
-	DWORD len_to_read = min(file_chunk_size, len);
+	DWORD len_to_read = (DWORD)min(file_chunk_size, len);
 	DWORD bytes_read = 0;
 	while (LOG_CHECK(ReadFile(file, file_chunk, len_to_read,
 		&bytes_read, NULL)))
@@ -42,7 +42,7 @@ bool hash_do_file_hashing(HANDLE file, HCRYPTHASH hash, DWORD flags, long long l
 		len = len - bytes_read;
 		if (len <= 0)
 			return true;
-		len_to_read = min(file_chunk_size, len);
+		len_to_read = (DWORD)min(file_chunk_size, len);
 	}
 	return true;
 }

--- a/xlive/XLive/XStorage/XStorage.cpp
+++ b/xlive/XLive/XStorage/XStorage.cpp
@@ -93,13 +93,16 @@ DWORD WINAPI XStorageUploadFromMemory(DWORD dwUserIndex, const WCHAR* wszServerP
 		return ERROR_FUNCTION_FAILED;
 	}
 
-	fseek(fp, 0l, SEEK_SET);
-	fwrite(pbBuffer, dwBufferSize, 1, fp);
-	fseek(fp, 0l, SEEK_END);
+	if (fp)
+	{
+		fseek(fp, 0l, SEEK_SET);
+		fwrite(pbBuffer, dwBufferSize, 1, fp);
+		fseek(fp, 0l, SEEK_END);
 
-	LOG_TRACE_XLIVE(L" - Uploaded total byte count: {}", ftell(fp));
+		LOG_TRACE_XLIVE(L" - Uploaded total byte count: {}", ftell(fp));
 
-	fclose(fp);
+		fclose(fp);
+	}
 
 	if (pOverlapped)
 	{

--- a/xlive/XLive/XUser/XUserContext.cpp
+++ b/xlive/XLive/XUser/XUserContext.cpp
@@ -193,6 +193,8 @@ DWORD WINAPI XUserSetContext(DWORD dwUserIndex, DWORD dwContextId, DWORD dwConte
 		LOG_TRACE_XLIVE("- X_CONTEXT_GAME_MODE = {:x}", dwContextValue);
 		sessionDetails.dwGameMode = dwContextValue;
 		break;
+	default:
+		break;
 	}
 
 	return ERROR_SUCCESS;


### PR DESCRIPTION
- make string_id a typedef instead of struct
- adjust prepareLogFileName code
- fix memcmp in particle_update_points_interpolate_hook
- use relative directories in c_tag_injecting_manager::init_directories instead of using GetExeDirectoryWide()
- set format string to a char array rather than pointer to so we can get the correct number of characters in it using NUMBEROF
- fix memory allocation/free mismatch in CommandsUtil.h
- set up constant strings and use NUMBEROF instead of strlen in AccountCreate and AccountLogin
- remove unused wstring in DediCommandHook
- use csprintf in configureXinput and pass the max buffer size
- remove fix_dynamic_lights function in TagFixes
- simplify if logic in GunGame::OnPlayerSpawn
- make H2Type and ProcessInfo private types in Memory.cpp
- add default case for XUserSetContext
- make sure to close the file handle if there's a failure in ComputeFileCrc32Hash