### PR TITLE
fix memory leaks in tag injection and new_hud_draw code

### DIFF
--- a/xlive/Blam/Engine/cseries/cseries_windows_minidump_logs.cpp
+++ b/xlive/Blam/Engine/cseries/cseries_windows_minidump_logs.cpp
@@ -16,7 +16,7 @@ const wchar_t *const k_report_text_file_names[k_report_text_file_type_count] = {
 
 // globals
 
-static c_static_wchar_string<MAX_PATH> g_report_text_file_paths[k_report_text_file_type_count];
+static c_static_wchar_string<MAX_PATH>* g_report_text_file_paths = { NULL };
 
 /* prototypes */
 
@@ -53,11 +53,16 @@ const wchar_t* get_crash_info_text_file_path(e_report_file_type type)
 
 void crash_info_text_files_create(const wchar_t* reports_path, const MINIDUMP_EXCEPTION_INFORMATION* minidump_info)
 {
+    g_report_text_file_paths = new c_static_wchar_string<MAX_PATH>[k_report_text_file_type_count]();
+    
     setup_cpu_info_text(reports_path, minidump_info);
     setup_exception_text(reports_path, minidump_info);
     setup_game_options_text(reports_path);
     setup_game_global_text(reports_path);
     setup_rasterizer_text(reports_path);
+
+    delete[] g_report_text_file_paths;
+    return;
 }
 
 /* private code */

--- a/xlive/Blam/Engine/interface/new_hud_draw.cpp
+++ b/xlive/Blam/Engine/interface/new_hud_draw.cpp
@@ -200,11 +200,18 @@ void hud_widget_anchor_calculate_point(e_hud_anchor anchor, real_point2d* out_po
 
 bool draw_hud_bitmap_is_crosshair(datum bitmap_datum)
 {
-	for(uint32 i = 0; i < g_draw_hud_crosshair_bitmap_cache_count; i++)
-		if (g_draw_hud_crosshair_bitmap_cache[i] == bitmap_datum)
-			return true;
+	bool result = false;
 
-	return false;
+	for (uint32 i = 0; i < g_draw_hud_crosshair_bitmap_cache_count; i++)
+	{
+		if (g_draw_hud_crosshair_bitmap_cache[i] == bitmap_datum)
+		{
+			result = true;
+			break;
+		}
+	}
+
+	return result;
 }
 
 void __cdecl draw_hud_bitmap_widget(int32 local_render_user_index, s_new_hud_temporary_user_state* user_state, s_hud_bitmap_widget_definition* bitmap_widget, real32* widget_function_results)
@@ -828,5 +835,14 @@ void new_hud_draw_apply_patches(void)
 	PatchCall(Memory::GetAddress(0x226702), draw_hud_player_indicators);
 	PatchCall(Memory::GetAddress(0x224F46), draw_hud_bitmap_widget);
 	PatchCall(Memory::GetAddress(0x224FDA), draw_hud_text_widget);
+	return;
+}
+
+void new_hud_draw_deinitialize(void)
+{
+	if (g_draw_hud_crosshair_bitmap_cache)
+	{
+		free(g_draw_hud_crosshair_bitmap_cache);
+	}
 	return;
 }

--- a/xlive/Blam/Engine/interface/new_hud_draw.h
+++ b/xlive/Blam/Engine/interface/new_hud_draw.h
@@ -26,4 +26,6 @@ void __cdecl draw_hud_layer(void);
 
 void new_hud_draw_apply_patches(void);
 
+void new_hud_draw_deinitialize(void);
+
 void hud_widget_anchor_calculate_point(e_hud_anchor anchor, real_point2d* out_point);

--- a/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_cartographer_menus.cpp
@@ -6,6 +6,7 @@
 
 #include "H2MOD/GUI/ImGui_Integration/imgui_handler.h"
 #include "H2MOD/Modules/CustomMenu/CustomMenuGlobals.h"
+#include "H2MOD/Modules/Shell/Config.h"
 #include "H2MOD/Modules/Updater/Updater.h"
 
 
@@ -247,7 +248,7 @@ void c_cartographer_guide_edit_list::handle_item_pressed_event(s_event_record** 
 	}
 	else if (button_id == _item_cartographer_guide_website) 
 	{
-		ShellExecuteA(NULL, "open", "https://cartographer.online/", NULL, NULL, SW_SHOWDEFAULT);
+		ShellExecuteA(NULL, "open", k_cartographer_url, NULL, NULL, SW_SHOWDEFAULT);
 	}
 	else if (button_id == _item_cartographer_guide_credits) 
 	{

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.cpp
@@ -3,7 +3,9 @@
 
 #include "tag_injection_manager.h"
 
-c_tag_injecting_manager g_manager;
+/* globals */
+
+c_tag_injecting_manager* g_manager = NULL;
 
 /*	todo: figure out how to redo this, so it doesn't blow
 	Currently the entire base tag table is just copied into a new buffer and then the pointer in engine
@@ -11,14 +13,15 @@ c_tag_injecting_manager g_manager;
 
 	possible solution.. Scan the tag table for available empty tag instances and use those, they will exist.
 */
-cache_file_tag_instance* g_tag_table;
+cache_file_tag_instance* g_tag_table = NULL;
 
+/* public code */
 
 bool tag_injection_check_map_exists(const wchar_t* map_name)
 {
 	if (!Memory::IsDedicatedServer())
 	{
-		return g_manager.find_map(map_name, nullptr);
+		return g_manager->find_map(map_name, nullptr);
 	}
 	else
 	{
@@ -31,7 +34,7 @@ void tag_injection_set_active_map(const wchar_t* map_name)
 {
 	if (!Memory::IsDedicatedServer())
 	{
-		g_manager.set_active_map(map_name);
+		g_manager->set_active_map(map_name);
 	}
 }
 
@@ -39,7 +42,7 @@ bool tag_injection_active_map_verified()
 {
 	if (!Memory::IsDedicatedServer())
 	{
-		return g_manager.get_active_map_verified();
+		return g_manager->get_active_map_verified();
 	}
 	else
 	{
@@ -51,29 +54,30 @@ bool tag_injection_active_map_verified()
 
 datum tag_injection_load(e_tag_group group, const char* tag_name, bool load_dependencies)
 {
-	return g_manager.load_tag(group, tag_name, load_dependencies);
+	return g_manager->load_tag(group, tag_name, load_dependencies);
 }
 
 datum tag_injection_load(e_tag_group group, datum cache_datum, bool load_dependencies)
 {
-	return g_manager.load_tag(group, cache_datum, load_dependencies);
+	return g_manager->load_tag(group, cache_datum, load_dependencies);
 }
 
-void tag_injection_inject()
+void tag_injection_inject(void)
 {
-	g_manager.inject_tags();
+	g_manager->inject_tags();
+	return;
 }
 
 bool tag_injection_is_injected(datum injected_index)
 {
 	if (injected_index == NONE)
 		return false;
-	return g_manager.get_table()->get_entry_by_injected_index(injected_index)->is_injected;
+	return g_manager->get_table()->get_entry_by_injected_index(injected_index)->is_injected;
 }
 
 datum tag_injection_resolve_cache_datum(datum cache_datum)
 {
-	s_tag_injecting_table_entry* entry = g_manager.get_table()->get_entry_by_cache_index(cache_datum);
+	s_tag_injecting_table_entry* entry = g_manager->get_table()->get_entry_by_cache_index(cache_datum);
 	if (!entry)
 	{
 		cache_file_tag_instance* inst = &g_tag_table[DATUM_INDEX_TO_ABSOLUTE_INDEX(cache_datum)];
@@ -90,15 +94,15 @@ void tag_injection_scenario_load_setup(uint32 allocation_size)
 {
 	LOG_DEBUG_GAME("[tag_injection_scenario_load_setup]: Setting up for injection - Alloc Size: {:x}", allocation_size);
 
-	g_manager.set_base_map_tag_data_size(allocation_size + 0x20);
+	g_manager->set_base_map_tag_data_size(allocation_size + 32);
 
 	//Clear the table
-	for (uint16 i = k_first_injected_datum; i < g_manager.get_entry_count(); i++)
+	for (uint16 i = k_first_injected_datum; i < g_manager->get_entry_count(); i++)
 	{
 		g_tag_table[i] = cache_file_tag_instance{ _tag_group_none, NONE, 0, 0 };
 	}
 
-	g_manager.reset();
+	g_manager->reset();
 
 	uint32* tag_table_start = Memory::GetAddress<uint32*>(0x47CD50, 0x4A29B8);
 	csmemset((BYTE*)g_tag_table, 0, 0x3BA40);
@@ -114,22 +118,32 @@ void tag_injection_scenario_load_setup(uint32 allocation_size)
 
 void* tag_injection_extend_block(void* block, uint32 entry_size, uint32 count)
 {
-	return g_manager.extend_tag_block(block, entry_size, count);
+	return g_manager->extend_tag_block(block, entry_size, count);
 }
 
 void* tag_injection_reserve_cache_memory(uint32 size, uint32* out_data_offset)
 {
-	return g_manager.reserve_space_in_cache_memory(size, out_data_offset);
+	return g_manager->reserve_space_in_cache_memory(size, out_data_offset);
 }
 
-void tag_injection_apply_hooks()
+void tag_injection_apply_hooks(void)
 {
+	return;
 }
 
-void tag_injection_initialize()
+void tag_injection_initialize(void)
 {
 	g_tag_table = (cache_file_tag_instance*)malloc(sizeof(cache_file_tag_instance) * k_max_tag_instance_count);
-	g_manager.set_instance_table(g_tag_table);
-	g_manager.init_directories();
+	g_manager = new c_tag_injecting_manager();
+	g_manager->set_instance_table(g_tag_table);
+	g_manager->init_directories();
 	tag_injection_apply_hooks();
+	return;
+}
+
+void tag_injection_deinitialize(void)
+{
+	free(g_tag_table);
+	delete g_manager;
+	return;
 }

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "tag_files/tag_groups.h"
-#include "tag_injection_define.h"
 
 /* constants */
 
@@ -15,12 +14,12 @@ bool tag_injection_check_map_exists(const wchar_t* map_name);
  * \param map_name the filename of the map file without .map
  */
 void tag_injection_set_active_map(const wchar_t* map_name);
-bool tag_injection_active_map_verified();
+bool tag_injection_active_map_verified(void);
 
 datum tag_injection_load(e_tag_group group, const char* tag_name, bool load_dependencies);
 datum tag_injection_load(e_tag_group group, datum cache_datum, bool load_dependencies);
 
-void tag_injection_inject();
+void tag_injection_inject(void);
 
 bool tag_injection_is_injected(datum injected_index);
 
@@ -32,5 +31,8 @@ void* tag_injection_extend_block(void* block, uint32 entry_size, uint32 count);
 
 void* tag_injection_reserve_cache_memory(uint32 size, uint32* out_data_offset);
 
-void tag_injection_apply_hooks();
-void tag_injection_initialize();
+void tag_injection_apply_hooks(void);
+
+void tag_injection_initialize(void);
+
+void tag_injection_deinitialize(void);

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_define.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_define.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define TAG_INJECTION_DEBUG 0
+#define TAG_INJECTION_DEBUG false

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_manager.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "tag_injection_manager.h"
 
+#include "tag_injection_define.h"
+
 #include "bitmaps/bitmap_group.h"
 #include "cache/pc_geometry_cache.h"
 #include "cache/pc_texture_cache.h"
@@ -587,8 +589,11 @@ datum c_tag_injecting_manager::load_tag(e_tag_group group, datum cache_datum, bo
 	return result;
 }
 
-void c_tag_injecting_manager::load_tag_internal(c_tag_injecting_manager* manager, tag_group group, datum cache_datum,
-                                                bool load_dependencies)
+void c_tag_injecting_manager::load_tag_internal(
+	c_tag_injecting_manager* manager,
+	tag_group group,
+	datum cache_datum,
+	bool load_dependencies)
 {
 	cache_file_tag_instance inst = manager->get_tag_instance_from_cache(cache_datum);
 	if (inst.tag_index != cache_datum || inst.group_tag.group != group.group)
@@ -629,6 +634,7 @@ void c_tag_injecting_manager::load_tag_internal(c_tag_injecting_manager* manager
 	{
 		c_tag_injecting_manager::load_dependencies(manager, new_entry);
 	}
+	return;
 }
 
 void c_tag_injecting_manager::load_dependencies(c_tag_injecting_manager* manager, const s_tag_injecting_table_entry* new_entry)

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_table.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_table.cpp
@@ -6,7 +6,7 @@ enum
 	k_injection_table_entry_count_per_resize = 100
 };
 
-c_tag_injection_table::c_tag_injection_table()
+c_tag_injection_table::c_tag_injection_table(void)
 {
 	this->m_entry_count = 0;
 	this->m_table_size = 0;
@@ -15,13 +15,13 @@ c_tag_injection_table::c_tag_injection_table()
 	return;
 }
 
-c_tag_injection_table::~c_tag_injection_table()
+c_tag_injection_table::~c_tag_injection_table(void)
 {
-	for(uint16 i = 0; i < this->m_entry_count; i++)
+	for(uint16 i = 0; i < this->m_entry_count; ++i)
 	{
 		ASSERT(this->m_table[i].loaded_data);
 		this->m_table[i].loaded_data->clear();
-		free(this->m_table[i].loaded_data);
+		delete this->m_table[i].loaded_data;
 	}
 
 	ASSERT(this->m_table);
@@ -32,11 +32,11 @@ c_tag_injection_table::~c_tag_injection_table()
 
 void c_tag_injection_table::clear()
 {
-	for (uint16 i = 0; i < this->m_entry_count; i++)
+	for (uint16 i = 0; i < this->m_entry_count; ++i)
 	{
 		ASSERT(this->m_table[i].loaded_data);
 		this->m_table[i].loaded_data->clear();
-		free(this->m_table[i].loaded_data);
+		delete this->m_table[i].loaded_data;
 	}
 
 	ASSERT(this->m_table);
@@ -55,9 +55,6 @@ uint16 c_tag_injection_table::get_entry_count() const
 
 s_tag_injecting_table_entry* c_tag_injection_table::init_entry(datum cache_index, e_tag_group type)
 {
-	//tag_group temp;
-	//temp.group = type;
-
 	if (this->m_entry_count >= this->m_table_size)
 	{
 		this->resize_table();
@@ -69,7 +66,7 @@ s_tag_injecting_table_entry* c_tag_injection_table::init_entry(datum cache_index
 	result->type = { type };
 	result->is_initialized = true;
 	result->is_injected = false;
-	result->loaded_data = (c_xml_definition_loader*)calloc(1, sizeof(c_xml_definition_loader));
+	result->loaded_data = new c_xml_definition_loader();
 	this->m_entry_count++;
 
 	return result;

--- a/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_table.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/tag_injection_table.h
@@ -26,8 +26,8 @@ private:
 
 	void resize_table();
 public:
-	c_tag_injection_table();
-	~c_tag_injection_table();
+	c_tag_injection_table(void);
+	~c_tag_injection_table(void);
 
 	void clear();
 

--- a/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_block.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_block.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "cseries/cseries_strings.h"
 #include "tinyxml/tinyxml2.h"
+
+#include "cseries/cseries_strings.h"
 #include "tag_files/tag_loader/tag_injection_define.h"
 
 

--- a/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_loader.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_loader.cpp
@@ -10,6 +10,7 @@
 #include "tag_files/tag_block.h"
 #include "tag_files/tag_reference.h"
 #include "tag_files/tag_loader/tag_injection.h"
+#include "tag_files/tag_loader/tag_injection_define.h"
 
 #define lazy_malloc_buffer(TYPE, COUNT)\
 	(TYPE*)malloc(sizeof(TYPE) * (COUNT))
@@ -88,29 +89,36 @@ void c_xml_definition_loader::reset_counts(void)
 	return;
 }
 
-void c_xml_definition_loader::clear()
+void c_xml_definition_loader::clear(void)
 {
 	if (this->m_tag_reference_offset_count)
+	{
 		free(this->m_tag_reference_offsets);
-
+	}
 	if (this->m_classless_tag_reference_offset_count)
+	{
 		free(this->m_classless_tag_reference_offsets);
-
+	}
 	if (this->m_data_reference_offset_count)
+	{
 		free(this->m_data_reference_offsets);
-
+	}
 	if (this->m_string_id_offset_count)
+	{
 		free(this->m_string_id_offsets);
-
+	}
 	if (this->m_tag_block_offset_count)
+	{
 		free(this->m_tag_block_offsets);
-
+	}
 	if (this->m_tag_reference_count)
+	{
 		free(this->m_tag_references);
-
+	}
 	if (this->m_data)
+	{
 		free(this->m_data);
-
+	}
 	this->reset_counts();
 	return;
 }
@@ -168,7 +176,7 @@ void c_xml_definition_loader::initialize_arrays_internal(c_xml_definition_loader
 	}
 }
 
-void c_xml_definition_loader::initialize_arrays()
+void c_xml_definition_loader::initialize_arrays(void)
 {
 	this->initialize_arrays_internal(this, this->m_definition, this->m_file_offset, 1);
 
@@ -191,6 +199,7 @@ void c_xml_definition_loader::initialize_arrays()
 		this->m_tag_references = lazy_malloc_buffer(datum, (this->m_tag_reference_offset_count + this->m_classless_tag_reference_offset_count));
 
 	this->m_data = (int8*)calloc(this->m_total_data_size, sizeof(int8));
+	return;
 }
 
 int8* c_xml_definition_loader::reserve_data(uint32 size)

--- a/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_loader.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_loader.h
@@ -81,7 +81,7 @@ private:
 	void reset_counts(void);
 
 	static void initialize_arrays_internal(c_xml_definition_loader* loader, const c_xml_definition_block* definition, uint32 file_offset, uint32 block_count);
-	void initialize_arrays();
+	void initialize_arrays(void);
 	int8* reserve_data(uint32 size);
 	static void load_tag_data_internal(c_xml_definition_loader* loader, const c_xml_definition_block* definition, uint32 file_offset, int8* buffer, uint32 block_count);
 	void load_tag_data();

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -1197,7 +1197,3 @@ void H2MOD::Initialize()
 
 	LOG_INFO_GAME("H2MOD - Initialized");
 }
-
-void H2MOD::Deinitialize() 
-{
-}

--- a/xlive/H2MOD.h
+++ b/xlive/H2MOD.h
@@ -18,7 +18,6 @@ class H2MOD
 {
 public:
 	static void Initialize();
-	static void Deinitialize();
 	static void ApplyHooks();
 	static void RegisterEvents();
 	static void RefreshTogglexDelay();

--- a/xlive/H2MOD/Modules/Accounts/AccountCreate.cpp
+++ b/xlive/H2MOD/Modules/Accounts/AccountCreate.cpp
@@ -15,6 +15,8 @@
 
 const char k_user_name_string[] = "username=";
 
+const char k_cartographer_create_url[] = k_cartographer_url"/create1";
+
 // TODO (Carefully) Cleanup and move
 
 static int InterpretMasterCreate(char* response_content) {
@@ -83,7 +85,7 @@ bool HandleGuiAccountCreate(char* username, char* email, char* password, e_carto
 	free(escaped_user_password);
 
 #ifndef LC4
-	int rtn_code = MasterHttpResponse(std::string(cartographerURL + "/create1").c_str(), http_request_body_build, &rtn_result);
+	int rtn_code = MasterHttpResponse(k_cartographer_create_url, http_request_body_build, &rtn_result);
 #else
 	TEST_N_DEF(LC4);
 #endif

--- a/xlive/H2MOD/Modules/Accounts/AccountLogin.cpp
+++ b/xlive/H2MOD/Modules/Accounts/AccountLogin.cpp
@@ -18,6 +18,8 @@ const char k_login_token_string[] = "login_token=";
 const char k_login_username_string[] = "login_username=";
 const char k_login_ab_online_string[] = "login_abOnline=";
 
+const char k_cartographer_login_url[] = k_cartographer_url"/login2";
+
 int masterState = -1;
 char* masterStateStr = NULL;
 bool AccountEdit_remember = true;
@@ -410,7 +412,7 @@ bool HandleGuiLogin(char* ltoken, char* identifier, char* password, int* out_mas
 	free(escaped_user_password);
 
 #if !defined(LC2)
-	int error_code = MasterHttpResponse(std::string(cartographerURL + "/login2").c_str(), http_request_body_build, &rtn_result);
+	int error_code = MasterHttpResponse(k_cartographer_login_url, http_request_body_build, &rtn_result);
 #else
 	TEST_N_DEF(LC2);
 #endif

--- a/xlive/H2MOD/Modules/Achievements/Achievements.cpp
+++ b/xlive/H2MOD/Modules/Achievements/Achievements.cpp
@@ -1,10 +1,14 @@
 #include "stdafx.h"
 #include "Achievements.h"
 
+#include "cseries/cseries_strings.h"
 #include "H2MOD/Modules/Accounts/Accounts.h"
 #include "H2MOD/Modules/Shell/Config.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
+
+const char k_cartographer_unlock_url[] = k_cartographer_url"/achievement-api/unlock.php";
+const char k_cartographer_achivement_list_url[] = k_cartographer_url"/achievement-api/achievement_list.php?xuid=";
 
 using namespace rapidjson;
 std::map<DWORD, bool> achievementList;
@@ -42,9 +46,7 @@ void AchievementUnlock(unsigned long long xuid, int achievement_id, XOVERLAPPED*
 		Writer<StringBuffer> writer(buffer);
 		document.Accept(writer);
 
-		std::string url(cartographerURL + "/achievement-api/unlock.php");
-
-		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+		curl_easy_setopt(curl, CURLOPT_URL, k_cartographer_unlock_url);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_POST, 1L);
@@ -64,9 +66,9 @@ void GetAchievements(unsigned long long xuid)
 	curl = curl_interface_init_no_verify();
 	if (curl) {
 
-		std::string server_url(cartographerURL + "/achievement-api/achievement_list.php?xuid=" + std::to_string(xuid));
-
-		curl_easy_setopt(curl, CURLOPT_URL, server_url.c_str());
+		c_static_string<512> server_url(k_cartographer_achivement_list_url);
+		server_url.append(std::to_string(xuid).c_str());
+		curl_easy_setopt(curl, CURLOPT_URL, server_url.get_string());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		res = curl_easy_perform(curl);

--- a/xlive/H2MOD/Modules/MapManager/MapManager.cpp
+++ b/xlive/H2MOD/Modules/MapManager/MapManager.cpp
@@ -5,11 +5,12 @@
 #include "H2MOD/Modules/Shell/Config.h"
 #include "H2MOD/Modules/OnScreenDebug/OnscreenDebug.h"
 
+#include "cseries/cseries_strings.h"
+#include "main/map_repository.h"
+#include "main/game_preferences.h"
 #include "networking/NetworkMessageTypeCollection.h"
 #include "networking/logic/life_cycle_manager.h"
 
-#include "main/map_repository.h"
-#include "main/game_preferences.h"
 
 std::unique_ptr<MapManager> mapManager(std::make_unique<MapManager>());
 
@@ -360,7 +361,8 @@ static int32 map_download_curl_xferinfo_cb(void* p, curl_off_t dltotal, curl_off
 }
 
 bool MapDownloadQuery::DownloadFromRepo() {
-	std::string url(cartographerMapRepoURL + "/");
+	c_static_string<512> url(k_cartographer_map_repo_url);
+	url.append("/");
 
 	FILE* fp = nullptr;
 	CURL* curl = nullptr;
@@ -380,12 +382,12 @@ bool MapDownloadQuery::DownloadFromRepo() {
 		}
 
 		char* url_encoded_map_filename = curl_easy_escape(curl, m_clientMapFilename.c_str(), m_clientMapFilename.length());
-		url += url_encoded_map_filename;
+		url.append(url_encoded_map_filename);
 		curl_free(url_encoded_map_filename);
 
 		//fail if 404 or any other type of http error
 		curl_easy_setopt(curl, CURLOPT_FAILONERROR, true);
-		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+		curl_easy_setopt(curl, CURLOPT_URL, url.get_string());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, map_download_curl_write_data_cb);
 		curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, map_download_curl_xferinfo_cb);
 		curl_easy_setopt(curl, CURLOPT_XFERINFODATA, (void*)this);

--- a/xlive/H2MOD/Modules/Shell/Config.cpp
+++ b/xlive/H2MOD/Modules/Shell/Config.cpp
@@ -31,8 +31,7 @@ unsigned short H2Config_master_port_relay = 1001;
 //config variables
 bool H2Portable = false;//TODO
 
-std::string cartographerURL = "https://cartographer.online";
-std::string cartographerMapRepoURL = "http://www.h2maps.net/Cartographer/CustomMaps";
+const char* k_cartographer_map_repo_url = "http://www.h2maps.net/Cartographer/CustomMaps";
 
 unsigned short H2Config_base_port = 2000;
 unsigned long H2Config_ip_lan = htonl(INADDR_NONE);

--- a/xlive/H2MOD/Modules/Shell/Config.h
+++ b/xlive/H2MOD/Modules/Shell/Config.h
@@ -32,8 +32,8 @@ enum H2Config_Experimental_Rendering_Mode : byte
 	_rendering_mode_original_game_frame_limit
 };
 
-extern std::string cartographerURL;
-extern std::string cartographerMapRepoURL;
+#define k_cartographer_url "https://cartographer.online"
+extern const char* k_cartographer_map_repo_url;
 
 extern unsigned long H2Config_master_ip;
 extern unsigned short H2Config_master_port_login;

--- a/xlive/H2MOD/Modules/Shell/Startup/Startup.cpp
+++ b/xlive/H2MOD/Modules/Shell/Startup/Startup.cpp
@@ -408,4 +408,8 @@ void DeinitH2Startup() {
 	DeinitCustomLanguage();
 	DeinitH2Accounts();
 	DeinitH2Config();
+
+	free(H2AppDataLocal);
+	free(H2ProcessFilePath);
+	return;
 }

--- a/xlive/H2MOD/Modules/Updater/Updater.cpp
+++ b/xlive/H2MOD/Modules/Updater/Updater.cpp
@@ -8,6 +8,8 @@
 
 #include "main/main.h"
 
+const char k_cartographer_update_ini_url[] = k_cartographer_url"/update1.ini";
+
 bool fork_cmd_elevate(const wchar_t* cmd, wchar_t* flags = 0) {
 	SHELLEXECUTEINFO shExInfo = { 0 };
 	shExInfo.cbSize = sizeof(shExInfo);
@@ -269,7 +271,7 @@ static void FetchUpdateDetails() {
 
 	addDebugText("Fetching Update Details.");
 	char* rtn_result = 0;
-	int rtn_code = MasterHttpResponse(std::string(cartographerURL + "/update1.ini").c_str(), "", &rtn_result);
+	int rtn_code = MasterHttpResponse(k_cartographer_update_ini_url, "", &rtn_result);
 	if (rtn_code == 0) {
 		addDebugText("Got Update Details.");
 
@@ -408,9 +410,10 @@ bool DownloadUpdatedFiles() {
 				swprintf(existingfilepath, ARRAYSIZE(existingfilepath), L"%s%hs", dir_update, UpdateFileEntries[i]->local_name);
 			}
 			_wremove(existingfilepath);
-			std::string im_lazy_2_dl = "https://cartographer.online/";
-			im_lazy_2_dl += UpdateFileEntries[i]->server_uri;
-			DownloadFile(im_lazy_2_dl.c_str(), existingfilepath);
+			
+			c_static_string<1024> download_url(k_cartographer_url);
+			download_url.append(UpdateFileEntries[i]->server_uri);
+			DownloadFile(download_url.get_string(), existingfilepath);
 		}
 	}
 

--- a/xlive/dllmain.cpp
+++ b/xlive/dllmain.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 
 #include "cartographer/discord/discord_interface.h"
+#include "interface/new_hud_draw.h"
+#include "tag_files/tag_loader/tag_injection.h"
 
 #include "H2MOD/Modules/Shell/Startup/Startup.h"
 #include "H2MOD/Modules/Shell/Config.h"
@@ -117,6 +119,8 @@ void initialize_instance(void)
 void exit_instance(void)
 {
 	discord_dispose();
+	tag_injection_deinitialize();
+	new_hud_draw_deinitialize();
 
 #ifndef NO_TRACE
 	EnterCriticalSection(&log_section);

--- a/xlive/dllmain.cpp
+++ b/xlive/dllmain.cpp
@@ -133,6 +133,9 @@ void exit_instance(void)
 	LeaveCriticalSection(&log_section);
 	DeleteCriticalSection(&log_section);
 #endif
+#if CARTOGRAPHER_HEAP_DEBUG
+	_CrtDumpMemoryLeaks();
+#endif
 	TerminateProcess(GetCurrentProcess(), 0);
 	return;
 }


### PR DESCRIPTION
- memory wouldn't be freed when the application was closed
- fix malloc and free usage in tag injector code when allocating classes (uses new/delete now)
- make carto url a macro constant