### PR TITLE
fix bug where motd can freeze the game

### DIFF
--- a/xlive/H2MOD/GUI/imgui_integration/MOTD.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/MOTD.cpp
@@ -43,6 +43,8 @@ namespace ImGuiHandler
 				fp = _wfopen(file_path, L"wb");
 				curl_easy_setopt(curl, CURLOPT_URL, k_motd_url);
 				curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
+				curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10);
+				curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10);
 				curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
 				res = curl_easy_perform(curl);
 				if (res == CURLcode::CURLE_OK)


### PR DESCRIPTION
there is a rare case where the curl request can hang and the process will wait forever to recieve the motd image.

added a timeout to the curl request so if it doesn't load within 10 seconds it will fail out and continue on.