### PR TITLE
add default sorting to network browser

### DIFF
--- a/xlive/Blam/Engine/interface/screens/screen_network_squad_browser.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_network_squad_browser.cpp
@@ -1,8 +1,53 @@
 #include "stdafx.h"
 #include "screen_network_squad_browser.h"
 
+#include "interface/user_interface_controller.h"
+
+/* typedefs */
+
+typedef c_screen_network_squad_browser* (__cdecl* load_network_browser_t)(s_screen_parameters*);
+load_network_browser_t p_load_network_browser;
+load_network_browser_t p_load_live_browser;
+
+/* public code */
+
+void c_network_squad_list::sort_event(s_event_record* event, int32 selected_column_index)
+{
+	INVOKE_TYPE(0x218EE7, 0, void(__thiscall*)(c_network_squad_list*, s_event_record*, int32), this, event, selected_column_index);
+}
+
+c_screen_network_squad_browser* c_screen_network_squad_browser::load_network_browser(s_screen_parameters* parameters)
+{
+	c_screen_network_squad_browser* screen = p_load_network_browser(parameters);
+
+	return screen;
+}
+
+c_screen_network_squad_browser* c_screen_network_squad_browser::load_live_browser(s_screen_parameters* parameters)
+{
+	c_screen_network_squad_browser* screen = p_load_live_browser(parameters);
+
+	screen->m_selected_column_index = _screen_network_squad_browser_column_players;
+	screen->m_list_is_sorted = true;
+
+	s_event_record t_event{};
+	t_event.type = _user_interface_event_type_mouse_button_left_click;
+
+	// this forces the server list to sort by player count default
+	// this called twice because the default behaviour in sorting
+	// is ascending instead of descending
+	screen->m_list.sort_event(&t_event, _screen_network_squad_browser_column_players);
+	screen->m_list.sort_event(&t_event, _screen_network_squad_browser_column_players);
+
+	screen->m_selected_column_index = NONE;
+
+	return screen;
+}
+
+
 #pragma region Live list fix for disappearing labels
 CLASS_HOOK_DECLARE_LABEL(c_screen_network_squad_browser__build_players_list_fix, c_screen_network_squad_browser::build_players_list_fix);
+
 void c_screen_network_squad_browser::build_players_list_fix(c_player_widget_representation* representations, int32 player_count)
 {
 	if (m_live_list)
@@ -31,4 +76,7 @@ void c_screen_network_squad_browser::apply_patches()
 	if (Memory::IsDedicatedServer()) return;
 
 	PatchCall(Memory::GetAddressRelative(0x619650), jmp_build_player_list);
+
+	DETOUR_ATTACH(p_load_network_browser, Memory::GetAddress<load_network_browser_t>(0x21A238), c_screen_network_squad_browser::load_network_browser);
+	DETOUR_ATTACH(p_load_live_browser, Memory::GetAddress<load_network_browser_t>(0x21A2E4), c_screen_network_squad_browser::load_live_browser);
 }

--- a/xlive/Blam/Engine/interface/screens/screen_network_squad_browser.h
+++ b/xlive/Blam/Engine/interface/screens/screen_network_squad_browser.h
@@ -1,13 +1,81 @@
 #pragma once
+#include "interface/user_interface_widget_list.h"
+#include "interface/user_interface_widget_list_item.h"
 #include "interface/user_interface_widget_window.h"
+
+enum e_screen_network_squad_browser_columns : uint32
+{
+	_screen_network_squad_browser_column_favorite,
+	_screen_network_squad_browser_column_dedicated_server,
+	_screen_network_squad_browser_column_host_name,
+	_screen_network_squad_browser_column_map,
+	_screen_network_squad_browser_column_custom_map,
+	_screen_network_squad_browser_column_game_type,
+	_screen_network_squad_browser_column_variant,
+	_screen_network_squad_browser_column_players,
+	_screen_network_squad_browser_column_description,
+
+	k_screen_network_squad_browser_column_count
+};
+
+struct c_network_squad_list : public c_list_widget
+{
+private:
+	c_list_item_widget* m_list;
+	uint32 m_list_count;
+	c_list_item_widget m_live_list[20];
+	c_list_item_widget m_network_list[18];
+	int8 field_1450;
+	int8 pad[3];
+	int32 field_1454;
+	c_slot2< c_network_squad_list, s_event_record*, int32> slot;
+	int32 field_1470;
+	int32 field_1474;
+	int32 field_1478;
+	int32 field_147C;
+	int32 field_1480;
+	int32 field_1484;
+	int32 field_1488;
+	int32 field_148C;
+	int32 field_1490;
+	int32 field_1494;
+	int32 field_1498;
+	int8 field_1499;
+	bool use_live_squad_list;
+	int16 field_149E;
+
+	
+public:
+	c_network_squad_list(uint16 user_flags);
+	virtual ~c_network_squad_list() = default;
+
+	virtual void pre_destroy() override;
+	virtual void update() override;
+	virtual bool handle_event(s_event_record* event) override;
+	virtual c_list_item_widget* get_list_items() override;
+	virtual int32 get_list_items_count() override;
+	virtual void update_list_items(c_list_item_widget*, int32 skin_index) override;
+
+	void sort_event(s_event_record* event, int32 selected_column_index);
+};
+ASSERT_STRUCT_SIZE(c_network_squad_list, 5280);
 
 class c_screen_network_squad_browser : c_screen_with_menu
 {
-	char gap_A60[0x14A0];
-	bool m_live_list;
-	char gap_1F04[11];
+	c_network_squad_list m_list;
+	int16 m_live_list;
+	bool m_list_is_sorted;
+	int8 field_1F03;
+	int32 m_selected_column_index;
+	int32 field_1F08;
+
+	static c_screen_network_squad_browser* __cdecl load_network_browser(s_screen_parameters* parameters);
+	static c_screen_network_squad_browser* __cdecl load_live_browser(s_screen_parameters* parameters);
 
 public:
+	c_screen_network_squad_browser(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags);
+	virtual ~c_screen_network_squad_browser() = default;
+
 	void build_players_list_fix(c_player_widget_representation* representations, int32 player_count);
 
 	static void* load(s_screen_parameters* parameters);


### PR DESCRIPTION
added definitions for c_screen_network_squad_browser and c_network_squad_list

modified the constructor for c_screen_network_squad_browser::load_live_browser to change the default sorting of the table to players descending