### PR TITLE
Add proper Bumper-Jumper support for controllers

### DIFF
--- a/xlive/Blam/Engine/camera/dead_camera.cpp
+++ b/xlive/Blam/Engine/camera/dead_camera.cpp
@@ -41,7 +41,7 @@ void* __cdecl death_cam_get_controller_input(e_controller_index controller)
 
 	// instead we return abstracted_input_state
 	// then we test for abstracted _button_jump in the caller
-	return &input_abstraction_globals->input_states[controller];
+	return &g_input_abstraction_globals->input_states[controller];
 }
 
 // allows keyboards/gamepads/any device to switch death b/w targets

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -143,7 +143,7 @@ void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferenc
 
 	//--- gamepad input settings --- //
 
-	if (thumbstick_layout != _joystick_preset_unused4 && button_preset_type != _button_preset_unused4)
+	if (thumbstick_layout != _joystick_preset_unused4 && button_preset_type != _button_preset_unused5)
 	{
 		//add baseline controls		
 		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_gamepad, _gamepad_binary_button_start, 0, 0);
@@ -296,6 +296,41 @@ void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferenc
 			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
 			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
 			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			break;
+		case _button_preset_jumpy:
+			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);			
+			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_right, 0, 0);
+			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_up, 0, 0);
+			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_up, 0, 0);
+
+
+			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
 			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
 			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
 			break;

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -1,8 +1,10 @@
 #include "stdafx.h"
 
 #include "input_abstraction.h"
+#include "input_windows.h"
 
 #include "game/player_constants.h"
+#include "main/game_preferences.h"
 #include "saved_games/cartographer_player_profile.h"
 
 #include "H2MOD/GUI/imgui_integration/imgui_handler.h"
@@ -20,6 +22,45 @@ s_keyboard_input_state old_keyboard_state;
 e_controller_index updating_gamepad_index = _controller_index_0;
 
 /* public code */
+
+bool c_input_control::add_button(e_input_device_types device_type, uint32 keycode, uint32 held_time, bool return_value_handled)
+{
+	return INVOKE_TYPE(0x5E473, 0x0, bool(__thiscall*)(c_input_control*, e_input_device_types, uint32, uint32, bool), this, device_type, keycode, held_time, return_value_handled);
+
+	//if (this->button_count < NUMBEROF(buttons))
+	//{
+	//	if (button_count >= 0)
+	//	{
+	//		this->buttons[button_count].m_device_type = device_type;
+	//		this->buttons[this->button_count].m_device_key = keycode;
+	//		this->buttons[this->button_count].m_device_key_held_time_msec = held_time;
+
+	//		++this->button_count;
+	//		return true;
+	//	}
+	//}
+	//ASSERT(button_count >= 0);
+	//ASSERT(return_value_handled || (button_count < NUMBEROF(buttons)));
+	//return false;
+
+}
+
+bool c_input_control::remove_button(uint32 button_index)
+{
+	return INVOKE_TYPE(0x5E4B2, 0x0, bool(__thiscall*)(c_input_control*, uint32), this, button_index);
+
+	//ASSERT(button_index >= 0);
+	//ASSERT(button_index < MAX_BUTTONS_PER_CONTROL);
+
+	//if (this->button_count <= 0)
+	//	return false;
+	//if (button_index != (MAX_BUTTONS_PER_CONTROL - 1))
+	//	csmemmove(&this->buttons[button_index], &this->buttons[button_index + 1], sizeof(s_input_button) * (MAX_BUTTONS_PER_CONTROL - button_index -1));
+	//if (button_index < this->button_count)
+	//	--this->button_count;
+	//return true;
+}
+
 
 void __cdecl input_abstraction_initialize()
 {
@@ -56,9 +97,429 @@ void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_cont
 	INVOKE(0x61CD3, 0x0, input_abstraction_get_player_look_angular_velocity_for_mouse, controller_index, angular_velocity);
 }
 
-void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout)
+void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout, int32 unused)
 {
-	INVOKE(0x5EE72, 0x0, input_abstraction_get_default_preferences, preference, thumbstick_layout, button_preset_type, kb_layout);
+	//INVOKE(0x5EE72, 0x0, input_abstraction_get_default_preferences, preference, thumbstick_layout, button_preset_type, kb_layout, unused);
+
+
+	//--- input settings pre process --- //
+
+	for (int32 current_action_idx = 0; current_action_idx < NUMBER_OF_EXTENDED_CONTROL_BUTTONS; current_action_idx++)
+	{
+		e_button_action current_action = (e_button_action)current_action_idx;
+		c_input_control* current_control = &preference->game_controls_to_hardware[current_action];
+
+		if (kb_layout != _custom_keyboard_preset_custom
+			|| current_action == _button_start
+			|| current_action == _button_back
+			|| current_action == _button_accept
+			|| current_action == _button_cancel
+			|| current_action == _button_ui_scroll_up
+			|| current_action == _button_ui_scroll_down)
+		{
+			current_control->button_count = 0;
+		}
+		else
+		{
+			for (uint8 button_index = 0; button_index < MAX_BUTTONS_PER_CONTROL; button_index++)
+			{
+				if (current_control->buttons[button_index].m_device_type == _input_device_type_gamepad && current_control->button_count > 0)
+				{
+					if (button_index != (MAX_BUTTONS_PER_CONTROL - 1))
+					{
+						csmemmove(&current_control->buttons[button_index], &current_control->buttons[button_index + 1], sizeof(s_input_button) * (MAX_BUTTONS_PER_CONTROL - button_index - 1));
+					}
+					if (button_index < current_control->button_count)
+					{
+						--current_control->button_count;
+					}
+				}
+			}
+		}
+	}
+
+
+
+
+	//--- gamepad input settings --- //
+
+	if (thumbstick_layout != _joystick_preset_unused4 && button_preset_type != _button_preset_unused4)
+	{
+		//add baseline controls		
+		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_gamepad, _gamepad_binary_button_start, 0, 0);
+		preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_gamepad, _gamepad_binary_button_back, 0, 0);
+		preference->game_controls_to_hardware[_button_crouch].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_thumb, 0, 0);
+		preference->game_controls_to_hardware[_button_lean_left].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_left, 0, 0);
+		preference->game_controls_to_hardware[_button_lean_right].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_right, 0, 0);
+		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+		preference->game_controls_to_hardware[_button_cancel].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+		preference->game_controls_to_hardware[_button_banshee_bomb].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+
+
+		switch (button_preset_type)
+		{
+		case _button_preset_default:
+			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+
+
+			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			break;
+		case _button_preset_south_paw:
+			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+
+
+			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+
+			break;
+		case _button_preset_boxer:
+			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+
+
+			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			break;
+		case _button_preset_green_thumb:
+			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
+			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
+			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
+
+
+			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
+			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			break;
+
+		default:
+			break;
+		}
+
+
+		e_gamepad_buttons fwd_key = _gamepad_analog_right_stick_up;
+		e_gamepad_buttons bkwd_key = _gamepad_analog_right_stick_down;
+		e_gamepad_buttons pitch_fwd_key = _gamepad_analog_left_stick_up;
+		e_gamepad_buttons pitch_bkwd_key = _gamepad_analog_left_stick_down;
+
+		e_gamepad_buttons strafe_left_key = _gamepad_analog_right_stick_left;
+		e_gamepad_buttons strafe_right_key = _gamepad_analog_right_stick_right;
+		e_gamepad_buttons yaw_left_key = _gamepad_analog_left_stick_left;
+		e_gamepad_buttons yaw_right_key = _gamepad_analog_left_stick_right;
+
+		if (thumbstick_layout == _joystick_preset_default || thumbstick_layout == _joystick_preset_legacy)
+		{
+			fwd_key = _gamepad_analog_left_stick_up;
+			bkwd_key = _gamepad_analog_left_stick_down;
+			pitch_fwd_key = _gamepad_analog_right_stick_up;
+			pitch_bkwd_key = _gamepad_analog_right_stick_down;
+		}
+
+		if (thumbstick_layout == _joystick_preset_default || thumbstick_layout == _joystick_preset_legacy_south_paw)
+		{
+			strafe_left_key = _gamepad_analog_left_stick_left;
+			strafe_right_key = _gamepad_analog_left_stick_right;
+			yaw_left_key = _gamepad_analog_right_stick_left;
+			yaw_right_key = _gamepad_analog_right_stick_right;
+		}
+
+		preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_gamepad, fwd_key, 0, 0);
+		preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_gamepad, bkwd_key, 0, 0);
+		preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_gamepad, strafe_left_key, 0, 0);
+		preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_gamepad, strafe_right_key, 0, 0);
+		preference->game_controls_to_hardware[_extended_button_gamepad_pitch_forward].add_button(_input_device_type_gamepad, pitch_fwd_key, 0, 0);
+		preference->game_controls_to_hardware[_extended_button_gamepad_pitch_backward].add_button(_input_device_type_gamepad, pitch_bkwd_key, 0, 0);
+		preference->game_controls_to_hardware[_extended_button_gamepad_yaw_left].add_button(_input_device_type_gamepad, yaw_left_key, 0, 0);
+		preference->game_controls_to_hardware[_extended_button_gamepad_yaw_right].add_button(_input_device_type_gamepad, yaw_right_key, 0, 0);
+
+
+
+
+
+		//--- keyboard and mouse input settings --- //
+
+
+		e_language language = get_current_language();
+		bool kb_type_south_paw = kb_layout == _custom_keyboard_preset_left_hold || kb_layout == _custom_keyboard_preset_left_split;
+		bool kb_type_legacy = !kb_type_south_paw;
+		bool kb_type_split = kb_layout == _custom_keyboard_preset_right_split || kb_layout == _custom_keyboard_preset_left_split;
+
+#define HELPER_GET_INT_KEY(code) (language != _language_english ? language_get_international_key(language, (code)) : (code))
+
+		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_keyboard, VK_PAUSE, 0, 0);
+		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_keyboard, VK_ESCAPE, 0, 0);
+		preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_keyboard, VK_BACK, 0, 0);
+
+
+		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, HELPER_GET_INT_KEY('A'), 0, 0);
+		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, VK_RETURN, 0, 0);
+		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_mouse, _mouse_button_left, 0, 0);
+		preference->game_controls_to_hardware[_button_ui_scroll_up].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
+		preference->game_controls_to_hardware[_button_ui_scroll_down].add_button(_input_device_type_mouse, _mouse_delta_w_back, 0, 0);
+
+		if (kb_layout != _custom_keyboard_preset_custom)
+		{
+			//default_mapping presets;
+
+			preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'C' : 'Y'), 0, 0);
+			preference->game_controls_to_hardware[_button_mouse_pitch_forward].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
+			preference->game_controls_to_hardware[_button_mouse_pitch_backward].add_button(_input_device_type_mouse, _mouse_delta_y_down, 0, 0);
+			preference->game_controls_to_hardware[_button_mouse_yaw_left].add_button(_input_device_type_mouse, _mouse_delta_x_left, 0, 0);
+			preference->game_controls_to_hardware[_button_mouse_yaw_right].add_button(_input_device_type_mouse, _mouse_delta_x_right, 0, 0);
+			preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('W') : 'I'), 0, 0);
+			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'S' : HELPER_GET_INT_KEY('K')), 0, 0);
+			preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('A') : 'J'), 0, 0);
+			preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'D' : HELPER_GET_INT_KEY('L')), 0, 0);
+			preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_keyboard, VK_UP, 0, 0);
+			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, VK_DOWN, 0, 0);
+			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, VK_DOWN, 0, 0);
+			preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_keyboard, VK_LEFT, 0, 0);
+			preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_keyboard, VK_RIGHT, 0, 0);
+			preference->game_controls_to_hardware[_button_crouch].add_button(_input_device_type_keyboard, (kb_type_legacy ? VK_LSHIFT : VK_RSHIFT), 0, 0);
+			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+			preference->game_controls_to_hardware[_button_text_chat_team].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'B' : 'V'), 0, 0);
+			preference->game_controls_to_hardware[_button_text_chat_toggle].add_button(_input_device_type_keyboard, VK_F1, 0, 0);
+			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('N') : HELPER_GET_INT_KEY('B')), 0, 0);
+			preference->game_controls_to_hardware[_button_cancel].add_button(_input_device_type_keyboard, 'B', 0, 0);
+
+
+			if (kb_type_split)
+			{
+				preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'R' : 'U'), 0, 0);
+				preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY(0x109)), 0, 0);
+				preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'Q' : HELPER_GET_INT_KEY(0x109)), 0, 0);
+				preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY(0x109)), 0, 0);
+				preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : HELPER_GET_INT_KEY(0x10A)), 0, 0);
+				preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'F' : 0x10B), 0, 0);
+				preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
+				preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
+				preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
+				preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
+				preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
+				preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
+				preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY(VK_TAB) : HELPER_GET_INT_KEY('P')), 0, 0);
+				preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'G' : HELPER_GET_INT_KEY(0x10F)), 0, 0);
+				preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'X' : HELPER_GET_INT_KEY('M')), 0, 0);
+			}
+			else
+			{
+				preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'R' : 'U'), 0, 0);
+				preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY('O')), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY('O')), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : 'O'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : 'O'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : 'O'), 0, 0);
+				preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'F' : 'H'), 0, 0);
+				preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), 0, 0);
+				preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), 0, 0);
+				preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+				preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY(VK_TAB) : HELPER_GET_INT_KEY('P')), 0, 0);
+				preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'G' : HELPER_GET_INT_KEY(0x10C)), 0, 0);
+				preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'X' : VK_RMENU), 0, 0);
+
+			}
+
+
+			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_left : _mouse_button_right), 0, 0);
+			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+
+			if (!kb_type_legacy || kb_type_split)
+			{
+				preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
+			}
+			else
+			{
+				preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
+			}
+
+			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_mouse, _mouse_button_left, 0, 0);
+			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_mouse, _mouse_button_right, 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_left : _mouse_button_right), 0, 0);
+			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+			preference->game_controls_to_hardware[_button_banshee_bomb].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom_in].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom_out].add_button(_input_device_type_mouse, _mouse_delta_w_back, 0, 0);
+			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_mouse, (kb_type_legacy ? HELPER_GET_INT_KEY('Z') : 'N'), 0, 0);
+			preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_mouse, _mouse_button_5, 0, 0);
+			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_mouse, _mouse_button_4, 0, 0);
+			preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_mouse, _mouse_button_6, 0, 0);
+			preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_mouse, _mouse_button_7, 0, 0);
+
+			//default_mapping presets end;
+#undef HELPER_GET_INT_KEY
+		}
+
+		preference->field_1658 = 0; // last used device being gamepad = false ?
+
+		bool mapping_ok = true;
+		for (int32 current_action_idx = 0; current_action_idx < NUMBER_OF_EXTENDED_CONTROL_BUTTONS; current_action_idx++)
+		{
+			e_button_action current_action = (e_button_action)current_action_idx;
+			c_input_control* current_control = &preference->game_controls_to_hardware[current_action];
+
+			if (current_action == _button_scope_zoom
+				|| current_action == _button_scope_zoom_in
+				|| current_action == _button_scope_zoom_out)
+			{
+
+				mapping_ok = preference->game_controls_to_hardware[_button_scope_zoom].button_count > 0
+					|| preference->game_controls_to_hardware[_button_scope_zoom_in].button_count > 0
+					&& preference->game_controls_to_hardware[_button_scope_zoom_out].button_count > 0;
+			}
+			else
+			{
+				mapping_ok = current_control->button_count > 0;
+			}
+		}
+		ASSERT(mapping_ok /*|| caller_handles_failures*/);
+
+
+	}
+
+	//--- global input preferences --- //
+
+	preference->gamepad_yaw_rate = 120.0f;
+	preference->mouse_yaw_rate = 90.0f;
+	preference->gamepad_pitch_rate = 60.0f;
+	preference->mouse_pitch_rate = 45.0f;
+	preference->mouse_acceleration = 0.69999999f;
+	preference->binary_yaw_rate = 1.0f;
+	preference->binary_pitch_rate = 1.0f;
+	preference->gamepad_axial_deadzone_left.y = 0x1EA9;
+	preference->gamepad_axial_deadzone_left.x = 0x1EA9;
+	preference->stick_threshold = 0.25f;
+	preference->gamepad_axial_deadzone_right.y = 0x21F1;
+	preference->gamepad_axial_deadzone_right.x = 0x21F1;
+	preference->gamepad_invert_look = false;
+	preference->mouse_invert_look = false;
+	preference->invert_aircraft_control = false;
+	preference->invert_dual_wield = true;
+	preference->mouse_delta_threshold = 0.050000001f;
+	preference->mouse_wheel_threshold = 0.050000001f;
+
 }
 
 void input_abstraction_set_controller_settings_from_preferences(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings)

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -824,11 +824,9 @@ static void input_abstraction_set_global_input_preferences(s_gamepad_input_prefe
 	preference->mouse_acceleration = 0.7f;
 	preference->binary_yaw_rate = 1.f;
 	preference->binary_pitch_rate = 1.f;
-	preference->gamepad_axial_deadzone_left.x = 0x1EA9;
-	preference->gamepad_axial_deadzone_left.y = 0x1EA9;
+	preference->gamepad_axial_deadzone_left = { XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE,XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE };
 	preference->stick_threshold = 0.25f;
-	preference->gamepad_axial_deadzone_right.x = 0x21F1;
-	preference->gamepad_axial_deadzone_right.y = 0x21F1;
+	preference->gamepad_axial_deadzone_right = { XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE,XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE };
 	preference->gamepad_invert_look = false;
 	preference->mouse_invert_look = false;
 	preference->invert_aircraft_control = false;

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -56,30 +56,40 @@ void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_cont
 	INVOKE(0x61CD3, 0x0, input_abstraction_get_player_look_angular_velocity_for_mouse, controller_index, angular_velocity);
 }
 
-bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_functions button_index)
+void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout)
+{
+	INVOKE(0x5EE72, 0x0, input_abstraction_get_default_preferences, preference, thumbstick_layout, button_preset_type, kb_layout);
+}
+
+void input_abstraction_set_controller_settings_from_preferences(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings)
+{
+	INVOKE(0x61B62, 0, input_abstraction_set_controller_settings_from_preferences, preferences, controller_settings);
+}
+
+void input_abstraction_set_preferences_from_controller_settings(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings)
+{
+	INVOKE(0x61AD0, 0, input_abstraction_set_preferences_from_controller_settings, preferences, controller_settings);
+}
+
+bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_action button_index)
 {
 	return INVOKE(0x61C5B, 0x0, input_abstraction_controller_button_test, controller_index, button_index);
 }
 
-e_button_functions __cdecl input_abstraction_get_primary_fire_button(datum unit)
+e_button_action __cdecl input_abstraction_get_primary_fire_button(datum unit)
 {
 	return INVOKE(0x5E2B6, 0x0, input_abstraction_get_primary_fire_button, unit);
 }
 
-e_button_functions __cdecl input_abstraction_get_secondary_fire_button(datum unit)
+e_button_action __cdecl input_abstraction_get_secondary_fire_button(datum unit)
 {
 	return INVOKE(0x5E2ED, 0x0, input_abstraction_get_secondary_fire_button, unit);
 }
 
 
-uint32 s_input_abstraction_globals_sub_45E501(e_button_functions button, void* a3)
+uint32 s_input_abstraction_globals_sub_45E501(e_button_action button, void* a3)
 {
-	return INVOKE_TYPE(0x5E501, 0x0, uint32(__thiscall*)(s_input_abstraction_globals*, e_button_functions, void*), input_abstraction_globals, button, a3);
-}
-
-bool input_abstraction_preferences_new(s_gamepad_input_preferences* preferences, int16 a2, bool a3, bool a4)
-{
-	return INVOKE(0x5EE72, 0, input_abstraction_preferences_new, preferences, a2, a3, a4);
+	return INVOKE_TYPE(0x5E501, 0x0, uint32(__thiscall*)(s_input_abstraction_globals*, e_button_action, void*), input_abstraction_globals, button, a3);
 }
 
 int32 __cdecl input_abstraction_get_last_used_device(e_controller_index controller)
@@ -87,25 +97,21 @@ int32 __cdecl input_abstraction_get_last_used_device(e_controller_index controll
 	return INVOKE(0x5E30E, 0x0, input_abstraction_get_last_used_device, controller);
 }
 
-uint32 input_abstraction_get_stick_type_for_function(e_button_functions function)
+e_abstract_gamepad_stick_types input_abstraction_get_stick_type_for_action(e_button_action action)
 {
-	// Todo : define enum
-	// -1 = bad type
-	// 0  = left_stick,
-	// 1  = right_stick,
-	uint32 button = s_input_abstraction_globals_sub_45E501(function, NULL);
+	uint32 button = s_input_abstraction_globals_sub_45E501(action, NULL);
 	if (button > _gamepad_analog_left_stick_right)
-		return button > _gamepad_analog_right_stick_right ? NONE : 1;
-	return 0;
+		return button > _gamepad_analog_right_stick_right ? _abstract_gamepad_stick_unknown : _abstract_gamepad_stick_right;
+	return _abstract_gamepad_stick_left;
 }
 
 
-void input_abstraction_update_default_throttle(const point2d* thumb, real_euler_angles2d* out_stick_euler_angles)
+void input_abstraction_update_dead_zones(const point2d* thumb, real_euler_angles2d* out_stick_euler_angles)
 {
 	constexpr real32 normalize_scale = 1.f / INT16_MAX;
 
 	real_point2d thumbstick_points = { (real32)thumb->x, (real32)thumb->y };
-	real_angle angle = atan2(thumbstick_points.y, thumbstick_points.x);
+	real_angle angle = arctangent(thumbstick_points.y, thumbstick_points.x);
 
 	real32 magnitude = MAX(fabs(sin(angle)), fabs(cos(angle)));
 	real32 inverse_magnitude = 1.0f / magnitude;
@@ -118,7 +124,7 @@ void input_abstraction_update_default_throttle(const point2d* thumb, real_euler_
 	return;
 }
 
-void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_angle angle, bool right_stick)
+void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_angle angle, e_abstract_gamepad_stick_types stick_index)
 {
 	real_angle flt_7B9F78[] =
 	{
@@ -131,10 +137,10 @@ void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_ang
 	uint8 index = ((stick->pitch >= 0.0f) ? 0 : 2) + (stick->yaw < 0.0f);
 
 	real_vector2d vec = { stick->yaw,stick->pitch };
-	real32 magnitude = square_root(dot_product2d(&vec, &vec));
+	real32 magnitude = magnitude2d(&vec);
 
 	real32 delta = fabs(angle - flt_7B9F78[index]);
-	real_angle min_delta = right_stick ? DEGREES_TO_RADIANS(10.0f) : DEGREES_TO_RADIANS(35.0f);
+	real_angle min_delta = stick_index == _abstract_gamepad_stick_right ? DEGREES_TO_RADIANS(10.0f) : DEGREES_TO_RADIANS(35.0f);
 
 	if (delta >= min_delta)
 	{
@@ -181,40 +187,36 @@ void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_ang
 
 void input_abstraction_post_update_all_throttles(real_euler_angles2d* left_stick, real_euler_angles2d* right_stick, point2d* lthumb, point2d* rthumb)
 {
-	bool adjust_left_stick = 0;
-	bool adjust_right_stick = 0;
+	bool adjust_left_stick = false;
+	bool adjust_right_stick = false;
 
-	uint32 move_fwd_stick_type = input_abstraction_get_stick_type_for_function(_button_move_forward);
-	uint32 extended_yaw_left_stick_type = input_abstraction_get_stick_type_for_function(_extended_button_gamepad_yaw_left);
-	uint32 strafe_left_stick_type = input_abstraction_get_stick_type_for_function(_button_strafe_left);
-	uint32 extended_pitch_fwd_stick_type = input_abstraction_get_stick_type_for_function(_extended_button_gamepad_pitch_forward);
+	e_abstract_gamepad_stick_types move_fwd_stick_type = input_abstraction_get_stick_type_for_action(_button_move_forward);
+	e_abstract_gamepad_stick_types extended_yaw_left_stick_type = input_abstraction_get_stick_type_for_action(_extended_button_gamepad_yaw_left);
+	e_abstract_gamepad_stick_types strafe_left_stick_type = input_abstraction_get_stick_type_for_action(_button_strafe_left);
+	e_abstract_gamepad_stick_types extended_pitch_fwd_stick_type = input_abstraction_get_stick_type_for_action(_extended_button_gamepad_pitch_forward);
 
-	if (move_fwd_stick_type == extended_yaw_left_stick_type && move_fwd_stick_type != NONE)
+	if (move_fwd_stick_type == extended_yaw_left_stick_type && move_fwd_stick_type != _abstract_gamepad_stick_unknown)
 	{
-		if (move_fwd_stick_type)
-		{
-			if (move_fwd_stick_type == 1)
-				adjust_right_stick = true;
-		}
+		if (move_fwd_stick_type == _abstract_gamepad_stick_right)
+			adjust_right_stick = true;
 		else
-		{
 			adjust_left_stick = true;
-		}
+
 	}
-	if (strafe_left_stick_type == extended_pitch_fwd_stick_type && strafe_left_stick_type != NONE)
+	if (strafe_left_stick_type == extended_pitch_fwd_stick_type && strafe_left_stick_type != _abstract_gamepad_stick_unknown)
 	{
-		if (!strafe_left_stick_type)
+		if (strafe_left_stick_type == _abstract_gamepad_stick_left)
 			adjust_left_stick = true;
-		if (strafe_left_stick_type == 1)
+		else
 			adjust_right_stick = true;
 	}
 
-	real_angle left_stick_angle = atan2((real32)lthumb->y, (real32)lthumb->x);
-	real_angle right_stick_angle = atan2((real32)rthumb->y, (real32)rthumb->x);
+	real_angle left_stick_angle = arctangent((real32)lthumb->y, (real32)lthumb->x);
+	real_angle right_stick_angle = arctangent((real32)rthumb->y, (real32)rthumb->x);
 
 	if (adjust_left_stick)
 	{
-		input_abstraction_post_update_throttle(left_stick, left_stick_angle, false);
+		input_abstraction_post_update_throttle(left_stick, left_stick_angle, _abstract_gamepad_stick_left);
 
 		left_stick->yaw = PIN(left_stick->yaw, -1.0f, 1.0f);
 		left_stick->pitch = PIN(left_stick->pitch, -1.0f, 1.0f);
@@ -222,7 +224,7 @@ void input_abstraction_post_update_all_throttles(real_euler_angles2d* left_stick
 
 	if (adjust_right_stick)
 	{
-		input_abstraction_post_update_throttle(right_stick, right_stick_angle, true);
+		input_abstraction_post_update_throttle(right_stick, right_stick_angle, _abstract_gamepad_stick_right);
 
 		right_stick->yaw = PIN(right_stick->yaw, -1.0f, 1.0f);
 		right_stick->pitch = PIN(right_stick->pitch, -1.0f, 1.0f);
@@ -231,8 +233,8 @@ void input_abstraction_post_update_all_throttles(real_euler_angles2d* left_stick
 }
 void input_abstraction_update_throttles_legacy(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick)
 {
-	input_abstraction_update_default_throttle(&gamepad_state->thumb_left, left_stick);
-	input_abstraction_update_default_throttle(&gamepad_state->thumb_right, right_stick);
+	input_abstraction_update_dead_zones(&gamepad_state->thumb_left, left_stick);
+	input_abstraction_update_dead_zones(&gamepad_state->thumb_right, right_stick);
 
 	input_abstraction_post_update_all_throttles(left_stick, right_stick, &gamepad_state->thumb_left, &gamepad_state->thumb_right);
 }
@@ -258,8 +260,8 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 	s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
 	s_saved_game_cartographer_player_profile* profile_settings = cartographer_player_profile_get_by_controller_index(controller);
 
-	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_axial 
-		|| profile_settings->controller_deadzone_type == _controller_deadzone_type_combined) 
+	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_axial
+		|| profile_settings->controller_deadzone_type == _controller_deadzone_type_combined)
 	{
 		preference->gamepad_axial_deadzone_right.x = (uint16)THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_axial.x);
 		preference->gamepad_axial_deadzone_right.y = (uint16)THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_axial.y);
@@ -270,7 +272,7 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 		preference->gamepad_axial_deadzone_right.y = 0;
 	}
 
-	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_radial 
+	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_radial
 		|| profile_settings->controller_deadzone_type == _controller_deadzone_type_combined)
 	{
 		g_controller_radial_deadzones[controller] = (uint16)THUMBSTICK_PERCENTAGE_TO_POINT(profile_settings->deadzone_radial);
@@ -312,7 +314,7 @@ void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller,
 	s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
 
 	preference->mouse_yaw_rate = (80.0f + 20.0f * value) - 30.0f;
-	
+
 	if (cartographer_player_profile->mouse_uniform)
 		preference->mouse_pitch_rate = preference->mouse_yaw_rate;
 	else
@@ -389,12 +391,12 @@ void input_abstraction_restore_windows_inputs()
 void input_abstraction_clear_windows_inputs()
 {
 	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
-	if(mouse_state)
+	if (mouse_state)
 	{
 		csmemset(mouse_state, 0, sizeof(*mouse_state));
 
 		uint16* mouse_buttons = input_get_mouse_button_state();
-		if(mouse_buttons)
+		if (mouse_buttons)
 		{
 			csmemset(mouse_buttons, 0, sizeof(old_mouse_buttons));
 		}
@@ -418,7 +420,7 @@ void input_abstraction_restore_abstracted_inputs(e_controller_index controller)
 		sizeof(s_game_abstracted_input_state));
 }
 
-bool g_controller_advanced_settings_toggle[k_number_of_users] {};
+bool g_controller_advanced_settings_toggle[k_number_of_users]{};
 
 void __cdecl input_abstraction_update()
 {
@@ -447,10 +449,10 @@ void __cdecl input_abstraction_update()
 			// controls players when gamepad is disconnected or no gamepad
 			input_abstraction_globals->input_has_gamepad[controller] = false;
 
-			if(controller != k_windows_device_controller_index)
+			if (controller != k_windows_device_controller_index)
 			{
 				// this needs to be done when a controller disconnects for active player, so it doesnt get controlled by m/k
-				input_abstraction_clear_windows_inputs();		
+				input_abstraction_clear_windows_inputs();
 				input_abstraction_update_input_state(
 					controller,
 					preference,
@@ -470,7 +472,7 @@ void __cdecl input_abstraction_update()
 					&right_stick,
 					game_input_state);
 				input_abstraction_apply_raw_mouse_update(k_windows_device_controller_index, game_input_state);
-			}	
+			}
 
 		}
 		else
@@ -487,7 +489,7 @@ void __cdecl input_abstraction_update()
 
 			if (!input_abstraction_globals->input_has_gamepad[controller])
 				input_abstraction_globals->input_has_gamepad[controller] = true;
-					
+
 
 			if (controller == k_windows_device_controller_index)
 			{

--- a/xlive/Blam/Engine/input/input_abstraction.cpp
+++ b/xlive/Blam/Engine/input/input_abstraction.cpp
@@ -1,7 +1,8 @@
 #include "stdafx.h"
-
 #include "input_abstraction.h"
+
 #include "input_windows.h"
+#include "input_xinput.h"
 
 #include "game/player_constants.h"
 #include "main/game_preferences.h"
@@ -9,19 +10,102 @@
 
 #include "H2MOD/GUI/imgui_integration/imgui_handler.h"
 
+/* constants */
+
+const real32 k_gamepad_stick_angles[] =
+{
+	DEGREES_TO_RADIANS(45.0f),
+	DEGREES_TO_RADIANS(135.0f),
+	DEGREES_TO_RADIANS(-45.0f),
+	DEGREES_TO_RADIANS(-135.0f)
+};
+
 /* globals */
 
-s_input_abstraction_globals* input_abstraction_globals;
-extern uint16 g_controller_radial_deadzones[k_number_of_controllers];
+s_input_abstraction_globals* g_input_abstraction_globals;
+
 //we need this because theres only a single abstracted_inputs inside input_abstraction_globals for h2v
 s_game_abstracted_input_state g_abstract_input_states[k_number_of_controllers];
+
 //buffers to store old windows input states
-DIMOUSESTATE2 old_mouse_state;
-uint16 old_mouse_buttons[8];
-s_keyboard_input_state old_keyboard_state;
-e_controller_index updating_gamepad_index = _controller_index_0;
+DIMOUSESTATE2 g_old_mouse_state;
+
+uint16 g_old_mouse_buttons[8];
+
+s_keyboard_input_state g_old_keyboard_state;
+
+e_controller_index g_updating_gamepad_index = _controller_index_0;
+
+bool g_controller_advanced_settings_toggle[k_number_of_users]{};
+
+/* macros */
+
+#define HELPER_GET_INT_KEY(code, language) (language != _language_english ? language_get_international_key(language, (code)) : (code))
+
+/* prototypes */
+
+static void input_abstraction_store_windows_inputs(void);
+
+static void input_abstraction_restore_windows_inputs(void);
+
+static void input_abstraction_clear_windows_inputs(void);
+
+static void input_abstraction_store_abstracted_inputs(e_controller_index controller);
+
+static void input_abstraction_restore_abstracted_inputs(e_controller_index controller);
+
+static e_abstract_gamepad_stick_types input_abstraction_get_stick_type_for_action(e_button_action action);
+
+static void input_abstraction_update_dead_zones(const point2d* thumb, real_euler_angles2d* out_stick_euler_angles);
+
+static void input_abstraction_apply_raw_mouse_update(e_controller_index controller, s_game_input_state* input_state);
+
+static void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_angle angle, e_abstract_gamepad_stick_types stick_index);
+
+static void input_abstraction_post_update_all_throttles(real_euler_angles2d* left_stick, real_euler_angles2d* right_stick, point2d* lthumb, point2d* rthumb);
+
+static void input_abstraction_update_throttles_legacy(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick);
+
+static void input_abstraction_update_throttles_modern(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick);
+
+static void input_abstraction_set_global_input_preferences(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_add_default_gamepad_baseline_controls(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_gamepad_add_default_preset_controls(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_gamepad_add_southpaw_preset_controls(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_gamepad_add_boxer_preset_controls(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_gamepad_add_greenthumb_preset_controls(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_gamepad_add_jumpy_preset_controls(s_gamepad_input_preferences* preference);
+
+static void input_abstraction_gamepad_set_default_stick_controls(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout);
+
+static void input_abstraction_keyboard_and_mouse_add_default_controls(s_gamepad_input_preferences* preference, e_language language);
+
+static void input_abstraction_keyboard_and_mouse_set_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy);
+
+static void input_abstraction_keyboard_set_normal_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy);
+
+static void input_abstraction_keyboard_set_split_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy);
+
+static void input_abstraction_mouse_set_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy, bool kb_type_split);
+
+static bool __cdecl input_abstraction_controller_plugged_hook(uint16 gamepad_index);
 
 /* public code */
+
+void input_abstraction_patches_apply(void)
+{
+	g_input_abstraction_globals = Memory::GetAddress<s_input_abstraction_globals*>(0x4A89B0);
+
+	PatchCall(Memory::GetAddress(0x39B82), input_abstraction_update);
+	PatchCall(Memory::GetAddress(0x61FBD), input_abstraction_controller_plugged_hook); //inside input_abstraction_update_input_state
+	return;
+}
 
 bool c_input_control::add_button(e_input_device_types device_type, uint32 keycode, uint32 held_time, bool return_value_handled)
 {
@@ -42,7 +126,6 @@ bool c_input_control::add_button(e_input_device_types device_type, uint32 keycod
 	//ASSERT(button_count >= 0);
 	//ASSERT(return_value_handled || (button_count < NUMBEROF(buttons)));
 	//return false;
-
 }
 
 bool c_input_control::remove_button(uint32 button_index)
@@ -62,47 +145,54 @@ bool c_input_control::remove_button(uint32 button_index)
 }
 
 
-void __cdecl input_abstraction_initialize()
+void __cdecl input_abstraction_initialize(void)
 {
 	INVOKE(0x61D43, 0x0, input_abstraction_initialize);
+	return;
 }
 
-void __cdecl input_abstraction_dispose()
+void __cdecl input_abstraction_dispose(void)
 {
 	INVOKE(0x5E296, 0x0, input_abstraction_dispose);
+	return;
 }
 
 void __cdecl input_abstraction_handle_device_change(uint32 flags)
 {
 	INVOKE(0x61C72, 0x0, input_abstraction_handle_device_change, flags);
+	return;
 }
 
 void __cdecl input_abstraction_get_controller_preferences(e_controller_index controller_index, s_gamepad_input_preferences* preferences)
 {
 	INVOKE(0x61BF4, 0x0, input_abstraction_get_controller_preferences, controller_index, preferences);
+	return;
 }
 
 void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state)
 {
 	INVOKE(0x61C3B, 0x0, input_abstraction_get_input_state, controller_index, state);
+	return;
 }
 
 void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity)
 {
 	INVOKE(0x61D0B, 0x0, input_abstraction_get_player_look_angular_velocity, controller_index, angular_velocity);
+	return;
 }
 
 void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_controller_index controller_index, real_euler_angles2d* angular_velocity)
 {
 	INVOKE(0x61CD3, 0x0, input_abstraction_get_player_look_angular_velocity_for_mouse, controller_index, angular_velocity);
+	return;
 }
 
-void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout, int32 unused)
+void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout, bool caller_handles_failures)
 {
 	//INVOKE(0x5EE72, 0x0, input_abstraction_get_default_preferences, preference, thumbstick_layout, button_preset_type, kb_layout, unused);
 
 
-	//--- input settings pre process --- //
+	//--- input settings pre-process --- //
 
 	for (int32 current_action_idx = 0; current_action_idx < NUMBER_OF_EXTENDED_CONTROL_BUTTONS; current_action_idx++)
 	{
@@ -138,379 +228,73 @@ void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferenc
 		}
 	}
 
-
-
-
 	//--- gamepad input settings --- //
 
 	if (thumbstick_layout != _joystick_preset_unused4 && button_preset_type != _button_preset_unused5)
 	{
-		//add baseline controls		
-		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_gamepad, _gamepad_binary_button_start, 0, 0);
-		preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_gamepad, _gamepad_binary_button_back, 0, 0);
-		preference->game_controls_to_hardware[_button_crouch].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_thumb, 0, 0);
-		preference->game_controls_to_hardware[_button_lean_left].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_left, 0, 0);
-		preference->game_controls_to_hardware[_button_lean_right].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_right, 0, 0);
-		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-		preference->game_controls_to_hardware[_button_cancel].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-		preference->game_controls_to_hardware[_button_banshee_bomb].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-
+		//add baseline controls
+		input_abstraction_add_default_gamepad_baseline_controls(preference);
 
 		switch (button_preset_type)
 		{
 		case _button_preset_default:
-			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-
-
-			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			input_abstraction_gamepad_add_default_preset_controls(preference);
 			break;
 		case _button_preset_south_paw:
-			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-
-
-			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-
+			input_abstraction_gamepad_add_southpaw_preset_controls(preference);
 			break;
 		case _button_preset_boxer:
-			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-
-
-			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			input_abstraction_gamepad_add_boxer_preset_controls(preference);
 			break;
 		case _button_preset_green_thumb:
-			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, 0);
-			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-
-
-			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
-			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			input_abstraction_gamepad_add_greenthumb_preset_controls(preference);
 			break;
 		case _button_preset_jumpy:
-			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);			
-			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_right, 0, 0);
-			preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, 0);
-			preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, k_key_hold_threshold_msec, 0);
-			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_up, 0, 0);
-			preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_up, 0, 0);
-
-
-			preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, 0);
-			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, 0);
+			input_abstraction_gamepad_add_jumpy_preset_controls(preference);
 			break;
-
 		default:
+			DISPLAY_ASSERT("unreachable");
 			break;
 		}
 
-
-		e_gamepad_buttons fwd_key = _gamepad_analog_right_stick_up;
-		e_gamepad_buttons bkwd_key = _gamepad_analog_right_stick_down;
-		e_gamepad_buttons pitch_fwd_key = _gamepad_analog_left_stick_up;
-		e_gamepad_buttons pitch_bkwd_key = _gamepad_analog_left_stick_down;
-
-		e_gamepad_buttons strafe_left_key = _gamepad_analog_right_stick_left;
-		e_gamepad_buttons strafe_right_key = _gamepad_analog_right_stick_right;
-		e_gamepad_buttons yaw_left_key = _gamepad_analog_left_stick_left;
-		e_gamepad_buttons yaw_right_key = _gamepad_analog_left_stick_right;
-
-		if (thumbstick_layout == _joystick_preset_default || thumbstick_layout == _joystick_preset_legacy)
-		{
-			fwd_key = _gamepad_analog_left_stick_up;
-			bkwd_key = _gamepad_analog_left_stick_down;
-			pitch_fwd_key = _gamepad_analog_right_stick_up;
-			pitch_bkwd_key = _gamepad_analog_right_stick_down;
-		}
-
-		if (thumbstick_layout == _joystick_preset_default || thumbstick_layout == _joystick_preset_legacy_south_paw)
-		{
-			strafe_left_key = _gamepad_analog_left_stick_left;
-			strafe_right_key = _gamepad_analog_left_stick_right;
-			yaw_left_key = _gamepad_analog_right_stick_left;
-			yaw_right_key = _gamepad_analog_right_stick_right;
-		}
-
-		preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_gamepad, fwd_key, 0, 0);
-		preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_gamepad, bkwd_key, 0, 0);
-		preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_gamepad, strafe_left_key, 0, 0);
-		preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_gamepad, strafe_right_key, 0, 0);
-		preference->game_controls_to_hardware[_extended_button_gamepad_pitch_forward].add_button(_input_device_type_gamepad, pitch_fwd_key, 0, 0);
-		preference->game_controls_to_hardware[_extended_button_gamepad_pitch_backward].add_button(_input_device_type_gamepad, pitch_bkwd_key, 0, 0);
-		preference->game_controls_to_hardware[_extended_button_gamepad_yaw_left].add_button(_input_device_type_gamepad, yaw_left_key, 0, 0);
-		preference->game_controls_to_hardware[_extended_button_gamepad_yaw_right].add_button(_input_device_type_gamepad, yaw_right_key, 0, 0);
-
-
-
-
+		input_abstraction_gamepad_set_default_stick_controls(preference, thumbstick_layout);
 
 		//--- keyboard and mouse input settings --- //
 
+		const e_language language = get_current_language();
 
-		e_language language = get_current_language();
 		bool kb_type_south_paw = kb_layout == _custom_keyboard_preset_left_hold || kb_layout == _custom_keyboard_preset_left_split;
 		bool kb_type_legacy = !kb_type_south_paw;
 		bool kb_type_split = kb_layout == _custom_keyboard_preset_right_split || kb_layout == _custom_keyboard_preset_left_split;
 
-#define HELPER_GET_INT_KEY(code) (language != _language_english ? language_get_international_key(language, (code)) : (code))
-
-		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_keyboard, VK_PAUSE, 0, 0);
-		preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_keyboard, VK_ESCAPE, 0, 0);
-		preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_keyboard, VK_BACK, 0, 0);
-
-
-		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, HELPER_GET_INT_KEY('A'), 0, 0);
-		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, VK_RETURN, 0, 0);
-		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
-		preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_mouse, _mouse_button_left, 0, 0);
-		preference->game_controls_to_hardware[_button_ui_scroll_up].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
-		preference->game_controls_to_hardware[_button_ui_scroll_down].add_button(_input_device_type_mouse, _mouse_delta_w_back, 0, 0);
+		input_abstraction_keyboard_and_mouse_add_default_controls(preference, language);
 
 		if (kb_layout != _custom_keyboard_preset_custom)
 		{
 			//default_mapping presets;
 
-			preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'C' : 'Y'), 0, 0);
-			preference->game_controls_to_hardware[_button_mouse_pitch_forward].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
-			preference->game_controls_to_hardware[_button_mouse_pitch_backward].add_button(_input_device_type_mouse, _mouse_delta_y_down, 0, 0);
-			preference->game_controls_to_hardware[_button_mouse_yaw_left].add_button(_input_device_type_mouse, _mouse_delta_x_left, 0, 0);
-			preference->game_controls_to_hardware[_button_mouse_yaw_right].add_button(_input_device_type_mouse, _mouse_delta_x_right, 0, 0);
-			preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('W') : 'I'), 0, 0);
-			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'S' : HELPER_GET_INT_KEY('K')), 0, 0);
-			preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('A') : 'J'), 0, 0);
-			preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'D' : HELPER_GET_INT_KEY('L')), 0, 0);
-			preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_keyboard, VK_UP, 0, 0);
-			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, VK_DOWN, 0, 0);
-			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, VK_DOWN, 0, 0);
-			preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_keyboard, VK_LEFT, 0, 0);
-			preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_keyboard, VK_RIGHT, 0, 0);
-			preference->game_controls_to_hardware[_button_crouch].add_button(_input_device_type_keyboard, (kb_type_legacy ? VK_LSHIFT : VK_RSHIFT), 0, 0);
-			preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
-			preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
-			preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
-			preference->game_controls_to_hardware[_button_text_chat_team].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'B' : 'V'), 0, 0);
-			preference->game_controls_to_hardware[_button_text_chat_toggle].add_button(_input_device_type_keyboard, VK_F1, 0, 0);
-			preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('N') : HELPER_GET_INT_KEY('B')), 0, 0);
-			preference->game_controls_to_hardware[_button_cancel].add_button(_input_device_type_keyboard, 'B', 0, 0);
-
+			input_abstraction_keyboard_and_mouse_set_default_mapping(preference, language, kb_type_legacy);
 
 			if (kb_type_split)
 			{
-				preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'R' : 'U'), 0, 0);
-				preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY(0x109)), 0, 0);
-				preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'Q' : HELPER_GET_INT_KEY(0x109)), 0, 0);
-				preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY(0x109)), 0, 0);
-				preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : HELPER_GET_INT_KEY(0x10A)), 0, 0);
-				preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'F' : 0x10B), 0, 0);
-				preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
-				preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
-				preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
-				preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
-				preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
-				preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E)), 0, 0);
-				preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY(VK_TAB) : HELPER_GET_INT_KEY('P')), 0, 0);
-				preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'G' : HELPER_GET_INT_KEY(0x10F)), 0, 0);
-				preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'X' : HELPER_GET_INT_KEY('M')), 0, 0);
+				input_abstraction_keyboard_set_split_default_mapping(preference, language, kb_type_legacy);
 			}
 			else
 			{
-				preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'R' : 'U'), 0, 0);
-				preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY('O')), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : HELPER_GET_INT_KEY('O')), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : 'O'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : 'O'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q') : 'O'), 0, 0);
-				preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'F' : 'H'), 0, 0);
-				preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), 0, 0);
-				preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), 0, 0);
-				preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
-				preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY(VK_TAB) : HELPER_GET_INT_KEY('P')), 0, 0);
-				preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'G' : HELPER_GET_INT_KEY(0x10C)), 0, 0);
-				preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'X' : VK_RMENU), 0, 0);
-
+				input_abstraction_keyboard_set_normal_default_mapping(preference, language, kb_type_legacy);
 			}
 
-
-			preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_left : _mouse_button_right), 0, 0);
-			preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
-
-			if (!kb_type_legacy || kb_type_split)
-			{
-				preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
-			}
-			else
-			{
-				preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
-			}
-
-			preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_mouse, _mouse_button_left, 0, 0);
-			preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_mouse, _mouse_button_right, 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_left : _mouse_button_right), 0, 0);
-			preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
-			preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
-			preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
-			preference->game_controls_to_hardware[_button_banshee_bomb].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom_in].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom_out].add_button(_input_device_type_mouse, _mouse_delta_w_back, 0, 0);
-			preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_mouse, (kb_type_legacy ? HELPER_GET_INT_KEY('Z') : 'N'), 0, 0);
-			preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_mouse, _mouse_button_5, 0, 0);
-			preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_mouse, _mouse_button_4, 0, 0);
-			preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_mouse, _mouse_button_6, 0, 0);
-			preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_mouse, _mouse_button_7, 0, 0);
+			input_abstraction_mouse_set_default_mapping(preference, language, kb_type_legacy, kb_type_split);
 
 			//default_mapping presets end;
-#undef HELPER_GET_INT_KEY
 		}
 
 		preference->field_1658 = 0; // last used device being gamepad = false ?
 
+		/* verify mapping */
+#ifdef ASSERTS_ENABLED
 		bool mapping_ok = true;
-		for (int32 current_action_idx = 0; current_action_idx < NUMBER_OF_EXTENDED_CONTROL_BUTTONS; current_action_idx++)
+		for (int32 current_action_idx = 0; current_action_idx < NUMBER_OF_EXTENDED_CONTROL_BUTTONS; ++current_action_idx)
 		{
 			e_button_action current_action = (e_button_action)current_action_idx;
 			c_input_control* current_control = &preference->game_controls_to_hardware[current_action];
@@ -529,42 +313,26 @@ void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferenc
 				mapping_ok = current_control->button_count > 0;
 			}
 		}
-		ASSERT(mapping_ok /*|| caller_handles_failures*/);
-
-
+		ASSERT(mapping_ok || caller_handles_failures);
+#endif
 	}
 
 	//--- global input preferences --- //
 
-	preference->gamepad_yaw_rate = 120.0f;
-	preference->mouse_yaw_rate = 90.0f;
-	preference->gamepad_pitch_rate = 60.0f;
-	preference->mouse_pitch_rate = 45.0f;
-	preference->mouse_acceleration = 0.69999999f;
-	preference->binary_yaw_rate = 1.0f;
-	preference->binary_pitch_rate = 1.0f;
-	preference->gamepad_axial_deadzone_left.y = 0x1EA9;
-	preference->gamepad_axial_deadzone_left.x = 0x1EA9;
-	preference->stick_threshold = 0.25f;
-	preference->gamepad_axial_deadzone_right.y = 0x21F1;
-	preference->gamepad_axial_deadzone_right.x = 0x21F1;
-	preference->gamepad_invert_look = false;
-	preference->mouse_invert_look = false;
-	preference->invert_aircraft_control = false;
-	preference->invert_dual_wield = true;
-	preference->mouse_delta_threshold = 0.050000001f;
-	preference->mouse_wheel_threshold = 0.050000001f;
-
+	input_abstraction_set_global_input_preferences(preference);
+	return;
 }
 
 void input_abstraction_set_controller_settings_from_preferences(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings)
 {
 	INVOKE(0x61B62, 0, input_abstraction_set_controller_settings_from_preferences, preferences, controller_settings);
+	return;
 }
 
 void input_abstraction_set_preferences_from_controller_settings(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings)
 {
 	INVOKE(0x61AD0, 0, input_abstraction_set_preferences_from_controller_settings, preferences, controller_settings);
+	return;
 }
 
 bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_action button_index)
@@ -582,10 +350,9 @@ e_button_action __cdecl input_abstraction_get_secondary_fire_button(datum unit)
 	return INVOKE(0x5E2ED, 0x0, input_abstraction_get_secondary_fire_button, unit);
 }
 
-
 uint32 s_input_abstraction_globals_sub_45E501(e_button_action button, void* a3)
 {
-	return INVOKE_TYPE(0x5E501, 0x0, uint32(__thiscall*)(s_input_abstraction_globals*, e_button_action, void*), input_abstraction_globals, button, a3);
+	return INVOKE_TYPE(0x5E501, 0x0, uint32(__thiscall*)(s_input_abstraction_globals*, e_button_action, void*), g_input_abstraction_globals, button, a3);
 }
 
 int32 __cdecl input_abstraction_get_last_used_device(e_controller_index controller)
@@ -593,167 +360,9 @@ int32 __cdecl input_abstraction_get_last_used_device(e_controller_index controll
 	return INVOKE(0x5E30E, 0x0, input_abstraction_get_last_used_device, controller);
 }
 
-e_abstract_gamepad_stick_types input_abstraction_get_stick_type_for_action(e_button_action action)
-{
-	uint32 button = s_input_abstraction_globals_sub_45E501(action, NULL);
-	if (button > _gamepad_analog_left_stick_right)
-		return button > _gamepad_analog_right_stick_right ? _abstract_gamepad_stick_unknown : _abstract_gamepad_stick_right;
-	return _abstract_gamepad_stick_left;
-}
-
-
-void input_abstraction_update_dead_zones(const point2d* thumb, real_euler_angles2d* out_stick_euler_angles)
-{
-	constexpr real32 normalize_scale = 1.f / INT16_MAX;
-
-	real_point2d thumbstick_points = { (real32)thumb->x, (real32)thumb->y };
-	real_angle angle = arctangent(thumbstick_points.y, thumbstick_points.x);
-
-	real32 magnitude = MAX(fabs(sin(angle)), fabs(cos(angle)));
-	real32 inverse_magnitude = 1.0f / magnitude;
-
-	out_stick_euler_angles->yaw = (real32)(thumbstick_points.x * inverse_magnitude) * normalize_scale;
-	out_stick_euler_angles->pitch = (real32)(thumbstick_points.y * inverse_magnitude) * normalize_scale;
-
-	out_stick_euler_angles->yaw = PIN(out_stick_euler_angles->yaw, -1.f, 1.f);
-	out_stick_euler_angles->pitch = PIN(out_stick_euler_angles->pitch, -1.f, 1.f);
-	return;
-}
-
-void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_angle angle, e_abstract_gamepad_stick_types stick_index)
-{
-	real_angle flt_7B9F78[] =
-	{
-		DEGREES_TO_RADIANS(45.0f),
-		DEGREES_TO_RADIANS(135.0f),
-		DEGREES_TO_RADIANS(-45.0f),
-		DEGREES_TO_RADIANS(-135.0f)
-	};
-
-	uint8 index = ((stick->pitch >= 0.0f) ? 0 : 2) + (stick->yaw < 0.0f);
-
-	real_vector2d vec = { stick->yaw,stick->pitch };
-	real32 magnitude = magnitude2d(&vec);
-
-	real32 delta = fabs(angle - flt_7B9F78[index]);
-	real_angle min_delta = stick_index == _abstract_gamepad_stick_right ? DEGREES_TO_RADIANS(10.0f) : DEGREES_TO_RADIANS(35.0f);
-
-	if (delta >= min_delta)
-	{
-		real32 sign = 0.0f;
-		if (fabs(stick->yaw) <= fabs(stick->pitch))
-		{
-			sign = (stick->pitch >= 0.0f) ? 1.0f : -1.0f;
-
-			stick->pitch = sign * magnitude;
-			stick->yaw = 0.0f;
-		}
-		else
-		{
-			sign = (stick->yaw >= 0.0f) ? 1.0f : -1.0f;
-
-			stick->yaw = sign * magnitude;
-			stick->pitch = 0.0f;
-		}
-	}
-	else
-	{
-		constexpr real32 normalize_scale = 1.0f / DEGREES_TO_RADIANS(35.0f);
-
-		real_angle angle_abs = fabs(angle);
-		real32 sign = 0.f;
-		if (angle_abs < DEGREES_TO_RADIANS(45.0f) || (angle_abs > DEGREES_TO_RADIANS(135.0f)))
-		{
-			sign = (stick->yaw >= 0.0f) ? 1.0f : -1.0f;
-			stick->yaw = sign * magnitude;
-
-			sign = (stick->pitch >= 0.0f) ? 1.0f : -1.0f;
-			stick->pitch = (1.0f - (delta * normalize_scale)) * sign * magnitude;
-		}
-		else
-		{
-			sign = (stick->pitch >= 0.0f) ? 1.0f : -1.0f;
-			stick->pitch = sign * magnitude;
-
-			sign = (stick->yaw >= 0.0f) ? 1.0f : -1.0f;
-			stick->yaw = (1.0f - (delta * normalize_scale)) * sign * magnitude;
-		}
-	}
-}
-
-void input_abstraction_post_update_all_throttles(real_euler_angles2d* left_stick, real_euler_angles2d* right_stick, point2d* lthumb, point2d* rthumb)
-{
-	bool adjust_left_stick = false;
-	bool adjust_right_stick = false;
-
-	e_abstract_gamepad_stick_types move_fwd_stick_type = input_abstraction_get_stick_type_for_action(_button_move_forward);
-	e_abstract_gamepad_stick_types extended_yaw_left_stick_type = input_abstraction_get_stick_type_for_action(_extended_button_gamepad_yaw_left);
-	e_abstract_gamepad_stick_types strafe_left_stick_type = input_abstraction_get_stick_type_for_action(_button_strafe_left);
-	e_abstract_gamepad_stick_types extended_pitch_fwd_stick_type = input_abstraction_get_stick_type_for_action(_extended_button_gamepad_pitch_forward);
-
-	if (move_fwd_stick_type == extended_yaw_left_stick_type && move_fwd_stick_type != _abstract_gamepad_stick_unknown)
-	{
-		if (move_fwd_stick_type == _abstract_gamepad_stick_right)
-			adjust_right_stick = true;
-		else
-			adjust_left_stick = true;
-
-	}
-	if (strafe_left_stick_type == extended_pitch_fwd_stick_type && strafe_left_stick_type != _abstract_gamepad_stick_unknown)
-	{
-		if (strafe_left_stick_type == _abstract_gamepad_stick_left)
-			adjust_left_stick = true;
-		else
-			adjust_right_stick = true;
-	}
-
-	real_angle left_stick_angle = arctangent((real32)lthumb->y, (real32)lthumb->x);
-	real_angle right_stick_angle = arctangent((real32)rthumb->y, (real32)rthumb->x);
-
-	if (adjust_left_stick)
-	{
-		input_abstraction_post_update_throttle(left_stick, left_stick_angle, _abstract_gamepad_stick_left);
-
-		left_stick->yaw = PIN(left_stick->yaw, -1.0f, 1.0f);
-		left_stick->pitch = PIN(left_stick->pitch, -1.0f, 1.0f);
-	}
-
-	if (adjust_right_stick)
-	{
-		input_abstraction_post_update_throttle(right_stick, right_stick_angle, _abstract_gamepad_stick_right);
-
-		right_stick->yaw = PIN(right_stick->yaw, -1.0f, 1.0f);
-		right_stick->pitch = PIN(right_stick->pitch, -1.0f, 1.0f);
-	}
-
-}
-void input_abstraction_update_throttles_legacy(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick)
-{
-	input_abstraction_update_dead_zones(&gamepad_state->thumb_left, left_stick);
-	input_abstraction_update_dead_zones(&gamepad_state->thumb_right, right_stick);
-
-	input_abstraction_post_update_all_throttles(left_stick, right_stick, &gamepad_state->thumb_left, &gamepad_state->thumb_right);
-}
-
-void input_abstraction_update_throttles_modern(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick)
-{
-	constexpr real32 normalize_scale = 1.0f / INT16_MAX;
-
-	left_stick->yaw = gamepad_state->thumb_left.x * normalize_scale;
-	left_stick->pitch = gamepad_state->thumb_left.y * normalize_scale;
-	right_stick->yaw = gamepad_state->thumb_right.x * normalize_scale;
-	right_stick->pitch = gamepad_state->thumb_right.y * normalize_scale;
-
-	left_stick->yaw = PIN(left_stick->yaw, -1.0f, 1.0f);
-	left_stick->pitch = PIN(left_stick->pitch, -1.0f, 1.0f);
-
-	right_stick->yaw = PIN(right_stick->yaw, -1.0f, 1.0f);
-	right_stick->pitch = PIN(right_stick->pitch, -1.0f, 1.0f);
-}
-
 void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index controller)
 {
-	s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
+	s_gamepad_input_preferences* preference = &g_input_abstraction_globals->preferences[controller];
 	s_saved_game_cartographer_player_profile* profile_settings = cartographer_player_profile_get_by_controller_index(controller);
 
 	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_axial
@@ -764,8 +373,7 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 	}
 	else
 	{
-		preference->gamepad_axial_deadzone_right.x = 0;
-		preference->gamepad_axial_deadzone_right.y = 0;
+		preference->gamepad_axial_deadzone_right = { 0, 0 };
 	}
 
 	if (profile_settings->controller_deadzone_type == _controller_deadzone_type_radial
@@ -777,7 +385,9 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 	{
 		g_controller_radial_deadzones[controller] = 0;
 	}
+	return;
 }
+
 void input_abstraction_set_controller_look_sensitivity(e_controller_index controller, real32 value)
 {
 	s_saved_game_cartographer_player_profile* cartographer_player_profile = cartographer_player_profile_get_by_user_index(controller);
@@ -786,15 +396,14 @@ void input_abstraction_set_controller_look_sensitivity(e_controller_index contro
 
 	value = MAX(value - 1.0f, 0.0f);
 
-	s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
+	s_gamepad_input_preferences* preference = &g_input_abstraction_globals->preferences[controller];
 
 	preference->gamepad_yaw_rate = 80.0f + 20.0f * value; //x-axis
 	preference->gamepad_pitch_rate = 40.0f + 10.0f * value; //y-axis
 
-	// ### FIXME: uniform yaw, ptitch sensitivity
+	// ### FIXME: uniform yaw, pitch sensitivity
+	return;
 }
-
-
 
 void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller, real32 value)
 {
@@ -807,7 +416,7 @@ void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller,
 
 	value = MAX(value - 1.0f, 0.0f);
 
-	s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
+	s_gamepad_input_preferences* preference = &g_input_abstraction_globals->preferences[controller];
 
 	preference->mouse_yaw_rate = (80.0f + 20.0f * value) - 30.0f;
 
@@ -815,113 +424,13 @@ void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller,
 		preference->mouse_pitch_rate = preference->mouse_yaw_rate;
 	else
 		preference->mouse_pitch_rate = (40.0f + 10.0f * value) - 15.0f;
+	
+	return;
 }
 
-void input_abstraction_apply_raw_mouse_update(e_controller_index controller, s_game_input_state* input_state)
-{
-	s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
-	s_saved_game_cartographer_player_profile* cartographer_player_profile = cartographer_player_profile_get_by_user_index(0);
-
-	if (cartographer_player_profile->raw_mouse_input)
-	{
-		DIMOUSESTATE2* mouse_state = input_get_mouse_state();
-
-		// ### FIXME this is fucking shit
-		real32 raw_mouse_sensitivity = (cartographer_player_profile->raw_mouse_sensitivity / 100.f);
-
-		input_abstraction_set_mouse_look_sensitivity(controller, 1.0f);
-		input_state->mouse.yaw = (real32)-mouse_state->lX;
-		input_state->mouse.pitch = (real32)-mouse_state->lY;
-
-		// multiply by 0.016 milliseconds, while this is likely wrong
-		// emulate current behaviour at all tickrates, instead of scaling with tick length lol
-		// which is a higher value at 30 tick, resulting in higher mouse sensitivity
-		input_state->mouse.yaw *= raw_mouse_sensitivity * (1.f / 60.f);
-		input_state->mouse.pitch *= raw_mouse_sensitivity * (1.f / 60.f);
-
-		if (preference->mouse_invert_look)
-		{
-			input_state->mouse.pitch = -0.0f - input_state->mouse.pitch;
-		}
-	}
-	else
-	{
-		input_abstraction_set_mouse_look_sensitivity(controller, cartographer_player_profile_get_by_user_index(0)->mouse_sensitivity);
-	}
-}
-
-void input_abstraction_store_windows_inputs()
-{
-	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
-	if (mouse_state)
-	{
-		csmemcpy(&old_mouse_state, mouse_state, sizeof(*mouse_state));
-
-		uint16* mouse_buttons = input_get_mouse_button_state();
-
-		if (mouse_buttons)
-		{
-			csmemcpy(old_mouse_buttons, mouse_buttons, sizeof(old_mouse_buttons));
-		}
-	}
-	csmemcpy(&old_keyboard_state, &input_globals->keyboard, sizeof(input_globals->keyboard));
-}
-
-void input_abstraction_restore_windows_inputs()
-{
-	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
-	if (mouse_state)
-	{
-		csmemcpy(mouse_state, &old_mouse_state, sizeof(*mouse_state));
-
-		uint16* mouse_buttons = input_get_mouse_button_state();
-		if (mouse_buttons)
-		{
-			csmemcpy(mouse_buttons, old_mouse_buttons, sizeof(input_globals->mouse_buttons));
-		}
-	}
-	csmemcpy(&input_globals->keyboard, &old_keyboard_state, sizeof(input_globals->keyboard));
-
-}
-
-void input_abstraction_clear_windows_inputs()
-{
-	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
-	if (mouse_state)
-	{
-		csmemset(mouse_state, 0, sizeof(*mouse_state));
-
-		uint16* mouse_buttons = input_get_mouse_button_state();
-		if (mouse_buttons)
-		{
-			csmemset(mouse_buttons, 0, sizeof(old_mouse_buttons));
-		}
-	}
-	csmemset(&input_globals->keyboard, 0, sizeof(input_globals->keyboard));
-}
-
-void input_abstraction_store_abstracted_inputs(e_controller_index controller)
-{
-	csmemcpy(
-		&g_abstract_input_states[controller],
-		&input_abstraction_globals->abstracted_inputs,
-		sizeof(s_game_abstracted_input_state));
-}
-
-void input_abstraction_restore_abstracted_inputs(e_controller_index controller)
-{
-	csmemcpy(
-		&input_abstraction_globals->abstracted_inputs,
-		&g_abstract_input_states[controller],
-		sizeof(s_game_abstracted_input_state));
-}
-
-bool g_controller_advanced_settings_toggle[k_number_of_users]{};
-
-void __cdecl input_abstraction_update()
+void __cdecl input_abstraction_update(void)
 {
 	//INVOKE(0x628A8, 0x0, input_abstraction_update);
-
 
 	input_abstraction_store_windows_inputs();
 
@@ -933,8 +442,8 @@ void __cdecl input_abstraction_update()
 		real_euler_angles2d right_stick = { 0.f, 0.f };
 
 		s_gamepad_input_button_state* gamepad_state = input_get_gamepad_state(controller);
-		s_game_input_state* game_input_state = &input_abstraction_globals->input_states[controller];
-		s_gamepad_input_preferences* preference = &input_abstraction_globals->preferences[controller];
+		s_game_input_state* game_input_state = &g_input_abstraction_globals->input_states[controller];
+		s_gamepad_input_preferences* preference = &g_input_abstraction_globals->preferences[controller];
 		s_saved_game_cartographer_player_profile* profile_settings = cartographer_player_profile_get_by_controller_index(controller);
 
 		//restore last state from global array before processing
@@ -943,11 +452,11 @@ void __cdecl input_abstraction_update()
 		if (!gamepad_state)
 		{
 			// controls players when gamepad is disconnected or no gamepad
-			input_abstraction_globals->input_has_gamepad[controller] = false;
+			g_input_abstraction_globals->input_has_gamepad[controller] = false;
 
 			if (controller != k_windows_device_controller_index)
 			{
-				// this needs to be done when a controller disconnects for active player, so it doesnt get controlled by m/k
+				// this needs to be done when a controller disconnects for active player, so it doesn't get controlled by m/k
 				input_abstraction_clear_windows_inputs();
 				input_abstraction_update_input_state(
 					controller,
@@ -983,8 +492,8 @@ void __cdecl input_abstraction_update()
 				input_abstraction_update_throttles_modern(gamepad_state, &left_stick, &right_stick);
 			}
 
-			if (!input_abstraction_globals->input_has_gamepad[controller])
-				input_abstraction_globals->input_has_gamepad[controller] = true;
+			if (!g_input_abstraction_globals->input_has_gamepad[controller])
+				g_input_abstraction_globals->input_has_gamepad[controller] = true;
 
 
 			if (controller == k_windows_device_controller_index)
@@ -1034,26 +543,667 @@ void __cdecl input_abstraction_update()
 	}
 	//restore mouse and keyboard states if it was cleared at any point
 	input_abstraction_restore_windows_inputs();
+	return;
 }
 
 void __cdecl input_abstraction_update_input_state(e_controller_index controller_index, s_gamepad_input_preferences* preference, s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick_analog, real_euler_angles2d* right_stick_analog, s_game_input_state* input_state)
 {
-	updating_gamepad_index = controller_index;
+	g_updating_gamepad_index = controller_index;
 
 	INVOKE(0x61EA2, 0x0, input_abstraction_update_input_state, controller_index, preference, gamepad_state, left_stick_analog, right_stick_analog, input_state);
-	////https://github.com/pnill/cartographer/blob/development-patches/xlive/H2MOD/Modules/Splitscreen/InputFixes.cpp#L311
+	
+	// Rewritten function: https://github.com/pnill/cartographer/blob/development-patches/xlive/H2MOD/Modules/Splitscreen/InputFixes.cpp#L311
+	return;
 }
 
-bool __cdecl input_abstraction_controller_plugged_hook(uint16 gamepad_index)
+/* private code */
+
+static void input_abstraction_store_windows_inputs(void)
+{
+	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
+	if (mouse_state)
+	{
+		csmemcpy(&g_old_mouse_state, mouse_state, sizeof(*mouse_state));
+
+		uint16* mouse_buttons = input_get_mouse_button_state();
+
+		if (mouse_buttons)
+		{
+			csmemcpy(g_old_mouse_buttons, mouse_buttons, sizeof(g_old_mouse_buttons));
+		}
+	}
+	csmemcpy(&g_old_keyboard_state, &input_globals->keyboard, sizeof(input_globals->keyboard));
+	return;
+}
+
+static void input_abstraction_restore_windows_inputs(void)
+{
+	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
+	if (mouse_state)
+	{
+		csmemcpy(mouse_state, &g_old_mouse_state, sizeof(*mouse_state));
+
+		uint16* mouse_buttons = input_get_mouse_button_state();
+		if (mouse_buttons)
+		{
+			csmemcpy(mouse_buttons, g_old_mouse_buttons, sizeof(input_globals->mouse_buttons));
+		}
+	}
+	csmemcpy(&input_globals->keyboard, &g_old_keyboard_state, sizeof(input_globals->keyboard));
+	return;
+}
+
+static void input_abstraction_clear_windows_inputs(void)
+{
+	DIMOUSESTATE2* mouse_state = input_get_mouse_state();
+	if (mouse_state)
+	{
+		csmemset(mouse_state, 0, sizeof(*mouse_state));
+
+		uint16* mouse_buttons = input_get_mouse_button_state();
+		if (mouse_buttons)
+		{
+			csmemset(mouse_buttons, 0, sizeof(g_old_mouse_buttons));
+		}
+	}
+	csmemset(&input_globals->keyboard, 0, sizeof(input_globals->keyboard));
+	return;
+}
+
+static void input_abstraction_store_abstracted_inputs(e_controller_index controller)
+{
+	csmemcpy(
+		&g_abstract_input_states[controller],
+		&g_input_abstraction_globals->abstracted_inputs,
+		sizeof(s_game_abstracted_input_state));
+	return;
+}
+
+static void input_abstraction_restore_abstracted_inputs(e_controller_index controller)
+{
+	csmemcpy(
+		&g_input_abstraction_globals->abstracted_inputs,
+		&g_abstract_input_states[controller],
+		sizeof(s_game_abstracted_input_state));
+	return;
+}
+
+static e_abstract_gamepad_stick_types input_abstraction_get_stick_type_for_action(e_button_action action)
+{
+	const uint32 button = s_input_abstraction_globals_sub_45E501(action, NULL);
+	if (button > _gamepad_analog_left_stick_right)
+		return button > _gamepad_analog_right_stick_right ? _abstract_gamepad_stick_unknown : _abstract_gamepad_stick_right;
+	return _abstract_gamepad_stick_left;
+}
+
+static void input_abstraction_update_dead_zones(const point2d* thumb, real_euler_angles2d* out_stick_euler_angles)
+{
+	constexpr real32 normalize_scale = 1.f / INT16_MAX;
+
+	real_point2d thumbstick_points = { (real32)thumb->x, (real32)thumb->y };
+	real_angle angle = arctangent(thumbstick_points.y, thumbstick_points.x);
+
+	real32 magnitude = MAX(fabs(sin(angle)), fabs(cos(angle)));
+	real32 inverse_magnitude = 1.0f / magnitude;
+
+	out_stick_euler_angles->yaw = (real32)(thumbstick_points.x * inverse_magnitude) * normalize_scale;
+	out_stick_euler_angles->pitch = (real32)(thumbstick_points.y * inverse_magnitude) * normalize_scale;
+
+	out_stick_euler_angles->yaw = PIN(out_stick_euler_angles->yaw, -1.f, 1.f);
+	out_stick_euler_angles->pitch = PIN(out_stick_euler_angles->pitch, -1.f, 1.f);
+	return;
+}
+
+static void input_abstraction_apply_raw_mouse_update(e_controller_index controller, s_game_input_state* input_state)
+{
+	s_gamepad_input_preferences* preference = &g_input_abstraction_globals->preferences[controller];
+	s_saved_game_cartographer_player_profile* cartographer_player_profile = cartographer_player_profile_get_by_user_index(0);
+
+	if (cartographer_player_profile->raw_mouse_input)
+	{
+		DIMOUSESTATE2* mouse_state = input_get_mouse_state();
+
+		// ### FIXME this is fucking shit
+		real32 raw_mouse_sensitivity = (cartographer_player_profile->raw_mouse_sensitivity / 100.f);
+
+		input_abstraction_set_mouse_look_sensitivity(controller, 1.0f);
+		input_state->mouse.yaw = (real32)-mouse_state->lX;
+		input_state->mouse.pitch = (real32)-mouse_state->lY;
+
+		// multiply by 0.016 milliseconds, while this is likely wrong
+		// emulate current behaviour at all tickrates, instead of scaling with tick length lol
+		// which is a higher value at 30 tick, resulting in higher mouse sensitivity
+		input_state->mouse.yaw *= raw_mouse_sensitivity * (1.f / 60.f);
+		input_state->mouse.pitch *= raw_mouse_sensitivity * (1.f / 60.f);
+
+		if (preference->mouse_invert_look)
+		{
+			input_state->mouse.pitch = -0.0f - input_state->mouse.pitch;
+		}
+	}
+	else
+	{
+		input_abstraction_set_mouse_look_sensitivity(controller, cartographer_player_profile_get_by_user_index(0)->mouse_sensitivity);
+	}
+	return;
+}
+
+static void input_abstraction_post_update_throttle(real_euler_angles2d* stick, real_angle angle, e_abstract_gamepad_stick_types stick_index)
+{
+	uint8 index = ((stick->pitch >= 0.0f) ? 0 : 2) + (stick->yaw < 0.0f);
+
+	real_vector2d vec = { stick->yaw,stick->pitch };
+	real32 magnitude = magnitude2d(&vec);
+
+	real32 delta = fabs(angle - k_gamepad_stick_angles[index]);
+	real_angle min_delta = stick_index == _abstract_gamepad_stick_right ? DEGREES_TO_RADIANS(10.0f) : DEGREES_TO_RADIANS(35.0f);
+
+	if (delta >= min_delta)
+	{
+		real32 sign = 0.0f;
+		if (fabs(stick->yaw) <= fabs(stick->pitch))
+		{
+			sign = (stick->pitch >= 0.0f) ? 1.0f : -1.0f;
+
+			stick->pitch = sign * magnitude;
+			stick->yaw = 0.0f;
+		}
+		else
+		{
+			sign = (stick->yaw >= 0.0f) ? 1.0f : -1.0f;
+
+			stick->yaw = sign * magnitude;
+			stick->pitch = 0.0f;
+		}
+	}
+	else
+	{
+		constexpr real32 normalize_scale = 1.0f / DEGREES_TO_RADIANS(35.0f);
+
+		real_angle angle_abs = fabs(angle);
+		real32 sign = 0.f;
+		if (angle_abs < DEGREES_TO_RADIANS(45.0f) || (angle_abs > DEGREES_TO_RADIANS(135.0f)))
+		{
+			sign = (stick->yaw >= 0.0f) ? 1.0f : -1.0f;
+			stick->yaw = sign * magnitude;
+
+			sign = (stick->pitch >= 0.0f) ? 1.0f : -1.0f;
+			stick->pitch = (1.0f - (delta * normalize_scale)) * sign * magnitude;
+		}
+		else
+		{
+			sign = (stick->pitch >= 0.0f) ? 1.0f : -1.0f;
+			stick->pitch = sign * magnitude;
+
+			sign = (stick->yaw >= 0.0f) ? 1.0f : -1.0f;
+			stick->yaw = (1.0f - (delta * normalize_scale)) * sign * magnitude;
+		}
+	}
+	return;
+}
+
+static void input_abstraction_post_update_all_throttles(real_euler_angles2d* left_stick, real_euler_angles2d* right_stick, point2d* lthumb, point2d* rthumb)
+{
+	bool adjust_left_stick = false;
+	bool adjust_right_stick = false;
+
+	e_abstract_gamepad_stick_types move_fwd_stick_type = input_abstraction_get_stick_type_for_action(_button_move_forward);
+	e_abstract_gamepad_stick_types extended_yaw_left_stick_type = input_abstraction_get_stick_type_for_action(_extended_button_gamepad_yaw_left);
+	e_abstract_gamepad_stick_types strafe_left_stick_type = input_abstraction_get_stick_type_for_action(_button_strafe_left);
+	e_abstract_gamepad_stick_types extended_pitch_fwd_stick_type = input_abstraction_get_stick_type_for_action(_extended_button_gamepad_pitch_forward);
+
+	if (move_fwd_stick_type == extended_yaw_left_stick_type && move_fwd_stick_type != _abstract_gamepad_stick_unknown)
+	{
+		if (move_fwd_stick_type == _abstract_gamepad_stick_right)
+			adjust_right_stick = true;
+		else
+			adjust_left_stick = true;
+
+	}
+	if (strafe_left_stick_type == extended_pitch_fwd_stick_type && strafe_left_stick_type != _abstract_gamepad_stick_unknown)
+	{
+		if (strafe_left_stick_type == _abstract_gamepad_stick_left)
+			adjust_left_stick = true;
+		else
+			adjust_right_stick = true;
+	}
+
+	real_angle left_stick_angle = arctangent((real32)lthumb->y, (real32)lthumb->x);
+	real_angle right_stick_angle = arctangent((real32)rthumb->y, (real32)rthumb->x);
+
+	if (adjust_left_stick)
+	{
+		input_abstraction_post_update_throttle(left_stick, left_stick_angle, _abstract_gamepad_stick_left);
+
+		left_stick->yaw = PIN(left_stick->yaw, -1.0f, 1.0f);
+		left_stick->pitch = PIN(left_stick->pitch, -1.0f, 1.0f);
+	}
+
+	if (adjust_right_stick)
+	{
+		input_abstraction_post_update_throttle(right_stick, right_stick_angle, _abstract_gamepad_stick_right);
+
+		right_stick->yaw = PIN(right_stick->yaw, -1.0f, 1.0f);
+		right_stick->pitch = PIN(right_stick->pitch, -1.0f, 1.0f);
+	}
+	return;
+}
+
+static void input_abstraction_update_throttles_legacy(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick)
+{
+	input_abstraction_update_dead_zones(&gamepad_state->thumb_left, left_stick);
+	input_abstraction_update_dead_zones(&gamepad_state->thumb_right, right_stick);
+
+	input_abstraction_post_update_all_throttles(left_stick, right_stick, &gamepad_state->thumb_left, &gamepad_state->thumb_right);
+	return;
+}
+
+static void input_abstraction_update_throttles_modern(s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick, real_euler_angles2d* right_stick)
+{
+	constexpr real32 normalize_scale = 1.0f / INT16_MAX;
+
+	left_stick->yaw = gamepad_state->thumb_left.x * normalize_scale;
+	left_stick->pitch = gamepad_state->thumb_left.y * normalize_scale;
+	right_stick->yaw = gamepad_state->thumb_right.x * normalize_scale;
+	right_stick->pitch = gamepad_state->thumb_right.y * normalize_scale;
+
+	left_stick->yaw = PIN(left_stick->yaw, -1.0f, 1.0f);
+	left_stick->pitch = PIN(left_stick->pitch, -1.0f, 1.0f);
+
+	right_stick->yaw = PIN(right_stick->yaw, -1.0f, 1.0f);
+	right_stick->pitch = PIN(right_stick->pitch, -1.0f, 1.0f);
+	return;
+}
+
+static void input_abstraction_set_global_input_preferences(s_gamepad_input_preferences* preference)
+{
+	preference->gamepad_yaw_rate = 120.f;
+	preference->mouse_yaw_rate = 90.f;
+	preference->gamepad_pitch_rate = 60.f;
+	preference->mouse_pitch_rate = 45.f;
+	preference->mouse_acceleration = 0.7f;
+	preference->binary_yaw_rate = 1.f;
+	preference->binary_pitch_rate = 1.f;
+	preference->gamepad_axial_deadzone_left.x = 0x1EA9;
+	preference->gamepad_axial_deadzone_left.y = 0x1EA9;
+	preference->stick_threshold = 0.25f;
+	preference->gamepad_axial_deadzone_right.x = 0x21F1;
+	preference->gamepad_axial_deadzone_right.y = 0x21F1;
+	preference->gamepad_invert_look = false;
+	preference->mouse_invert_look = false;
+	preference->invert_aircraft_control = false;
+	preference->invert_dual_wield = true;
+	preference->mouse_delta_threshold = 0.05f;
+	preference->mouse_wheel_threshold = 0.05f;
+	return;
+}
+
+static void input_abstraction_add_default_gamepad_baseline_controls(s_gamepad_input_preferences* preference)
+{
+	preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_gamepad, _gamepad_binary_button_start, 0, false);
+	preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_gamepad, _gamepad_binary_button_back, 0, false);
+	preference->game_controls_to_hardware[_button_crouch].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_thumb, 0, false);
+	preference->game_controls_to_hardware[_button_lean_left].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_left, 0, false);
+	preference->game_controls_to_hardware[_button_lean_right].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_right, 0, false);
+	preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_cancel].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_banshee_bomb].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	return;
+}
+
+static void input_abstraction_gamepad_add_default_preset_controls(s_gamepad_input_preferences* preference)
+{
+	preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+
+
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	return;
+}
+
+static void input_abstraction_gamepad_add_southpaw_preset_controls(s_gamepad_input_preferences* preference)
+{
+	preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+
+
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	return;
+}
+
+static void input_abstraction_gamepad_add_boxer_preset_controls(s_gamepad_input_preferences* preference)
+{
+	preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+
+
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	return;
+}
+
+static void input_abstraction_gamepad_add_greenthumb_preset_controls(s_gamepad_input_preferences* preference)
+{
+	preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, 0, false);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, 0, false);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_x, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+
+
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, false);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	return;
+}
+
+static void input_abstraction_gamepad_add_jumpy_preset_controls(s_gamepad_input_preferences* preference)
+{
+	preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_gamepad, _gamepad_binary_button_left_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_right, 0, false);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, 0, false);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_b, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_y, 0, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_gamepad, _gamepad_binary_button_a, k_key_hold_threshold_msec, false);
+	preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_up, 0, false);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_gamepad, _gamepad_binary_button_dpad_up, 0, false);
+
+
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_shoulder, 0, false);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_right_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_gamepad, _gamepad_binary_button_right_thumb, 0, false);
+	preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_gamepad, _gamepad_analog_button_left_trigger, 0, false);
+	return;
+}
+
+static void input_abstraction_gamepad_set_default_stick_controls(s_gamepad_input_preferences* preference, e_joystick_preset_types thumbstick_layout)
+{
+	e_gamepad_buttons fwd_key = _gamepad_analog_right_stick_up;
+	e_gamepad_buttons bkwd_key = _gamepad_analog_right_stick_down;
+	e_gamepad_buttons pitch_fwd_key = _gamepad_analog_left_stick_up;
+	e_gamepad_buttons pitch_bkwd_key = _gamepad_analog_left_stick_down;
+
+	e_gamepad_buttons strafe_left_key = _gamepad_analog_right_stick_left;
+	e_gamepad_buttons strafe_right_key = _gamepad_analog_right_stick_right;
+	e_gamepad_buttons yaw_left_key = _gamepad_analog_left_stick_left;
+	e_gamepad_buttons yaw_right_key = _gamepad_analog_left_stick_right;
+
+	if (thumbstick_layout == _joystick_preset_default || thumbstick_layout == _joystick_preset_legacy)
+	{
+		fwd_key = _gamepad_analog_left_stick_up;
+		bkwd_key = _gamepad_analog_left_stick_down;
+		pitch_fwd_key = _gamepad_analog_right_stick_up;
+		pitch_bkwd_key = _gamepad_analog_right_stick_down;
+	}
+
+	if (thumbstick_layout == _joystick_preset_default || thumbstick_layout == _joystick_preset_legacy_south_paw)
+	{
+		strafe_left_key = _gamepad_analog_left_stick_left;
+		strafe_right_key = _gamepad_analog_left_stick_right;
+		yaw_left_key = _gamepad_analog_right_stick_left;
+		yaw_right_key = _gamepad_analog_right_stick_right;
+	}
+
+	preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_gamepad, fwd_key, 0, false);
+	preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_gamepad, bkwd_key, 0, false);
+	preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_gamepad, strafe_left_key, 0, false);
+	preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_gamepad, strafe_right_key, 0, false);
+	preference->game_controls_to_hardware[_extended_button_gamepad_pitch_forward].add_button(_input_device_type_gamepad, pitch_fwd_key, 0, false);
+	preference->game_controls_to_hardware[_extended_button_gamepad_pitch_backward].add_button(_input_device_type_gamepad, pitch_bkwd_key, 0, false);
+	preference->game_controls_to_hardware[_extended_button_gamepad_yaw_left].add_button(_input_device_type_gamepad, yaw_left_key, 0, false);
+	preference->game_controls_to_hardware[_extended_button_gamepad_yaw_right].add_button(_input_device_type_gamepad, yaw_right_key, 0, false);
+	return;
+}
+
+static void input_abstraction_keyboard_and_mouse_add_default_controls(s_gamepad_input_preferences* preference, e_language language)
+{
+	preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_keyboard, VK_PAUSE, 0, 0);
+	preference->game_controls_to_hardware[_button_start].add_button(_input_device_type_keyboard, VK_ESCAPE, 0, 0);
+	preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_keyboard, VK_BACK, 0, 0);
+
+
+	preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, HELPER_GET_INT_KEY('A', language), 0, 0);
+	preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, VK_RETURN, 0, 0);
+	preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+	preference->game_controls_to_hardware[_button_accept].add_button(_input_device_type_mouse, _mouse_button_left, 0, 0);
+	preference->game_controls_to_hardware[_button_ui_scroll_up].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
+	preference->game_controls_to_hardware[_button_ui_scroll_down].add_button(_input_device_type_mouse, _mouse_delta_w_back, 0, 0);
+	return;
+}
+
+static void input_abstraction_keyboard_and_mouse_set_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy)
+{
+	preference->game_controls_to_hardware[_button_back].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'C' : 'Y'), 0, 0);
+	preference->game_controls_to_hardware[_button_mouse_pitch_forward].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
+	preference->game_controls_to_hardware[_button_mouse_pitch_backward].add_button(_input_device_type_mouse, _mouse_delta_y_down, 0, 0);
+	preference->game_controls_to_hardware[_button_mouse_yaw_left].add_button(_input_device_type_mouse, _mouse_delta_x_left, 0, 0);
+	preference->game_controls_to_hardware[_button_mouse_yaw_right].add_button(_input_device_type_mouse, _mouse_delta_x_right, 0, 0);
+	preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('W', language) : 'I'), 0, 0);
+	preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'S' : HELPER_GET_INT_KEY('K', language)), 0, 0);
+	preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('A', language) : 'J'), 0, 0);
+	preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'D' : HELPER_GET_INT_KEY('L', language)), 0, 0);
+	preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_keyboard, VK_UP, 0, 0);
+	preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, VK_DOWN, 0, 0);
+	preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_keyboard, VK_DOWN, 0, 0);
+	preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_keyboard, VK_LEFT, 0, 0);
+	preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_keyboard, VK_RIGHT, 0, 0);
+	preference->game_controls_to_hardware[_button_crouch].add_button(_input_device_type_keyboard, (kb_type_legacy ? VK_LSHIFT : VK_RSHIFT), 0, 0);
+	preference->game_controls_to_hardware[_button_jump].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+	preference->game_controls_to_hardware[_button_brake].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+	preference->game_controls_to_hardware[_button_trick].add_button(_input_device_type_keyboard, VK_SPACE, 0, 0);
+	preference->game_controls_to_hardware[_button_text_chat_team].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'B' : 'V'), 0, 0);
+	preference->game_controls_to_hardware[_button_text_chat_toggle].add_button(_input_device_type_keyboard, VK_F1, 0, 0);
+	preference->game_controls_to_hardware[_button_team_voice].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('N', language) : HELPER_GET_INT_KEY('B', language)), 0, 0);
+	preference->game_controls_to_hardware[_button_cancel].add_button(_input_device_type_keyboard, 'B', 0, 0);
+	return;
+}
+
+static void input_abstraction_keyboard_set_normal_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy)
+{
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'R' : 'U'), 0, 0);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : HELPER_GET_INT_KEY('O', language)), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : HELPER_GET_INT_KEY('O', language)), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : 'O'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : 'O'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : 'O'), 0, 0);
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'F' : 'H'), 0, 0);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), 0, 0);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), 0, 0);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'U'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY(VK_TAB, language) : HELPER_GET_INT_KEY('P', language)), 0, 0);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'G' : HELPER_GET_INT_KEY(0x10C, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'X' : VK_RMENU), 0, 0);
+	return;
+}
+
+static void input_abstraction_keyboard_set_split_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy)
+{
+	preference->game_controls_to_hardware[_button_reload].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'R' : 'U'), 0, 0);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_pick_up_secondary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_put_away_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_put_away_or_drop_secondary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : 'O'), k_key_hold_threshold_msec, 0);
+	preference->game_controls_to_hardware[_button_pick_up_primary_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : HELPER_GET_INT_KEY(0x109, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_pick_up_primary_multiplayer_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'Q' : HELPER_GET_INT_KEY(0x109, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_trade_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY('Q', language) : HELPER_GET_INT_KEY(0x109, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_switch_weapon].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'E' : HELPER_GET_INT_KEY(0x10A, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_melee_attack].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'F' : 0x10B), 0, 0);
+	preference->game_controls_to_hardware[_button_enter_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_board_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_evict_from_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_exit_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_flip_vehicle].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_touch_device].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'T' : HELPER_GET_INT_KEY(0x10E, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? HELPER_GET_INT_KEY(VK_TAB, language) : HELPER_GET_INT_KEY('P', language)), 0, 0);
+	preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'G' : HELPER_GET_INT_KEY(0x10F, language)), 0, 0);
+	preference->game_controls_to_hardware[_button_flashlight].add_button(_input_device_type_keyboard, (kb_type_legacy ? 'X' : HELPER_GET_INT_KEY('M', language)), 0, 0);
+	return;
+}
+
+static void input_abstraction_mouse_set_default_mapping(s_gamepad_input_preferences* preference, e_language language, bool kb_type_legacy, bool kb_type_split)
+{
+	preference->game_controls_to_hardware[_button_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_left : _mouse_button_right), 0, 0);
+	preference->game_controls_to_hardware[_button_throw_grenade].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+
+	if (!kb_type_legacy || kb_type_split)
+	{
+		preference->game_controls_to_hardware[_button_switch_grenade].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
+	}
+	else
+	{
+		preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
+	}
+
+	preference->game_controls_to_hardware[_button_dual_wield_primary_fire].add_button(_input_device_type_mouse, _mouse_button_left, 0, 0);
+	preference->game_controls_to_hardware[_button_dual_wield_secondary_fire].add_button(_input_device_type_mouse, _mouse_button_right, 0, 0);
+	preference->game_controls_to_hardware[_button_vehicle_primary_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_left : _mouse_button_right), 0, 0);
+	preference->game_controls_to_hardware[_button_vehicle_secondary_fire].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+	preference->game_controls_to_hardware[_button_speed_boost].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+	preference->game_controls_to_hardware[_button_e_brake].add_button(_input_device_type_mouse, (kb_type_legacy ? _mouse_button_right : _mouse_button_left), 0, 0);
+	preference->game_controls_to_hardware[_button_banshee_bomb].add_button(_input_device_type_mouse, _mouse_button_middle, 0, 0);
+	preference->game_controls_to_hardware[_button_scope_zoom_in].add_button(_input_device_type_mouse, _mouse_delta_w_forward, 0, 0);
+	preference->game_controls_to_hardware[_button_scope_zoom_out].add_button(_input_device_type_mouse, _mouse_delta_w_back, 0, 0);
+	preference->game_controls_to_hardware[_button_scope_zoom].add_button(_input_device_type_mouse, (kb_type_legacy ? HELPER_GET_INT_KEY('Z', language) : 'N'), 0, 0);
+	preference->game_controls_to_hardware[_button_move_forward].add_button(_input_device_type_mouse, _mouse_button_5, 0, 0);
+	preference->game_controls_to_hardware[_button_move_backward].add_button(_input_device_type_mouse, _mouse_button_4, 0, 0);
+	preference->game_controls_to_hardware[_button_strafe_left].add_button(_input_device_type_mouse, _mouse_button_6, 0, 0);
+	preference->game_controls_to_hardware[_button_strafe_right].add_button(_input_device_type_mouse, _mouse_button_7, 0, 0);
+	return;
+}
+
+static bool __cdecl input_abstraction_controller_plugged_hook(uint16 gamepad_index)
 {
 	//fixes a hardcode check to _controller_index_0 that prevents other controllers from working without _controller_index_0 being connected
-	return input_has_gamepad_plugged(updating_gamepad_index);
-}
-
-void input_abstraction_patches_apply()
-{
-	input_abstraction_globals = Memory::GetAddress<s_input_abstraction_globals*>(0x4A89B0);
-
-	PatchCall(Memory::GetAddress(0x39B82), input_abstraction_update);
-	PatchCall(Memory::GetAddress(0x61FBD), input_abstraction_controller_plugged_hook); //inside input_abstraction_update_input_state
+	return input_has_gamepad_plugged(g_updating_gamepad_index);
 }

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -11,7 +11,8 @@
 #define THUMBSTICK_POINT_TO_PERCENTAGE(_point) \
 	(((real32)_point / (real32)INT16_MAX) * 100.f)
 
-#define k_maximum_number_of_game_function_binds 8
+#define k_key_hold_threshold_msec 0xE9
+
 #define k_last_used_device_was_gamepad 1
 
 #define k_default_right_thumbstick_deadzone_axial_percentage_x THUMBSTICK_POINT_TO_PERCENTAGE(XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE)
@@ -21,6 +22,8 @@
 #define k_default_right_thumbstick_deadzone_radial_percentage THUMBSTICK_POINT_TO_PERCENTAGE(THUMBSTICK_PERCENTAGE_TO_POINT(8))
 
 #define NUMBER_OF_GAMEPAD_STICKS 2
+
+#define MAX_BUTTONS_PER_CONTROL 8
 
 /* enums */
 
@@ -52,10 +55,10 @@ enum e_button_preset_types : int8
 
 enum e_custom_keyboard_preset_types : int8
 {
-	_custom_keyboard_preset_right_hold,
-	_custom_keyboard_preset_right_split,
-	_custom_keyboard_preset_left_hold,
-	_custom_keyboard_preset_left_split,
+	_custom_keyboard_preset_right_hold,	//default
+	_custom_keyboard_preset_right_split,//skirmish
+	_custom_keyboard_preset_left_hold,	//southpaw
+	_custom_keyboard_preset_left_split,	//southpaw_boxer
 	_custom_keyboard_preset_custom
 };
 
@@ -164,6 +167,30 @@ enum e_gamepad_buttons
 	NUMBER_OF_GAMEPAD_BUTTON_STRINGS = 0x18,
 };
 
+enum e_mouse_buttons
+{
+	_mouse_button_left = 0x0,
+	_mouse_button_middle = 0x1,
+	_mouse_button_right = 0x2,
+	_mouse_button_4 = 0x3,
+	_mouse_button_5 = 0x4,
+	_mouse_button_6 = 0x5,
+	_mouse_button_7 = 0x6,
+	_mouse_button_8 = 0x7,
+	NUMBER_OF_MOUSE_BUTTONS,
+
+
+	_mouse_delta_x_left = 0x8,
+	_mouse_delta_x_right = 0x9,
+	_mouse_delta_y_up = 0xA,
+	_mouse_delta_y_down = 0xB,
+	_mouse_delta_w_forward = 0xC,
+	_mouse_delta_w_back = 0xD,
+
+	NUMBER_OF_MOUSE_BUTTON_STRINGS = 0xE,
+};
+
+
 /* structures */
 
 struct s_input_button
@@ -174,10 +201,15 @@ struct s_input_button
 };
 ASSERT_STRUCT_SIZE(s_input_button, 0xC);
 
-struct c_input_control
+class c_input_control
 {
+public:
 	uint32 button_count;
-	s_input_button buttons[k_maximum_number_of_game_function_binds];
+	s_input_button buttons[MAX_BUTTONS_PER_CONTROL];
+
+	bool add_button(e_input_device_types device_type, uint32 keycode, uint32 held_time, bool return_value_handled);
+	bool remove_button(uint32 button_index);
+
 };
 ASSERT_STRUCT_SIZE(c_input_control, 0x64);
 
@@ -267,7 +299,7 @@ void __cdecl input_abstraction_get_controller_preferences(e_controller_index con
 void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state);
 void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
 void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
-void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* out_preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout);
+void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* out_preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout, int32 unused);
 void __cdecl input_abstraction_set_controller_settings_from_preferences(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings);
 void __cdecl input_abstraction_set_preferences_from_controller_settings(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings);
 void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller, real32 value);

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -24,15 +24,50 @@
 
 /* enums */
 
-enum e_input_preference_device_type :uint32
+enum e_input_device_types :int32
 {
-	_input_preference_device_general = 0xFFFFFFFF,
-	_input_preference_device_mouse = 0x0,
-	_input_preference_device_keyboard = 0x1,
-	_input_preference_device_gamepad = 0x2,
+	_input_device_type_general = -1,
+	_input_device_type_mouse,
+	_input_device_type_keyboard,
+	_input_device_type_gamepad
 };
 
-enum e_button_functions
+enum e_joystick_preset_types : int8
+{
+	_joystick_preset_default,
+	_joystick_preset_south_paw,
+	_joystick_preset_legacy,
+	_joystick_preset_legacy_south_paw,
+	_joystick_preset_unused4
+};
+
+enum e_button_preset_types : int8
+{
+	_button_preset_default,
+	_button_preset_south_paw,
+	_button_preset_boxer,
+	_button_preset_green_thumb,
+	_button_preset_unused4
+};
+
+enum e_custom_keyboard_preset_types : int8
+{
+	_custom_keyboard_preset_right_hold,
+	_custom_keyboard_preset_right_split,
+	_custom_keyboard_preset_left_hold,
+	_custom_keyboard_preset_left_split,
+	_custom_keyboard_preset_custom
+};
+
+enum e_abstract_gamepad_stick_types
+{
+	_abstract_gamepad_stick_unknown = -1,
+	_abstract_gamepad_stick_left,
+	_abstract_gamepad_stick_right,
+	k_abstract_gamepad_stick_count
+};
+
+enum e_button_action
 {
 	_button_jump = 0x0,
 	_button_trick = 0x1,
@@ -131,20 +166,20 @@ enum e_gamepad_buttons
 
 /* structures */
 
-struct s_game_function_bind
+struct s_input_button
 {
-	e_input_preference_device_type m_device_type;
-	uint32 m_button_key;
-	uint32 unknown;
+	e_input_device_types m_device_type;
+	uint32 m_device_key;
+	uint32 m_device_key_held_time_msec;
 };
-ASSERT_STRUCT_SIZE(s_game_function_bind, 0xC);
+ASSERT_STRUCT_SIZE(s_input_button, 0xC);
 
-struct s_game_function
+struct c_input_control
 {
-	uint32 m_bind_count;
-	s_game_function_bind m_bind[k_maximum_number_of_game_function_binds];
+	uint32 button_count;
+	s_input_button buttons[k_maximum_number_of_game_function_binds];
 };
-ASSERT_STRUCT_SIZE(s_game_function, 0x64);
+ASSERT_STRUCT_SIZE(c_input_control, 0x64);
 
 
 struct s_gamepad_input_preferences
@@ -157,7 +192,7 @@ struct s_gamepad_input_preferences
 	bool mouse_invert_look;
 	bool invert_aircraft_control;
 	uint8 gap_13;
-	s_game_function game_function_mapping[NUMBER_OF_EXTENDED_CONTROL_BUTTONS];
+	c_input_control game_controls_to_hardware[NUMBER_OF_EXTENDED_CONTROL_BUTTONS];
 	uint32 field_1658;
 	real32 binary_yaw_rate;
 	real32 binary_pitch_rate;
@@ -222,6 +257,8 @@ ASSERT_STRUCT_SIZE(s_input_abstraction_globals, 0x5EB8);
 
 extern s_input_abstraction_globals* input_abstraction_globals;
 
+struct s_saved_game_profile_input_preferences;
+
 
 void __cdecl input_abstraction_initialize();
 void __cdecl input_abstraction_dispose();
@@ -230,15 +267,17 @@ void __cdecl input_abstraction_get_controller_preferences(e_controller_index con
 void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state);
 void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
 void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
+void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* out_preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout);
+void __cdecl input_abstraction_set_controller_settings_from_preferences(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings);
+void __cdecl input_abstraction_set_preferences_from_controller_settings(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings);
 void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller, real32 value);
 void input_abstraction_set_controller_look_sensitivity(e_controller_index controller, real32 value);
 void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index controller);
-bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_functions button_index);
-e_button_functions __cdecl input_abstraction_get_primary_fire_button(datum unit);
-e_button_functions __cdecl input_abstraction_get_secondary_fire_button(datum unit);
+bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_action button_index);
+e_button_action __cdecl input_abstraction_get_primary_fire_button(datum unit);
+e_button_action __cdecl input_abstraction_get_secondary_fire_button(datum unit);
 void __cdecl input_abstraction_update();
 void __cdecl input_abstraction_update_input_state(e_controller_index controller_index, s_gamepad_input_preferences* preference, s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick_analog, real_euler_angles2d* right_stick_analog, s_game_input_state* input_state);
-uint32 s_input_abstraction_globals_sub_45E501(e_button_functions button, void* a3);
-bool __cdecl input_abstraction_preferences_new(s_gamepad_input_preferences* preferences, int16 a2, bool a3, bool a4);
+uint32 s_input_abstraction_globals_sub_45E501(e_button_action button, void* a3);
 int32 __cdecl input_abstraction_get_last_used_device(e_controller_index controller);
 void input_abstraction_patches_apply();

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -1,29 +1,31 @@
 #pragma once
-
 #include "controllers.h"
 #include "input_windows.h"
 
-/* macro defines*/
+/* macros */
 
-#define THUMBSTICK_PERCENTAGE_TO_POINT(_percentage) \
-	((real32)INT16_MAX * ((_percentage) / 100.f))
+#define THUMBSTICK_PERCENTAGE_TO_POINT(_percentage) ((real32)INT16_MAX * ((_percentage) / 100.f))
+#define THUMBSTICK_POINT_TO_PERCENTAGE(_point) (((real32)_point / (real32)INT16_MAX) * 100.f)
 
-#define THUMBSTICK_POINT_TO_PERCENTAGE(_point) \
-	(((real32)_point / (real32)INT16_MAX) * 100.f)
+/* forward declarations */
 
-#define k_key_hold_threshold_msec 0xE9
+struct s_saved_game_profile_input_preferences;
 
-#define k_last_used_device_was_gamepad 1
+/* constants */
 
-#define k_default_right_thumbstick_deadzone_axial_percentage_x THUMBSTICK_POINT_TO_PERCENTAGE(XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE)
-#define k_default_right_thumbstick_deadzone_axial_percentage_y THUMBSTICK_POINT_TO_PERCENTAGE(XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE)
+enum
+{
+	k_key_hold_threshold_msec = 233,
+	k_last_used_device_was_gamepad = 1,
+	NUMBER_OF_GAMEPAD_STICKS = 2,
+	MAX_BUTTONS_PER_CONTROL = 8,
+};
 
-// set this to a default of 8
-#define k_default_right_thumbstick_deadzone_radial_percentage THUMBSTICK_POINT_TO_PERCENTAGE(THUMBSTICK_PERCENTAGE_TO_POINT(8))
+// Set this to a default of 8
+const real32 k_default_right_thumbstick_deadzone_radial_percentage = THUMBSTICK_POINT_TO_PERCENTAGE(THUMBSTICK_PERCENTAGE_TO_POINT(8));
 
-#define NUMBER_OF_GAMEPAD_STICKS 2
-
-#define MAX_BUTTONS_PER_CONTROL 8
+const real32 k_default_right_thumbstick_deadzone_axial_percentage_x = THUMBSTICK_POINT_TO_PERCENTAGE(XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
+const real32 k_default_right_thumbstick_deadzone_axial_percentage_y = THUMBSTICK_POINT_TO_PERCENTAGE(XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
 
 /* enums */
 
@@ -288,20 +290,21 @@ struct s_input_abstraction_globals
 };
 ASSERT_STRUCT_SIZE(s_input_abstraction_globals, 0x5EB8);
 
+/* globals */
 
-extern s_input_abstraction_globals* input_abstraction_globals;
+extern s_input_abstraction_globals* g_input_abstraction_globals;
 
-struct s_saved_game_profile_input_preferences;
+/* prototypes */
 
-
-void __cdecl input_abstraction_initialize();
-void __cdecl input_abstraction_dispose();
+void input_abstraction_patches_apply(void);
+void __cdecl input_abstraction_initialize(void);
+void __cdecl input_abstraction_dispose(void);
 void __cdecl input_abstraction_handle_device_change(uint32 flags);
 void __cdecl input_abstraction_get_controller_preferences(e_controller_index controller_index, s_gamepad_input_preferences* preferences);
 void __cdecl input_abstraction_get_input_state(e_controller_index controller_index, s_game_input_state* state);
 void __cdecl input_abstraction_get_player_look_angular_velocity(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
 void __cdecl input_abstraction_get_player_look_angular_velocity_for_mouse(e_controller_index controller_index, real_euler_angles2d* angular_velocity);
-void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* out_preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout, int32 unused);
+void __cdecl input_abstraction_get_default_preferences(s_gamepad_input_preferences* out_preference, e_joystick_preset_types thumbstick_layout, e_button_preset_types button_preset_type, e_custom_keyboard_preset_types kb_layout, bool caller_handles_failures);
 void __cdecl input_abstraction_set_controller_settings_from_preferences(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings);
 void __cdecl input_abstraction_set_preferences_from_controller_settings(s_gamepad_input_preferences* preferences, s_saved_game_profile_input_preferences* controller_settings);
 void input_abstraction_set_mouse_look_sensitivity(e_controller_index controller, real32 value);
@@ -310,8 +313,7 @@ void input_abstraction_set_controller_right_thumb_deadzone(e_controller_index co
 bool __cdecl input_abstraction_controller_button_test(e_controller_index controller_index, e_button_action button_index);
 e_button_action __cdecl input_abstraction_get_primary_fire_button(datum unit);
 e_button_action __cdecl input_abstraction_get_secondary_fire_button(datum unit);
-void __cdecl input_abstraction_update();
+void __cdecl input_abstraction_update(void);
 void __cdecl input_abstraction_update_input_state(e_controller_index controller_index, s_gamepad_input_preferences* preference, s_gamepad_input_button_state* gamepad_state, real_euler_angles2d* left_stick_analog, real_euler_angles2d* right_stick_analog, s_game_input_state* input_state);
 uint32 s_input_abstraction_globals_sub_45E501(e_button_action button, void* a3);
 int32 __cdecl input_abstraction_get_last_used_device(e_controller_index controller);
-void input_abstraction_patches_apply();

--- a/xlive/Blam/Engine/input/input_abstraction.h
+++ b/xlive/Blam/Engine/input/input_abstraction.h
@@ -50,7 +50,9 @@ enum e_button_preset_types : int8
 	_button_preset_south_paw,
 	_button_preset_boxer,
 	_button_preset_green_thumb,
-	_button_preset_unused4
+	//_button_preset_unused4,
+	_button_preset_jumpy,
+	_button_preset_unused5,
 };
 
 enum e_custom_keyboard_preset_types : int8

--- a/xlive/Blam/Engine/input/input_windows.cpp
+++ b/xlive/Blam/Engine/input/input_windows.cpp
@@ -8,7 +8,7 @@
 #include "shell/shell_windows.h"
 
 extern input_device** g_xinput_devices;
-extern s_input_abstraction_globals* input_abstraction_globals;
+extern s_input_abstraction_globals* g_input_abstraction_globals;
 
 /* globals */
 

--- a/xlive/Blam/Engine/input/input_xinput.cpp
+++ b/xlive/Blam/Engine/input/input_xinput.cpp
@@ -8,23 +8,14 @@
 #include "saved_games/cartographer_player_profile.h"
 #include "H2MOD/Modules/Input/ControllerInput.h"
 
-#include "render/render.h"
 
-/* globals */
+/* typedefs */
+
 typedef DWORD(WINAPI* XInputGetStateEx_t)(DWORD dwUserIndex, XINPUT_STATE* pState);
-XInputGetStateEx_t XInputGetStateEx;
 
-HMODULE g_xinput1_4_module;
+/* constants */
 
-bool g_input_feedback_suppress = false;
-XINPUT_VIBRATION g_xinput_vibration{};
-input_device** g_xinput_devices;
-uint32* g_main_controller_index;
-uint16 g_controller_radial_deadzones[k_number_of_controllers]{};
-
-bool g_controller_home_button_state[k_number_of_controllers] = { false, false, false, false };
-
-const uint32 XINPUT_BUTTON_FLAGS[k_number_of_xinput_buttons] =
+const uint32 k_xinput_button_flags[k_number_of_xinput_buttons] =
 {
 	XINPUT_GAMEPAD_DPAD_UP,
 	XINPUT_GAMEPAD_DPAD_DOWN,
@@ -43,12 +34,29 @@ const uint32 XINPUT_BUTTON_FLAGS[k_number_of_xinput_buttons] =
 }; // 0x39DEE0
 
 
-/* forward declaration */
+/* globals */
+
+XInputGetStateEx_t XInputGetStateEx;
+
+HMODULE g_xinput1_4_module;
+
+bool g_input_feedback_suppress = false;
+
+XINPUT_VIBRATION g_xinput_vibration{};
+
+input_device** g_xinput_devices;
+
+uint32* g_main_controller_index;
+
+uint16 g_controller_radial_deadzones[k_number_of_controllers] = {};
+
+bool g_controller_home_button_state[k_number_of_controllers] = { false, false, false, false };
+
+/* prototypes */
 
 void input_xinput_update_get_gamepad_buttons(uint32 gamepad_index, uint16* out_buttons);
 
 /* public code */
-
 
 uint32 xinput_device::get_port() const
 {
@@ -214,7 +222,7 @@ bool input_xinput_update_gamepad(uint32 gamepad_index, uint32 duration_ms, s_gam
 		uint8& frames_down = gamepad_state->button_frames_down[button_index];
 		uint16& msec_down = gamepad_state->button_msec_down[button_index];
 		
-		bool button_down = TEST_FLAG(gamepad_buttons, XINPUT_BUTTON_FLAGS[button_index]);
+		bool button_down = TEST_FLAG(gamepad_buttons, k_xinput_button_flags[button_index]);
 		//if (button_down)
 		//	LOG_DEBUG_FUNC(" down {}", button_index);
 		if (button_down)
@@ -262,7 +270,7 @@ void input_xinput_update_get_gamepad_buttons(uint32 gamepad_index, uint16* out_b
 		{
 			for (uint8 button_index = 0; button_index < k_number_of_xinput_buttons; button_index++)
 			{
-				if (TEST_FLAG(state.Gamepad.wButtons, XINPUT_BUTTON_FLAGS[button_index]))
+				if (TEST_FLAG(state.Gamepad.wButtons, k_xinput_button_flags[button_index]))
 				{
 					*out_buttons |= custom_button_flags[button_index];
 				}

--- a/xlive/Blam/Engine/input/input_xinput.h
+++ b/xlive/Blam/Engine/input/input_xinput.h
@@ -23,6 +23,12 @@ public:
 };
 ASSERT_STRUCT_SIZE(xinput_device, 0x1C);
 
+/* globals */
+
+extern uint16 g_controller_radial_deadzones[k_number_of_controllers];
+
+/* prototypes */
+
 int16 input_xinput_adjust_thumb_axis_deadzone(int16 thumb_axis, int16 thumb_deadzone);
 
 void input_xinput_adjust_thumb_radial_deadzones(uint32 gamepad_index, s_gamepad_input_button_state* gamepad_state);

--- a/xlive/Blam/Engine/interface/screens/screen_button_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_button_settings.cpp
@@ -7,6 +7,7 @@
 #include "interface/user_interface_bitmap_block.h"
 #include "tag_files/global_string_ids.h"
 #include "tag_files/tag_loader/tag_injection.h"
+#include "text/text_group.h"
 
 /* macro defines */
 
@@ -139,78 +140,41 @@ enum e_jumpy_ingame_pane_bitmap_blocks //qtr_screen
 
 };
 
-
-enum e_button_settings_multilingual_unicode_string_list : uint32
+enum e_button_settings_multilingual_unicode_string_list
 {
-	_string_id_l_header = 0x6000234,
-	_string_id_l_default = _string_id_default,
-	_string_id_l_south_paw = _string_id_south_paw,
-	_string_id_l_jumpy = 0x5001A09,
-	_string_id_l_boxer = _string_id_boxer,
-	_string_id_l_green_thumb = _string_id_green_thumb,
-	_string_id_l_button_fire = 0xB001A34,
-	_string_id_l_button_throw_grenade = 0x14001A30,
-	_string_id_l_button_reload = 0xD001A35,
-	_string_id_l_button_switch_weapons = 0x15001A36,
-	_string_id_l_button_melee = 0xC001A37,
-	_string_id_l_button_jump = 0xB001A38,
-	_string_id_l_button_swap_grenades = 0x14001A3A,
-	_string_id_l_button_flashlight = 0x11001A39,
-	_string_id_l_button_zoom = 0xB001A3B,
-	_string_id_l_button_crouch = 0xD001A31,
-	_string_id_l_button_score = 0xC001A32,
-	_string_id_l_button_pause = 0xC001A33,
-	_string_id_l_button_lean_left = 0x10001A41,
-	_string_id_l_button_lean_right = 0x11001A42,
-	_string_id_l_standard_help = 0xD002653,
-	_string_id_l_southpaw_help = 0xD001A3C,
-	_string_id_l_jumpy_help = 0xA001A43,
-	_string_id_l_boxer_help = 0xA001A3D,
-	_string_id_l_greenthumb_help = 0xF001A40,
-	_string_id_l_default_ingame = 0xE002644,
-	_string_id_l_south_paw_ingame = 0x10002661,
-	_string_id_l_jumpy_ingame = 0xC001A45,
-	_string_id_l_boxer_ingame = 0xC002665,
-	_string_id_l_green_thumb_ingame = 0x12002667,
-	_string_id_l_button_boxer_grenade = 0x14001A3F,
-	_string_id_l_button_boxer_melee = 0x12001A3E,
-};
-
-
-enum e_button_settings_ingame_multilingual_unicode_string_list : uint32
-{
-	_string_id_l_ig_header = 0x6000234,
-	_string_id_l_ig_default = _string_id_default,
-	_string_id_l_ig_south_paw = _string_id_south_paw,
-	_string_id_l_ig_jumpy = 0x5001A09,
-	_string_id_l_ig_boxer = _string_id_boxer,
-	_string_id_l_ig_green_thumb = _string_id_green_thumb,
-	_string_id_l_ig_button_fire = 0xB002658,
-	_string_id_l_ig_button_throw_grenade = 0x14002654,
-	_string_id_l_ig_button_reload = 0xD002659,
-	_string_id_l_ig_button_switch_weapons = 0x1500265A,
-	_string_id_l_ig_button_melee = 0xC00265B,
-	_string_id_l_ig_button_jump = 0xB00265C,
-	_string_id_l_ig_button_swap_grenades = 0x1400265E,
-	_string_id_l_ig_button_flashlight = 0x1100265D,
-	_string_id_l_ig_button_zoom = 0xB00265F,
-	_string_id_l_ig_button_crouch = 0xD002655,
-	_string_id_l_ig_button_score = 0xC002656,
-	_string_id_l_ig_button_pause = 0xC002657,
-	_string_id_l_ig_button_lean_left = 0x1000267B,
-	_string_id_l_ig_button_lean_right = 0x1100267C,
-	_string_id_l_ig_standard_help = 0xD002653,
-	_string_id_l_ig_southpaw_help = 0xD002660,
-	_string_id_l_ig_jumpy_help = 0xA00267D,
-	_string_id_l_ig_boxer_help = 0xA002662,
-	_string_id_l_ig_greenthumb_help = 0xF002666,
-	_string_id_l_ig_default_ingame = 0xE002644,
-	_string_id_l_ig_south_paw_ingame = 0x10002661,
-	_string_id_l_ig_jumpy_ingame = 0xC00267E,
-	_string_id_l_ig_boxer_ingame = 0xC002665,
-	_string_id_l_ig_green_thumb_ingame = 0x12002667,
-	_string_id_l_ig_button_boxer_grenade = 0x14002664,
-	_string_id_l_ig_button_boxer_melee = 0x12002663,
+	_string_id_l_header,
+	_string_id_l_default,
+	_string_id_l_south_paw,
+	_string_id_l_jumpy,
+	_string_id_l_boxer,
+	_string_id_l_green_thumb,
+	_string_id_l_button_fire,
+	_string_id_l_button_throw_grenade,
+	_string_id_l_button_reload,
+	_string_id_l_button_switch_weapons,
+	_string_id_l_button_melee,
+	_string_id_l_button_jump,
+	_string_id_l_button_swap_grenades,
+	_string_id_l_button_flashlight,
+	_string_id_l_button_zoom,
+	_string_id_l_button_crouch,
+	_string_id_l_button_score,
+	_string_id_l_button_pause,
+	_string_id_l_button_lean_left,
+	_string_id_l_button_lean_right,
+	_string_id_l_standard_help,
+	_string_id_l_southpaw_help,
+	_string_id_l_jumpy_help,
+	_string_id_l_boxer_help,
+	_string_id_l_greenthumb_help,
+	_string_id_l_default_ingame,
+	_string_id_l_south_paw_ingame,
+	_string_id_l_jumpy_ingame,
+	_string_id_l_boxer_ingame,
+	_string_id_l_green_thumb_ingame,
+	_string_id_l_button_boxer_grenade,
+	_string_id_l_button_boxer_melee,
+	k_number_of_button_settings_multilingual_unicode_string_list
 };
 
 /* constants */
@@ -227,6 +191,11 @@ const wchar_t* g_jumpy_text_button_swap_left_string[k_language_count]
 	L"交换左武器",
 	L"Trocar Arma Esquerda"
 };
+
+/* globals */
+
+// generate string_ids on runtime instead of hardcoding them
+string_id strings_array[k_number_of_button_settings_multilingual_unicode_string_list] = {};
 
 /* prototypes */
 
@@ -275,22 +244,22 @@ void c_button_settings_edit_list::update_list_items(c_list_item_widget* item, in
 		switch (DATUM_INDEX_TO_ABSOLUTE_INDEX(item->get_last_data_index()))
 		{
 		case _item_standard:
-			item_text->set_text_from_string_id(_string_id_l_default);
+			item_text->set_text_from_string_id(strings_array[_string_id_l_default]);
 			break;
 		case _item_south_paw:
-			item_text->set_text_from_string_id(_string_id_l_south_paw);
+			item_text->set_text_from_string_id(strings_array[_string_id_l_south_paw]);
 			break;
 		case _item_boxer:
-			item_text->set_text_from_string_id(_string_id_l_boxer);
+			item_text->set_text_from_string_id(strings_array[_string_id_l_boxer]);
 			break;
 		case _item_green_thumb:
-			item_text->set_text_from_string_id(_string_id_l_green_thumb);
+			item_text->set_text_from_string_id(strings_array[_string_id_l_green_thumb]);
 			break;
 		case _item_jumpy:
-			item_text->set_text_from_string_id(_string_id_l_jumpy);
+			item_text->set_text_from_string_id(strings_array[_string_id_l_jumpy]);
 			break;
 		default:
-			item_text->set_text_from_string_id(_string_id_invalid);
+			item_text->set_text_from_string_id(strings_array[_string_id_invalid]);
 			break;
 		}
 	}
@@ -542,13 +511,16 @@ void c_screen_button_settings_menu::apply_patches_on_ui_map_load()
 		csmemcpy(jumpy_pane->text_blocks[0], standard_pane->text_blocks[0], sizeof(s_text_block_reference) * standard_pane->text_blocks.count);
 	}
 
+
 	//start adjusting texts for jumpy
-	jumpy_pane->text_blocks[_jumpy_pane_text_help]->string = _string_id_l_jumpy_help;
-	jumpy_pane->text_blocks[_jumpy_pane_text_button_reload]->string = _string_id_l_button_reload;
-	jumpy_pane->text_blocks[_jumpy_pane_text_button_melee]->string = _string_id_l_button_melee;
-	jumpy_pane->text_blocks[_jumpy_pane_text_button_jump]->string = _string_id_l_button_jump;
-	jumpy_pane->text_blocks[_jumpy_pane_text_button_flashlight]->string = _string_id_l_button_flashlight;
-	jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_grenades]->string = _string_id_l_button_swap_grenades;
+	string_list_get_string_id_list(main_widget_tag->string_list_tag.index, strings_array, NUMBEROF(strings_array));
+	
+	jumpy_pane->text_blocks[_jumpy_pane_text_help]->string = strings_array[_string_id_l_jumpy_help];
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_reload]->string = strings_array[_string_id_l_button_reload];
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_melee]->string = strings_array[_string_id_l_button_melee];
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_jump]->string = strings_array[_string_id_l_button_jump];
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_flashlight]->string = strings_array[_string_id_l_button_flashlight];
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_grenades]->string = strings_array[_string_id_l_button_swap_grenades];
 
 	//reposition
 	jumpy_pane->text_blocks[_jumpy_pane_text_button_flashlight]->text_bounds = { -60 ,-600,-100,-266 };
@@ -592,14 +564,18 @@ void c_screen_button_settings_menu::apply_patches_on_mp_map_load()
 		csmemcpy(jumpy_pane->text_blocks[0], standard_pane->text_blocks[0], sizeof(s_text_block_reference) * standard_pane->text_blocks.count);
 	}
 
+	
+
 	//start adjusting texts for jumpy
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_help]->string = _string_id_l_ig_jumpy_help;
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_reload]->string = _string_id_l_ig_button_reload;
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_melee]->string = _string_id_l_ig_button_melee;
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_jump]->string = _string_id_l_ig_button_jump;
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_flashlight]->string = _string_id_l_ig_button_flashlight;
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_grenades]->string = _string_id_l_ig_button_swap_grenades;
-	jumpy_pane->text_blocks[_jumpy_ig_pane_text_header]->string = _string_id_l_ig_jumpy_ingame;
+	string_list_get_string_id_list(main_widget_tag->string_list_tag.index, strings_array, NUMBEROF(strings_array));
+	
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_help]->string = strings_array[_string_id_l_jumpy_help];
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_reload]->string = strings_array[_string_id_l_button_reload];
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_melee]->string = strings_array[_string_id_l_button_melee];
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_jump]->string = strings_array[_string_id_l_button_jump];
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_flashlight]->string = strings_array[_string_id_l_button_flashlight];
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_grenades]->string = strings_array[_string_id_l_button_swap_grenades];
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_header]->string = strings_array[_string_id_l_jumpy_ingame];
 
 	//reposition
 	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_flashlight]->text_bounds = { 40 ,-540,0,-170 };

--- a/xlive/Blam/Engine/interface/screens/screen_button_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_button_settings.cpp
@@ -1,10 +1,12 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 
 #include "screen_button_settings.h"
+#include "cache/cache_files.h"
 #include "interface/user_interface_memory.h"
 #include "interface/user_interface_globals.h"
 #include "interface/user_interface_bitmap_block.h"
 #include "tag_files/global_string_ids.h"
+#include "tag_files/tag_loader/tag_injection.h"
 
 /* macro defines */
 
@@ -18,6 +20,9 @@ enum e_button_list_items : uint16
 	_item_south_paw,
 	_item_boxer,
 	_item_green_thumb,
+	
+	//custom addons
+	_item_jumpy,
 
 	k_total_no_of_button_list_items
 };
@@ -28,12 +33,64 @@ enum e_button_screen_panes
 	_button_screen_pane_south_paw,
 	_button_screen_pane_boxer,
 	_button_screen_pane_green_thumb,
-	_button_screen_pane_unused4,//copy_of_standard
+	//_button_screen_pane_unused4,//copy_of_standard
+	_button_screen_pane_jumpy,
 	_button_screen_pane_unused5,//copy_of_south_paw
 	_button_screen_pane_unused6,//copy_of_boxer
 	_button_screen_pane_unused7,//copy_of_green_thumb	
 
-	k_total_no_of_settings_pane,
+	k_total_no_of_button_settings_pane,
+};
+
+enum e_jumpy_pane_text_blocks
+{
+	_jumpy_pane_text_help,
+	_jumpy_pane_text_button_throw_grenade,
+	_jumpy_pane_text_button_crouch,
+	_jumpy_pane_text_button_score,
+	_jumpy_pane_text_button_pause,
+	_jumpy_pane_text_button_fire,
+	_jumpy_pane_text_button_flashlight,//_jumpy_pane_text_button_reload
+	_jumpy_pane_text_button_switch_weapons,
+	_jumpy_pane_text_button_reload,//_jumpy_pane_text_button_melee
+	_jumpy_pane_text_button_swap_grenades,//_jumpy_pane_text_button_jump
+	_jumpy_pane_text_button_jump,//_jumpy_pane_text_button_flashlight
+	_jumpy_pane_text_button_melee,//_jumpy_pane_text_button_swap_grenades
+	_jumpy_pane_text_button_zoom,
+
+	//addtions
+	_jumpy_pane_text_button_swap_left,
+	k_jumpy_pane_texts_count,
+
+	k_orignal_jumpy_pane_texts_count =13,
+	k_number_of_jumpy_pane_text_addons = k_jumpy_pane_texts_count- k_orignal_jumpy_pane_texts_count
+
+};
+
+enum e_jumpy_ingame_pane_text_blocks
+{
+	_jumpy_ig_pane_text_help,
+	_jumpy_ig_pane_text_button_throw_grenade,
+	_jumpy_ig_pane_text_button_crouch,
+	_jumpy_ig_pane_text_button_score,
+	_jumpy_ig_pane_text_button_pause,
+	_jumpy_ig_pane_text_button_fire,
+	_jumpy_ig_pane_text_button_flashlight,//_jumpy_pane_text_button_reload
+	_jumpy_ig_pane_text_button_switch_weapons,
+	_jumpy_ig_pane_text_button_reload,//_jumpy_pane_text_button_melee
+	_jumpy_ig_pane_text_button_swap_grenades,//_jumpy_pane_text_button_jump
+	_jumpy_ig_pane_text_button_jump,//_jumpy_pane_text_button_flashlight
+	_jumpy_ig_pane_text_button_melee,//_jumpy_pane_text_button_swap_grenades
+	_jumpy_ig_pane_text_button_zoom,
+
+	//addtions
+	_jumpy_ig_pane_text_header,
+	_jumpy_ig_pane_text_button_swap_left,
+	k_jumpy_ig_pane_texts_count,
+
+	k_orignal_jumpy_ig_pane_texts_count = 13,
+	k_number_of_jumpy_ingame_pane_text_addons = k_jumpy_ig_pane_texts_count - k_orignal_jumpy_ig_pane_texts_count
+
 };
 
 enum e_button_settings_bitmap_blocks
@@ -61,6 +118,28 @@ enum e_button_settings_ingame_bitmap_blocks //qtr_screen
 	k_number_of_button_settings_ingame_bitmap_blocks
 };
 
+enum e_jumpy_ingame_pane_bitmap_blocks //qtr_screen
+{
+	_jumpy_ig_pane_bitmap_ul_07,
+	_jumpy_ig_pane_bitmap_br_07,
+	_jumpy_ig_pane_bitmap_dialog1,
+	_jumpy_ig_pane_bitmap_dialog2,
+	_jumpy_ig_pane_bitmap_settings_framing,
+	_jumpy_ig_pane_bitmap_settings_framing2,
+	_jumpy_ig_pane_bitmap_arrows_up,
+	_jumpy_ig_pane_bitmap_arrows_down,
+
+	//addtions
+	_jumpy_ig_pane_bitmap_settings_framing3,
+	_jumpy_ig_pane_bitmap_button_config,
+	k_jumpy_ig_pane_bitmaps_count,
+
+	k_orignal_jumpy_ig_pane_bitmaps_count = 8,
+	k_number_of_jumpy_ingame_pane_bitmap_addons = k_jumpy_ig_pane_bitmaps_count - k_orignal_jumpy_ig_pane_bitmaps_count
+
+};
+
+
 enum e_button_settings_multilingual_unicode_string_list : uint32
 {
 	_string_id_l_header = 0x6000234,
@@ -69,18 +148,18 @@ enum e_button_settings_multilingual_unicode_string_list : uint32
 	_string_id_l_jumpy = 0x5001A09,
 	_string_id_l_boxer = _string_id_boxer,
 	_string_id_l_green_thumb = _string_id_green_thumb,
-	_string_id_l_button_fire = 0xB002658,
-	_string_id_l_button_throw_grenade = 0x14002654,
-	_string_id_l_button_reload = 0xD002659,
-	_string_id_l_button_switch_weapons = 0x1500265A,
-	_string_id_l_button_melee = 0xC00265B,
-	_string_id_l_button_jump = 0xB00265C,
-	_string_id_l_button_swap_grenades = 0x1400265E,
-	_string_id_l_button_flashlight = 0x1100265D,
-	_string_id_l_button_zoom = 0xB00265F,
-	_string_id_l_button_crouch = 0xD002655,
-	_string_id_l_button_score = 0xC002656,
-	_string_id_l_button_pause = 0xC002657,
+	_string_id_l_button_fire = 0xB001A34,
+	_string_id_l_button_throw_grenade = 0x14001A30,
+	_string_id_l_button_reload = 0xD001A35,
+	_string_id_l_button_switch_weapons = 0x15001A36,
+	_string_id_l_button_melee = 0xC001A37,
+	_string_id_l_button_jump = 0xB001A38,
+	_string_id_l_button_swap_grenades = 0x14001A3A,
+	_string_id_l_button_flashlight = 0x11001A39,
+	_string_id_l_button_zoom = 0xB001A3B,
+	_string_id_l_button_crouch = 0xD001A31,
+	_string_id_l_button_score = 0xC001A32,
+	_string_id_l_button_pause = 0xC001A33,
 	_string_id_l_button_lean_left = 0x10001A41,
 	_string_id_l_button_lean_right = 0x11001A42,
 	_string_id_l_standard_help = 0xD002653,
@@ -98,6 +177,56 @@ enum e_button_settings_multilingual_unicode_string_list : uint32
 };
 
 
+enum e_button_settings_ingame_multilingual_unicode_string_list : uint32
+{
+	_string_id_l_ig_header = 0x6000234,
+	_string_id_l_ig_default = _string_id_default,
+	_string_id_l_ig_south_paw = _string_id_south_paw,
+	_string_id_l_ig_jumpy = 0x5001A09,
+	_string_id_l_ig_boxer = _string_id_boxer,
+	_string_id_l_ig_green_thumb = _string_id_green_thumb,
+	_string_id_l_ig_button_fire = 0xB002658,
+	_string_id_l_ig_button_throw_grenade = 0x14002654,
+	_string_id_l_ig_button_reload = 0xD002659,
+	_string_id_l_ig_button_switch_weapons = 0x1500265A,
+	_string_id_l_ig_button_melee = 0xC00265B,
+	_string_id_l_ig_button_jump = 0xB00265C,
+	_string_id_l_ig_button_swap_grenades = 0x1400265E,
+	_string_id_l_ig_button_flashlight = 0x1100265D,
+	_string_id_l_ig_button_zoom = 0xB00265F,
+	_string_id_l_ig_button_crouch = 0xD002655,
+	_string_id_l_ig_button_score = 0xC002656,
+	_string_id_l_ig_button_pause = 0xC002657,
+	_string_id_l_ig_button_lean_left = 0x1000267B,
+	_string_id_l_ig_button_lean_right = 0x1100267C,
+	_string_id_l_ig_standard_help = 0xD002653,
+	_string_id_l_ig_southpaw_help = 0xD002660,
+	_string_id_l_ig_jumpy_help = 0xA00267D,
+	_string_id_l_ig_boxer_help = 0xA002662,
+	_string_id_l_ig_greenthumb_help = 0xF002666,
+	_string_id_l_ig_default_ingame = 0xE002644,
+	_string_id_l_ig_south_paw_ingame = 0x10002661,
+	_string_id_l_ig_jumpy_ingame = 0xC00267E,
+	_string_id_l_ig_boxer_ingame = 0xC002665,
+	_string_id_l_ig_green_thumb_ingame = 0x12002667,
+	_string_id_l_ig_button_boxer_grenade = 0x14002664,
+	_string_id_l_ig_button_boxer_melee = 0x12002663,
+};
+
+/* constants */
+
+const wchar_t* g_jumpy_text_button_swap_left_string[k_language_count]
+{
+	L"Swap Left Weapon",
+	L"左武器の交換",
+	L"Linke Waffe tauschen",
+	L"Échanger l'arme gauche",
+	L"Cambiar arma izquierda",
+	L"Scambia arma sinistra",
+	L"왼쪽 무기 교체",
+	L"交换左武器",
+	L"Trocar Arma Esquerda"
+};
 
 /* prototypes */
 
@@ -157,6 +286,9 @@ void c_button_settings_edit_list::update_list_items(c_list_item_widget* item, in
 		case _item_green_thumb:
 			item_text->set_text_from_string_id(_string_id_l_green_thumb);
 			break;
+		case _item_jumpy:
+			item_text->set_text_from_string_id(_string_id_l_jumpy);
+			break;
 		default:
 			item_text->set_text_from_string_id(_string_id_invalid);
 			break;
@@ -183,6 +315,9 @@ void c_button_settings_edit_list::handle_item_pressed_event(s_event_record** pev
 		break;
 	case _item_green_thumb:
 		selected_preset = _button_preset_green_thumb;
+		break;
+	case _item_jumpy:
+		selected_preset = _button_preset_jumpy;
 		break;
 	default:
 		selected_preset = _button_preset_default;
@@ -217,7 +352,32 @@ c_screen_button_settings_menu::c_screen_button_settings_menu(e_user_interface_ch
 
 void c_screen_button_settings_menu::update()
 {
-	INVOKE_TYPE(0x25d180, 0, void(__thiscall*)(c_screen_button_settings_menu*), this);
+	//INVOKE_TYPE(0x25d180, 0, void(__thiscall*)(c_screen_button_settings_menu*), this);
+
+	if (this->get_any_responding_controller() != k_no_controller)
+	{
+		//const int32 unk_setting = return_0x0();
+		const int32 unk_setting = 0;
+		if (unk_setting != this->field_D3C)
+		{
+			if (unk_setting == 2)
+				this->field_9FB = 5; // wgit pane offset pointer ?
+			else
+				this->field_9FB = 0;
+
+			datum old_data_idx = this->m_button_settings_list.get_old_data_index();
+			c_screen_widget::switch_panes(&old_data_idx);
+			this->field_D3C = unk_setting;
+		}
+		if (this->m_using_qtr_arrows)
+		{
+			c_bitmap_widget* bitmap_down_arrow = this->try_find_bitmap_widget(_button_settings_ingame_bitmap_arrows_down);
+			c_bitmap_widget* bitmap_up_arrow = this->try_find_bitmap_widget(_button_settings_ingame_bitmap_arrows_up);
+			this->set_list_arrows_widget(bitmap_up_arrow, bitmap_down_arrow);
+
+		}
+	}
+	c_user_interface_widget::update();
 }
 
 bool c_screen_button_settings_menu::handle_event(s_event_record* event)
@@ -255,12 +415,37 @@ void c_screen_button_settings_menu::post_initialize()
 		case _button_preset_green_thumb:
 			this->m_button_settings_list.set_focused_item_index(_item_green_thumb);
 			break;
+		case _button_preset_jumpy:
+			this->m_button_settings_list.set_focused_item_index(_item_jumpy);
+			break;
 		default:
 			this->m_button_settings_list.set_focused_item_index(_item_standard);
 
 		}
 	}
 	c_screen_widget::post_initialize();
+}
+
+void c_screen_button_settings_menu::post_initialize_button_keys()
+{
+	// this function is executed once upon every pane creation
+	// thus can be used as on_pane_switch hook
+
+	if (this->m_pane_index == _button_screen_pane_jumpy
+		|| DATUM_INDEX_TO_ABSOLUTE_INDEX(this->m_button_settings_list.get_old_data_index()) == _item_jumpy)
+	{
+		c_text_widget* swap_left_text = this->try_find_screen_text(
+			m_using_qtr_arrows ? _jumpy_ig_pane_text_button_swap_left : _jumpy_pane_text_button_swap_left);
+
+		if (swap_left_text)
+		{
+			swap_left_text->set_text(g_jumpy_text_button_swap_left_string[get_current_language()]);
+		}
+
+	}
+
+	// call orignal function now
+	c_screen_widget::post_initialize_button_keys();
 }
 
 const void* c_screen_button_settings_menu::load_proc() const
@@ -321,6 +506,110 @@ void* c_screen_button_settings_menu::load_qtr(s_screen_parameters* parameters)
 	}
 
 	return screen;
+}
+
+void c_screen_button_settings_menu::apply_patches_on_ui_map_load()
+{
+	const char* main_widget_tag_path = "ui\\screens\\game_shell\\settings_screen\\player_profile\\button_settings";
+
+	datum main_widget_datum_index = tag_loaded(_tag_group_user_interface_screen_widget_definition, main_widget_tag_path);
+
+	if (main_widget_datum_index == NONE)
+	{
+		LOG_ERROR_FUNC("bad datum found ");
+		return;
+	}
+
+	s_user_interface_screen_widget_definition* main_widget_tag = (s_user_interface_screen_widget_definition*)tag_get_fast(main_widget_datum_index);
+
+	main_widget_tag->panes[_button_screen_pane_standard]->list_block[0]->num_visible_items = k_no_of_visible_items_for_button_settings;
+	//_button_screen_pane_south_paw to _button_screen_pane_unused7 all use same s_list_reference tag_block
+	main_widget_tag->panes[_button_screen_pane_south_paw]->list_block[0]->num_visible_items = k_no_of_visible_items_for_button_settings;
+
+	s_window_pane_reference* standard_pane = main_widget_tag->panes[_button_screen_pane_standard];
+	s_window_pane_reference* jumpy_pane = main_widget_tag->panes[_button_screen_pane_jumpy];
+
+	//fixup bitmap blocks
+	if (standard_pane->bitmap_blocks.count)
+	{
+		csmemcpy(jumpy_pane->bitmap_blocks[0], standard_pane->bitmap_blocks[0], sizeof(s_bitmap_block_reference) * standard_pane->bitmap_blocks.count);
+	}
+
+	if (standard_pane->text_blocks.count)
+	{
+		//addon text blocks
+		tag_injection_extend_block(&jumpy_pane->text_blocks, sizeof(s_text_block_reference), k_number_of_jumpy_pane_text_addons);
+		csmemcpy(jumpy_pane->text_blocks[0], standard_pane->text_blocks[0], sizeof(s_text_block_reference) * standard_pane->text_blocks.count);
+	}
+
+	//start adjusting texts for jumpy
+	jumpy_pane->text_blocks[_jumpy_pane_text_help]->string = _string_id_l_jumpy_help;
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_reload]->string = _string_id_l_button_reload;
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_melee]->string = _string_id_l_button_melee;
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_jump]->string = _string_id_l_button_jump;
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_flashlight]->string = _string_id_l_button_flashlight;
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_grenades]->string = _string_id_l_button_swap_grenades;
+
+	//reposition
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_flashlight]->text_bounds = { -60 ,-600,-100,-266 };
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_grenades]->text_bounds = { -280,-550,-420,-216 };
+
+	//additional texts to be added
+	csmemcpy(jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_left], jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_grenades], sizeof(s_text_block_reference));
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_left]->string = _string_id_invalid;
+	jumpy_pane->text_blocks[_jumpy_pane_text_button_swap_left]->text_bounds = { -175,296,-215,640 };
+
+}
+
+void c_screen_button_settings_menu::apply_patches_on_mp_map_load()
+{
+
+	const char* ingame_widget_tag_path = "ui\\screens\\game_shell\\settings_screen\\player_profile\\button_settings_ingame";
+	datum main_widget_datum_index = tag_loaded(_tag_group_user_interface_screen_widget_definition, ingame_widget_tag_path);
+
+	if (main_widget_datum_index == NONE)
+	{
+		LOG_ERROR_FUNC("bad datum found ");
+		return;
+	}
+
+	s_user_interface_screen_widget_definition* main_widget_tag = (s_user_interface_screen_widget_definition*)tag_get_fast(main_widget_datum_index);
+
+	s_window_pane_reference* standard_pane = main_widget_tag->panes[_button_screen_pane_standard];
+	s_window_pane_reference* jumpy_pane = main_widget_tag->panes[_button_screen_pane_jumpy];
+
+	if (standard_pane->bitmap_blocks.count)
+	{
+		//add & fixup bitmap blocks
+		tag_injection_extend_block(&jumpy_pane->bitmap_blocks, sizeof(s_bitmap_block_reference), k_number_of_jumpy_ingame_pane_bitmap_addons);
+		csmemcpy(jumpy_pane->bitmap_blocks[0], standard_pane->bitmap_blocks[0], sizeof(s_bitmap_block_reference) * standard_pane->bitmap_blocks.count);
+	}
+
+	if (standard_pane->text_blocks.count)
+	{
+		//addon text blocks
+		tag_injection_extend_block(&jumpy_pane->text_blocks, sizeof(s_text_block_reference), k_number_of_jumpy_ingame_pane_text_addons);
+		csmemcpy(jumpy_pane->text_blocks[0], standard_pane->text_blocks[0], sizeof(s_text_block_reference) * standard_pane->text_blocks.count);
+	}
+
+	//start adjusting texts for jumpy
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_help]->string = _string_id_l_ig_jumpy_help;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_reload]->string = _string_id_l_ig_button_reload;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_melee]->string = _string_id_l_ig_button_melee;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_jump]->string = _string_id_l_ig_button_jump;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_flashlight]->string = _string_id_l_ig_button_flashlight;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_grenades]->string = _string_id_l_ig_button_swap_grenades;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_header]->string = _string_id_l_ig_jumpy_ingame;
+
+	//reposition
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_flashlight]->text_bounds = { 40 ,-540,0,-170 };
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_grenades]->text_bounds = { -180,-520,-320,-216 };
+
+	//additional texts to be added
+	csmemcpy(jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_left], jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_grenades], sizeof(s_text_block_reference));
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_left]->string = _string_id_invalid;
+	jumpy_pane->text_blocks[_jumpy_ig_pane_text_button_swap_left]->text_bounds = { -75,326,-115,640 };
+
 }
 
 void c_screen_button_settings_menu::apply_instance_patches()

--- a/xlive/Blam/Engine/interface/screens/screen_button_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_button_settings.cpp
@@ -1,0 +1,332 @@
+#include "stdafx.h"
+
+#include "screen_button_settings.h"
+#include "interface/user_interface_memory.h"
+#include "interface/user_interface_globals.h"
+#include "interface/user_interface_bitmap_block.h"
+#include "tag_files/global_string_ids.h"
+
+/* macro defines */
+
+#define k_button_setting_list_name "button settings edit list"
+
+/* enums */
+
+enum e_button_list_items : uint16
+{
+	_item_standard,
+	_item_south_paw,
+	_item_boxer,
+	_item_green_thumb,
+
+	k_total_no_of_button_list_items
+};
+
+enum e_button_screen_panes
+{
+	_button_screen_pane_standard,
+	_button_screen_pane_south_paw,
+	_button_screen_pane_boxer,
+	_button_screen_pane_green_thumb,
+	_button_screen_pane_unused4,//copy_of_standard
+	_button_screen_pane_unused5,//copy_of_south_paw
+	_button_screen_pane_unused6,//copy_of_boxer
+	_button_screen_pane_unused7,//copy_of_green_thumb	
+
+	k_total_no_of_settings_pane,
+};
+
+enum e_button_settings_bitmap_blocks
+{
+	_button_settings_bitmap_ul_03,
+	_button_settings_bitmap_br_05,
+	_button_settings_bitmap_button_config,
+
+	k_number_of_button_settings_bitmap_blocks
+};
+
+enum e_button_settings_ingame_bitmap_blocks //qtr_screen
+{
+	_button_settings_ingame_bitmap_ul_07,
+	_button_settings_ingame_bitmap_br_07,
+	_button_settings_ingame_bitmap_dialog1,
+	_button_settings_ingame_bitmap_dialog2,
+	_button_settings_ingame_bitmap_settings_framing,
+	_button_settings_ingame_bitmap_settings_framing2,
+	_button_settings_ingame_bitmap_arrows_up,
+	_button_settings_ingame_bitmap_arrows_down,
+	_button_settings_ingame_bitmap_settings_framing3,
+	_button_settings_ingame_bitmap_button_config,
+
+	k_number_of_button_settings_ingame_bitmap_blocks
+};
+
+enum e_button_settings_multilingual_unicode_string_list : uint32
+{
+	_string_id_l_header = 0x6000234,
+	_string_id_l_default = _string_id_default,
+	_string_id_l_south_paw = _string_id_south_paw,
+	_string_id_l_jumpy = 0x5001A09,
+	_string_id_l_boxer = _string_id_boxer,
+	_string_id_l_green_thumb = _string_id_green_thumb,
+	_string_id_l_button_fire = 0xB002658,
+	_string_id_l_button_throw_grenade = 0x14002654,
+	_string_id_l_button_reload = 0xD002659,
+	_string_id_l_button_switch_weapons = 0x1500265A,
+	_string_id_l_button_melee = 0xC00265B,
+	_string_id_l_button_jump = 0xB00265C,
+	_string_id_l_button_swap_grenades = 0x1400265E,
+	_string_id_l_button_flashlight = 0x1100265D,
+	_string_id_l_button_zoom = 0xB00265F,
+	_string_id_l_button_crouch = 0xD002655,
+	_string_id_l_button_score = 0xC002656,
+	_string_id_l_button_pause = 0xC002657,
+	_string_id_l_button_lean_left = 0x10001A41,
+	_string_id_l_button_lean_right = 0x11001A42,
+	_string_id_l_standard_help = 0xD002653,
+	_string_id_l_southpaw_help = 0xD001A3C,
+	_string_id_l_jumpy_help = 0xA001A43,
+	_string_id_l_boxer_help = 0xA001A3D,
+	_string_id_l_greenthumb_help = 0xF001A40,
+	_string_id_l_default_ingame = 0xE002644,
+	_string_id_l_south_paw_ingame = 0x10002661,
+	_string_id_l_jumpy_ingame = 0xC001A45,
+	_string_id_l_boxer_ingame = 0xC002665,
+	_string_id_l_green_thumb_ingame = 0x12002667,
+	_string_id_l_button_boxer_grenade = 0x14001A3F,
+	_string_id_l_button_boxer_melee = 0x12001A3E,
+};
+
+
+
+/* prototypes */
+
+c_button_settings_edit_list::c_button_settings_edit_list(int16 user_flags) :
+	c_list_widget(user_flags),
+	m_slot(this, &c_button_settings_edit_list::handle_item_pressed_event),
+	m_qtr_screen(false)
+{
+	//we dont need s_list_item_datum here as no of list items remain same
+	m_list_data = ui_list_data_new(k_button_setting_list_name, k_total_no_of_button_list_items, sizeof(datum));
+	data_make_valid(m_list_data);
+
+	for (int32 i = 0; i < m_list_data->datum_max_elements; ++i)
+	{
+		datum_new(m_list_data);
+	}
+
+	linker_type2.link(&m_slot);
+}
+
+void c_button_settings_edit_list::set_using_qtr_screen(bool param)
+{
+	this->m_qtr_screen = param;
+}
+
+c_list_item_widget* c_button_settings_edit_list::get_list_items()
+{
+	//return INVOKE_TYPE(0x25D425, 0x0, c_list_item_widget*(__thiscall*)(c_button_settings_edit_list*), this);
+	return this->m_list_items;
+}
+
+int32 c_button_settings_edit_list::get_list_items_count()
+{
+	return k_no_of_visible_items_for_button_settings;
+}
+
+void c_button_settings_edit_list::update_list_items(c_list_item_widget* item, int32 skin_index)
+{
+	//INVOKE_TYPE(0x25D021, 0x0, void(__thiscall*)(c_button_settings_edit_list*, c_list_item_widget*, int32), this, item, skin_index);
+
+	ASSERT(item);
+	c_text_widget* item_text = item->try_find_text_widget(_default_list_skin_text_main);
+
+	if (item_text)
+	{
+		switch (DATUM_INDEX_TO_ABSOLUTE_INDEX(item->get_last_data_index()))
+		{
+		case _item_standard:
+			item_text->set_text_from_string_id(_string_id_l_default);
+			break;
+		case _item_south_paw:
+			item_text->set_text_from_string_id(_string_id_l_south_paw);
+			break;
+		case _item_boxer:
+			item_text->set_text_from_string_id(_string_id_l_boxer);
+			break;
+		case _item_green_thumb:
+			item_text->set_text_from_string_id(_string_id_l_green_thumb);
+			break;
+		default:
+			item_text->set_text_from_string_id(_string_id_invalid);
+			break;
+		}
+	}
+
+}
+
+
+void c_button_settings_edit_list::handle_item_pressed_event(s_event_record** pevent, datum* pitem_index)
+{
+	//INVOKE_TYPE(0x25D0AC, 0x0, void(__thiscall*)(c_button_settings_edit_list*, s_event_record**, datum*), this, pevent, pitem_index);
+
+	s_gamepad_input_preferences preferences;
+	e_button_preset_types selected_preset;
+
+	switch (DATUM_INDEX_TO_ABSOLUTE_INDEX(*pitem_index))
+	{
+	case _item_south_paw:
+		selected_preset = _button_preset_south_paw;
+		break;
+	case _item_boxer:
+		selected_preset = _button_preset_boxer;
+		break;
+	case _item_green_thumb:
+		selected_preset = _button_preset_green_thumb;
+		break;
+	default:
+		selected_preset = _button_preset_default;
+	}
+
+	s_saved_game_player_profile* player_profile = user_interface_globals_get_edit_player_profile();
+
+	player_profile->input_preferences.controller_button_layout = selected_preset;
+	input_abstraction_set_preferences_from_controller_settings(&preferences, &player_profile->input_preferences);
+	input_abstraction_get_default_preferences(&preferences, player_profile->input_preferences.controller_thumbstick_layout, selected_preset, player_profile->input_preferences.keyboard_preset_type, 0);
+	input_abstraction_set_controller_settings_from_preferences(&preferences, &player_profile->input_preferences);
+
+	// apparently ingame setting changes are directly commited to disk unlike settings screen which uses (edit_player_profile)
+	if (this->m_qtr_screen)
+		user_interface_globals_save_profile_changes_to_disk();
+
+	user_interface_back_out_from_channel(this->get_parent_channel(), this->get_parent_render_window());
+}
+
+
+//
+// c_screen_button_settings_menu class starts here
+// 
+
+
+c_screen_button_settings_menu::c_screen_button_settings_menu(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, e_user_interface_screen_id screen_id) :
+	c_screen_with_menu(screen_id, channel_type, window_index, user_flags, &m_button_settings_list),
+	m_button_settings_list(user_flags),
+	field_D3C(NONE)
+{
+}
+
+void c_screen_button_settings_menu::update()
+{
+	INVOKE_TYPE(0x25d180, 0, void(__thiscall*)(c_screen_button_settings_menu*), this);
+}
+
+bool c_screen_button_settings_menu::handle_event(s_event_record* event)
+{
+	return INVOKE_TYPE(0x25d2d0, 0, bool(__thiscall*)(c_screen_button_settings_menu*, s_event_record*), this, event);
+}
+
+void c_screen_button_settings_menu::post_initialize()
+{
+	//INVOKE_TYPE(0x25d229, 0, void(__thiscall*)(c_screen_button_settings_menu*), this);
+
+	//This menu class is designed to handle both button_settings.wgit and button_settings_ingame.wgit together
+	//m_using_qtr_arrows == true only when button_settings_ingame.wgit is being used
+
+	if (this->m_using_qtr_arrows)
+	{
+		c_bitmap_widget* bitmap_down_arrow = this->try_find_bitmap_widget(_button_settings_ingame_bitmap_arrows_down);
+		c_bitmap_widget* bitmap_up_arrow = this->try_find_bitmap_widget(_button_settings_ingame_bitmap_arrows_up);
+		this->set_list_arrows_widget(bitmap_up_arrow, bitmap_down_arrow);
+
+	}
+
+	//player_profile != nullptr when button_settings.wgit is being used inside player profile settings menu
+	s_saved_game_player_profile* player_profile = user_interface_globals_get_edit_player_profile();
+	if (player_profile)
+	{
+		switch (player_profile->input_preferences.controller_button_layout)
+		{
+		case _button_preset_south_paw:
+			this->m_button_settings_list.set_focused_item_index(_item_south_paw);
+			break;
+		case _button_preset_boxer:
+			this->m_button_settings_list.set_focused_item_index(_item_boxer);
+			break;
+		case _button_preset_green_thumb:
+			this->m_button_settings_list.set_focused_item_index(_item_green_thumb);
+			break;
+		default:
+			this->m_button_settings_list.set_focused_item_index(_item_standard);
+
+		}
+	}
+	c_screen_widget::post_initialize();
+}
+
+const void* c_screen_button_settings_menu::load_proc() const
+{
+	//return INVOKE_TYPE(0x256037, 0, void*(__thiscall*)(const c_screen_button_settings_menu*), this);
+	return &c_screen_button_settings_menu::load;
+}
+
+
+void* c_screen_button_settings_menu::load(s_screen_parameters* parameters)
+{
+	//return INVOKE(0x255FA4, 0x0, c_screen_button_settings_menu::load, parameters);
+	c_screen_button_settings_menu* screen;
+
+	void* pool = ui_pool_allocate_space(sizeof(c_screen_button_settings_menu), 0);
+	if (pool)
+	{
+		screen = new (pool) c_screen_button_settings_menu(
+			parameters->m_channel_type,
+			parameters->m_window_index,
+			parameters->user_flags,
+			_screen_pp_button_settings);
+
+		screen->m_allocated = true;
+		screen->m_using_qtr_arrows = false;
+		user_interface_register_screen_to_channel(screen, parameters);
+	}
+	else
+	{
+		screen = NULL;
+	}
+
+	return screen;
+}
+
+void* c_screen_button_settings_menu::load_qtr(s_screen_parameters* parameters)
+{
+	//return INVOKE(0x259DC0, 0x0, c_screen_button_settings_menu::load_qtr, parameters);
+	c_screen_button_settings_menu* screen;
+
+	void* pool = ui_pool_allocate_space(sizeof(c_screen_button_settings_menu), 0);
+	if (pool)
+	{
+		screen = new (pool) c_screen_button_settings_menu(
+			parameters->m_channel_type,
+			parameters->m_window_index,
+			parameters->user_flags,
+			_screen_pp_buttons_qtr); //qtr screen is button_settings_ingame.wgit
+
+		screen->m_allocated = true;
+		screen->m_button_settings_list.set_using_qtr_screen(true);
+		screen->m_using_qtr_arrows = true;
+		user_interface_register_screen_to_channel(screen, parameters);
+	}
+	else
+	{
+		screen = NULL;
+	}
+
+	return screen;
+}
+
+void c_screen_button_settings_menu::apply_instance_patches()
+{
+	//Replace orignal call with custom one inside c_controller_settings_edit_list::handle_item_pressed_event
+	WriteValue(Memory::GetAddress(0x256214) + 4, c_screen_button_settings_menu::load);
+	//Replace orignal call with custom one inside c_multiplayer_controller_settings_list::handle_item_pressed_event
+	WriteValue(Memory::GetAddress(0x259F85) + 4, c_screen_button_settings_menu::load_qtr);
+}

--- a/xlive/Blam/Engine/interface/screens/screen_button_settings.h
+++ b/xlive/Blam/Engine/interface/screens/screen_button_settings.h
@@ -1,0 +1,58 @@
+#include "interface/user_interface_widget.h"
+#include "interface/user_interface_widget_list.h"
+#include "interface/user_interface_widget_list_item.h"
+#include "interface/user_interface_widget_window.h"
+
+
+/* macro defines */
+
+#define k_no_of_visible_items_for_button_settings 4
+
+/* classes */
+
+class c_button_settings_edit_list : public c_list_widget
+{
+protected:
+	c_list_item_widget m_list_items[k_no_of_visible_items_for_button_settings];
+	bool m_qtr_screen;
+	c_slot2<c_button_settings_edit_list, s_event_record*, datum> m_slot;
+
+	void handle_item_pressed_event(s_event_record** pevent, datum* pitem_index);
+
+public:
+	c_button_settings_edit_list(int16 user_flags);
+	void set_using_qtr_screen(bool param);
+
+	// c_button_settings_edit_list virtual functions
+
+	virtual ~c_button_settings_edit_list() = default;
+	virtual c_list_item_widget* get_list_items() override;
+	virtual int32 get_list_items_count() override;
+	virtual void update_list_items(c_list_item_widget* item, int32 skin_index) override;
+
+};
+ASSERT_STRUCT_SIZE(c_button_settings_edit_list, 0x2DC);
+
+class c_screen_button_settings_menu : public c_screen_with_menu
+{
+protected:
+	c_button_settings_edit_list m_button_settings_list;
+	int32 field_D3C; 	// non functional unfinished setting
+	bool m_using_qtr_arrows;
+
+public:
+	static void* load(s_screen_parameters* parameters);
+	static void* load_qtr(s_screen_parameters* parameters);
+	static void apply_instance_patches();
+	c_screen_button_settings_menu(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, e_user_interface_screen_id screen_id);
+
+	// c_screen_button_settings_menu virtual functions
+
+	virtual ~c_screen_button_settings_menu() = default;
+	virtual void update() override;
+	virtual bool handle_event(s_event_record* event) override;
+	virtual void post_initialize() override;
+	virtual const void* load_proc() const override;
+
+};
+ASSERT_STRUCT_SIZE(c_screen_button_settings_menu, 0xD44);

--- a/xlive/Blam/Engine/interface/screens/screen_button_settings.h
+++ b/xlive/Blam/Engine/interface/screens/screen_button_settings.h
@@ -6,7 +6,7 @@
 
 /* macro defines */
 
-#define k_no_of_visible_items_for_button_settings 4
+#define k_no_of_visible_items_for_button_settings 4+1
 
 /* classes */
 
@@ -31,7 +31,7 @@ public:
 	virtual void update_list_items(c_list_item_widget* item, int32 skin_index) override;
 
 };
-ASSERT_STRUCT_SIZE(c_button_settings_edit_list, 0x2DC);
+//ASSERT_STRUCT_SIZE(c_button_settings_edit_list, 0x2DC);
 
 class c_screen_button_settings_menu : public c_screen_with_menu
 {
@@ -43,6 +43,8 @@ protected:
 public:
 	static void* load(s_screen_parameters* parameters);
 	static void* load_qtr(s_screen_parameters* parameters);
+	static void apply_patches_on_ui_map_load();
+	static void apply_patches_on_mp_map_load();
 	static void apply_instance_patches();
 	c_screen_button_settings_menu(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, e_user_interface_screen_id screen_id);
 
@@ -52,7 +54,8 @@ public:
 	virtual void update() override;
 	virtual bool handle_event(s_event_record* event) override;
 	virtual void post_initialize() override;
+	virtual void post_initialize_button_keys() override;
 	virtual const void* load_proc() const override;
 
 };
-ASSERT_STRUCT_SIZE(c_screen_button_settings_menu, 0xD44);
+//ASSERT_STRUCT_SIZE(c_screen_button_settings_menu, 0xD44);

--- a/xlive/Blam/Engine/interface/screens/screen_controller_settings_menu.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_controller_settings_menu.cpp
@@ -1,0 +1,159 @@
+#include "stdafx.h"
+
+#include "screen_controller_settings_menu.h"
+#include "interface/user_interface_globals.h"
+#include "interface/user_interface_widget_list.h"
+#include "interface/user_interface_widget_list_item.h"
+#include "interface/user_interface_widget_text.h"
+#include "tag_files/global_string_ids.h"
+
+/* enums */
+
+enum e_controller_list_items : uint16
+{
+	_item_thumbstick_settings,
+	_item_button_settings,
+	_item_look_sensitivity,
+	_item_invert_look,
+	_item_auto_center,
+	_item_vibration,
+	_item_restore,
+	k_total_no_of_controller_list_items
+};
+
+enum
+{
+	_string_id_l_jumpy = 0x5001A09
+};
+
+
+CLASS_HOOK_DECLARE_LABEL(c_controller_settings_edit_list_update_list_items, c_controller_settings_edit_list::update_list_items);
+void c_controller_settings_edit_list::update_list_items(c_list_item_widget* item, int32 skin_index)
+{
+	//INVOKE_TYPE(0x2551EC, 0x0, void(__thiscall*)(c_controller_settings_edit_list*, c_list_item_widget*, int32), this, item, skin_index);
+
+	ASSERT(item);
+	s_saved_game_player_profile* player_profile = user_interface_globals_get_edit_player_profile();
+	c_text_widget* header_text = item->try_find_text_widget(_settings_list_skin_text_header);
+	c_text_widget* value_text = item->try_find_text_widget(_settings_list_skin_text_value);
+
+	string_id header_string, value_string;
+	switch (DATUM_INDEX_TO_ABSOLUTE_INDEX(item->get_last_data_index()))
+	{
+			case _item_thumbstick_settings:
+				header_string = _string_id_thumbstick_settings;
+				value_string = _string_id_empty_string;
+				switch (player_profile->input_preferences.controller_thumbstick_layout)
+				{
+				case _joystick_preset_default:
+					value_string = _string_id_default;
+					break;
+				case _joystick_preset_south_paw:
+					value_string = _string_id_southpaw;
+					break;
+				case _joystick_preset_legacy:
+					value_string = _string_id_legacy;
+					break;
+				case _joystick_preset_legacy_south_paw:
+					value_string = _string_id_legacy_southpaw;
+					break;
+				}
+				break;
+			case _item_button_settings:
+				header_string = _string_id_button_settings;
+				value_string = _string_id_empty_string;
+				switch (player_profile->input_preferences.controller_button_layout)
+				{
+				case _button_preset_default:
+					value_string = _string_id_default;
+					break;
+				case _button_preset_south_paw:
+					value_string = _string_id_south_paw;
+					break;
+				case _button_preset_boxer:
+					value_string = _string_id_boxer;
+					break;
+				case _button_preset_green_thumb:
+					value_string = _string_id_green_thumb;
+					break;
+					//add jumpy text value to controller_settings menu
+				case _button_preset_jumpy:
+					value_string = _string_id_l_jumpy;
+					break;
+				}
+				break;
+			case _item_look_sensitivity:
+				header_string = _string_id_look_sensitivity;
+				value_string = _string_id_empty_string;
+
+				switch (PIN(player_profile->input_preferences.controller_sensitivity, 1, 10))
+				{
+				case 1:
+					value_string = _string_id_look_sensitivity_1;
+					break;
+				case 2:
+					value_string = _string_id_look_sensitivity_2;
+					break;
+				case 3:
+					value_string = _string_id_look_sensitivity_3;
+					break;
+				case 4:
+					value_string = _string_id_look_sensitivity_4;
+					break;
+				case 5:
+					value_string = _string_id_look_sensitivity_5;
+					break;
+				case 6:
+					value_string = _string_id_look_sensitivity_6;
+					break;
+				case 7:
+					value_string = _string_id_look_sensitivity_7;
+					break;
+				case 8:
+					value_string = _string_id_look_sensitivity_8;
+					break;
+				case 9:
+					value_string = _string_id_look_sensitivity_9;
+					break;
+				case 10:
+					value_string = _string_id_look_sensitivity_10;
+					break;				
+				}
+				break;
+			case _item_invert_look:
+				header_string = _string_id_invert_look;
+				value_string = player_profile->input_preferences.flags.test(_saved_game_profile_input_preference_bit_controller_look_inversion) ? _string_id_enable : _string_id_disable;
+				break;
+			case _item_auto_center:
+				header_string = _string_id_auto_center;
+				value_string = player_profile->input_preferences.flags.test(_saved_game_profile_input_preference_bit_controller_auto_look_centering) ? _string_id_enable : _string_id_disable;
+				break;
+			case _item_vibration:
+				header_string = _string_id_vibration;
+				value_string = player_profile->input_preferences.flags.test(_saved_game_profile_input_preference_bit_vibration_disabled) ? _string_id_off : _string_id_on;
+				break;
+			case _item_restore:
+				header_string = _string_id_restore_controller_defaults;
+				break;
+			default:
+				header_string = _string_id_invalid;
+				value_string = _string_id_empty_string;
+	}
+
+	if (header_text)
+		header_text->set_text_from_string_id(header_string);
+
+	if (value_text)
+		value_text->set_text_from_string_id(value_string);
+
+}
+__declspec(naked) void jmp_c_controller_settings_edit_list_update_list_items()
+{
+	CLASS_HOOK_JMP(c_controller_settings_edit_list_update_list_items, c_controller_settings_edit_list::update_list_items);
+}
+
+void c_controller_settings_edit_list::apply_instance_patches()
+{
+	//Replace orignal vtable function with ours
+	WritePointer(Memory::GetAddress(0x3DA594), jmp_c_controller_settings_edit_list_update_list_items);
+}

--- a/xlive/Blam/Engine/interface/screens/screen_controller_settings_menu.h
+++ b/xlive/Blam/Engine/interface/screens/screen_controller_settings_menu.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class c_list_item_widget;
+
+class c_controller_settings_edit_list // : public c_list_widget
+{
+public:
+	void update_list_items(c_list_item_widget* item, int32 skin_index);
+	static void apply_instance_patches();
+};

--- a/xlive/Blam/Engine/interface/screens/screens_patches.cpp
+++ b/xlive/Blam/Engine/interface/screens/screens_patches.cpp
@@ -14,6 +14,7 @@
 #include "screen_virtual_keyboard.h"
 #include "screen_error_dialog.h"
 #include "screen_button_settings.h"
+#include "screen_controller_settings_menu.h"
 
 void screens_apply_patches_on_map_load()
 {
@@ -44,4 +45,5 @@ void screens_apply_patches()
 	c_screen_error_dialog_ok::apply_patches();
 	c_screen_error_dialog_ok_cancel::apply_patches();
 	c_screen_button_settings_menu::apply_instance_patches();
+	c_controller_settings_edit_list::apply_instance_patches();
 }

--- a/xlive/Blam/Engine/interface/screens/screens_patches.cpp
+++ b/xlive/Blam/Engine/interface/screens/screens_patches.cpp
@@ -22,6 +22,12 @@ void screens_apply_patches_on_map_load()
 	c_screen_multiplayer_pregame_lobby::apply_patches_on_map_load();
 	c_screen_squad_settings::apply_patches_on_map_load();
 	c_screen_settings::apply_patches_on_map_load();
+	c_screen_button_settings_menu::apply_patches_on_ui_map_load();
+}
+
+void screens_apply_patches_on_mp_map_load()
+{
+	c_screen_button_settings_menu::apply_patches_on_mp_map_load();
 }
 
 void screens_apply_patches()

--- a/xlive/Blam/Engine/interface/screens/screens_patches.cpp
+++ b/xlive/Blam/Engine/interface/screens/screens_patches.cpp
@@ -13,6 +13,7 @@
 #include "screen_single_player_profile_select.h"
 #include "screen_virtual_keyboard.h"
 #include "screen_error_dialog.h"
+#include "screen_button_settings.h"
 
 void screens_apply_patches_on_map_load()
 {
@@ -36,4 +37,5 @@ void screens_apply_patches()
 	c_screen_virtual_keyboard::apply_patches();
 	c_screen_error_dialog_ok::apply_patches();
 	c_screen_error_dialog_ok_cancel::apply_patches();
+	c_screen_button_settings_menu::apply_instance_patches();
 }

--- a/xlive/Blam/Engine/interface/screens/screens_patches.h
+++ b/xlive/Blam/Engine/interface/screens/screens_patches.h
@@ -3,5 +3,8 @@
 // Applies patches to ui screens (wgit tags)
 void screens_apply_patches_on_map_load();
 
+// Applies patches to ui screens ingame (wgit tags)
+void screens_apply_patches_on_mp_map_load();
+
 // Applies screen related hooks
 void screens_apply_patches();

--- a/xlive/Blam/Engine/interface/user_interface_globals.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_globals.cpp
@@ -44,3 +44,8 @@ void __cdecl user_interface_globals_commit_edit_profile_changes()
 {
 	INVOKE(0x209A98, 0x0, user_interface_globals_commit_edit_profile_changes);
 }
+
+void __cdecl user_interface_globals_save_profile_changes_to_disk()
+{
+	INVOKE(0x209C3E, 0x0, user_interface_globals_save_profile_changes_to_disk);
+}

--- a/xlive/Blam/Engine/interface/user_interface_globals.h
+++ b/xlive/Blam/Engine/interface/user_interface_globals.h
@@ -45,4 +45,4 @@ e_scenario_type __cdecl user_interface_globals_get_map_type();
 void __cdecl user_interface_globals_set_game_difficulty_real(int32 difficulty);
 void __cdecl user_interface_globals_set_loading_from_persistent_storage(bool a1);
 void __cdecl user_interface_globals_commit_edit_profile_changes();
-
+void __cdecl user_interface_globals_save_profile_changes_to_disk();

--- a/xlive/Blam/Engine/interface/user_interface_widget_list.h
+++ b/xlive/Blam/Engine/interface/user_interface_widget_list.h
@@ -16,6 +16,13 @@ enum e_default_list_skin_texts
 	k_number_of_default_list_skin_texts,
 };
 
+enum e_settings_list_skin_texts
+{
+	_settings_list_skin_text_header = 0,
+	_settings_list_skin_text_value = 1,
+	k_number_of_settings_list_skin_texts,
+};
+
 
 /* structures */
 

--- a/xlive/Blam/Engine/interface/user_interface_widget_list.h
+++ b/xlive/Blam/Engine/interface/user_interface_widget_list.h
@@ -43,7 +43,7 @@ protected:
 	uint16 m_up_arrow_transition_time;
 	uint16 m_down_arrow_transition_time;
 	int32 m_intro_delay_milliseconds;
-	uint16 m_tabbing_count;
+	int16 m_tabbing_count;
 	uint8 gap_7E[2];
 	real_rectangle2d m_up_arrow_position;
 	real_rectangle2d m_down_arrow_position;

--- a/xlive/Blam/Engine/interface/user_interface_widget_window.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_widget_window.cpp
@@ -89,6 +89,13 @@ void c_screen_widget::initialize_button_keys_text(bool add_new_child)
 	return INVOKE_TYPE(0x20FF73, 0x0, void(__thiscall*)(c_screen_widget*, bool), this, add_new_child);
 }
 
+void c_screen_widget::set_list_arrows_widget(c_bitmap_widget* up_arrow, c_bitmap_widget* down_arrow)
+{
+	//INVOKE_TYPE(0x20EF47, 0x0, void(__thiscall*)(c_screen_widget*, c_bitmap_widget*, c_bitmap_widget*), this, up_arrow, down_arrow);;
+	m_special_widgets[_special_widget_type_0] = (c_user_interface_widget*)up_arrow;
+	m_special_widgets[_special_widget_type_0] = (c_user_interface_widget*)down_arrow;
+}
+
 void* c_screen_widget::get_screen_definition()
 {
 	return INVOKE_TYPE(0x20E8A6, 0x0, void*(__thiscall*)(c_screen_widget*), this);

--- a/xlive/Blam/Engine/interface/user_interface_widget_window.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_widget_window.cpp
@@ -93,7 +93,7 @@ void c_screen_widget::set_list_arrows_widget(c_bitmap_widget* up_arrow, c_bitmap
 {
 	//INVOKE_TYPE(0x20EF47, 0x0, void(__thiscall*)(c_screen_widget*, c_bitmap_widget*, c_bitmap_widget*), this, up_arrow, down_arrow);;
 	m_special_widgets[_special_widget_type_0] = (c_user_interface_widget*)up_arrow;
-	m_special_widgets[_special_widget_type_0] = (c_user_interface_widget*)down_arrow;
+	m_special_widgets[_special_widget_type_1] = (c_user_interface_widget*)down_arrow;
 }
 
 void* c_screen_widget::get_screen_definition()

--- a/xlive/Blam/Engine/interface/user_interface_widget_window.h
+++ b/xlive/Blam/Engine/interface/user_interface_widget_window.h
@@ -387,7 +387,7 @@ protected:
 	c_normal_text_widget m_screen_button_key_text;
 	int16 m_pane_index;
 	bool field_9FA;
-	bool field_9FB;
+	int8 field_9FB;
 	bool m_disable_overlay_effect;
 	bool field_9FD;
 	bool field_9FE;

--- a/xlive/Blam/Engine/interface/user_interface_widget_window.h
+++ b/xlive/Blam/Engine/interface/user_interface_widget_window.h
@@ -411,6 +411,7 @@ public:
 	void verify_and_load_from_layout(datum widget_tag, s_interface_expected_screen_layout* expected_layout);
 	void apply_new_representations_to_players(c_player_widget_representation* representations, int32 player_count);
 	void initialize_button_keys_text(bool add_new_child);
+	void set_list_arrows_widget(c_bitmap_widget* up_arrow, c_bitmap_widget* down_arrow);
 	void* get_screen_definition();
 	
 	

--- a/xlive/Blam/Engine/main/game_preferences.cpp
+++ b/xlive/Blam/Engine/main/game_preferences.cpp
@@ -17,3 +17,8 @@ void __cdecl game_preferences_flag_dirty(void)
 	INVOKE(0x323D2, 0x25994, game_preferences_flag_dirty);
 	return;
 }
+
+int32 __cdecl language_get_international_key(e_language lang, int32 value)
+{
+	return INVOKE(0x5E88E, 0x0, language_get_international_key, lang, value);
+}

--- a/xlive/Blam/Engine/main/game_preferences.h
+++ b/xlive/Blam/Engine/main/game_preferences.h
@@ -19,3 +19,5 @@ e_language get_current_language(void);
 void __cdecl global_preferences_initialize(void);
 
 void __cdecl game_preferences_flag_dirty(void);
+
+int32 __cdecl language_get_international_key(e_language lang, int32 value);

--- a/xlive/Blam/Engine/main/game_preferences.h
+++ b/xlive/Blam/Engine/main/game_preferences.h
@@ -2,6 +2,7 @@
 
 enum e_language : uint32
 {
+	_language_invalid = (uint32)NONE,
 	_language_english = 0,
 	_language_japanese = 1,
 	_language_german = 2,

--- a/xlive/Blam/Engine/saved_games/player_profile.cpp
+++ b/xlive/Blam/Engine/saved_games/player_profile.cpp
@@ -9,11 +9,6 @@ void __cdecl saved_game_player_profile_set_default_variant(void* saved_game_vari
 	INVOKE(0x98FD, 0, saved_game_player_profile_set_default_variant, saved_game_variant);
 }
 
-void saved_game_player_profile_set_input_preferences(s_gamepad_input_preferences* input_preferences,
-	s_saved_game_profile_input_preferences* profile_input_preferences)
-{
-	INVOKE(0x61B62, 0, saved_game_player_profile_set_input_preferences, input_preferences, profile_input_preferences);
-}
 
 void saved_game_player_profile_default_new(s_saved_game_player_profile* profile, int32 default_profile_type)
 {
@@ -37,20 +32,20 @@ void saved_game_player_profile_default_new(s_saved_game_player_profile* profile,
 	{
 		if(default_profile_type == 1)
 		{
-			profile->input_preferences.controller_button_layout = 0;
-			profile->input_preferences.controller_thumbstick_layout = 0;
+			profile->input_preferences.controller_button_layout = _button_preset_default;
+			profile->input_preferences.controller_thumbstick_layout = _joystick_preset_default;
 			profile->input_preferences.flags.set(_saved_game_profile_input_preference_flag_controller_look_inversion, true);
 			profile->input_preferences.flags.set(_saved_game_profile_input_preference_flag_mouse_look_inversion, true);
 		}
 	}
 	else
 	{
-		profile->input_preferences.controller_button_layout = 0;
-		profile->input_preferences.controller_thumbstick_layout = 0;
+		profile->input_preferences.controller_button_layout = _button_preset_default;
+		profile->input_preferences.controller_thumbstick_layout = _joystick_preset_default;
 	}
 	saved_game_player_profile_set_default_variant(&profile->variant);
-	input_abstraction_preferences_new(&input_preferences, 0, false, false);
-	saved_game_player_profile_set_input_preferences(&input_preferences, &profile->input_preferences);
+	input_abstraction_get_default_preferences(&input_preferences, _joystick_preset_default, _button_preset_default, _custom_keyboard_preset_right_hold);
+	input_abstraction_set_controller_settings_from_preferences(&input_preferences, &profile->input_preferences);
 }
 
 bool saved_game_player_profile_read_file(uint32 enumerated_file_index, s_saved_game_player_profile* profile)

--- a/xlive/Blam/Engine/saved_games/player_profile.cpp
+++ b/xlive/Blam/Engine/saved_games/player_profile.cpp
@@ -34,8 +34,8 @@ void saved_game_player_profile_default_new(s_saved_game_player_profile* profile,
 		{
 			profile->input_preferences.controller_button_layout = _button_preset_default;
 			profile->input_preferences.controller_thumbstick_layout = _joystick_preset_default;
-			profile->input_preferences.flags.set(_saved_game_profile_input_preference_flag_controller_look_inversion, true);
-			profile->input_preferences.flags.set(_saved_game_profile_input_preference_flag_mouse_look_inversion, true);
+			profile->input_preferences.flags.set(_saved_game_profile_input_preference_bit_controller_look_inversion, true);
+			profile->input_preferences.flags.set(_saved_game_profile_input_preference_bit_mouse_look_inversion, true);
 		}
 	}
 	else

--- a/xlive/Blam/Engine/saved_games/player_profile.cpp
+++ b/xlive/Blam/Engine/saved_games/player_profile.cpp
@@ -44,7 +44,7 @@ void saved_game_player_profile_default_new(s_saved_game_player_profile* profile,
 		profile->input_preferences.controller_thumbstick_layout = _joystick_preset_default;
 	}
 	saved_game_player_profile_set_default_variant(&profile->variant);
-	input_abstraction_get_default_preferences(&input_preferences, _joystick_preset_default, _button_preset_default, _custom_keyboard_preset_right_hold);
+	input_abstraction_get_default_preferences(&input_preferences, _joystick_preset_default, _button_preset_default, _custom_keyboard_preset_right_hold, 0);
 	input_abstraction_set_controller_settings_from_preferences(&input_preferences, &profile->input_preferences);
 }
 

--- a/xlive/Blam/Engine/saved_games/player_profile.h
+++ b/xlive/Blam/Engine/saved_games/player_profile.h
@@ -27,23 +27,22 @@ enum e_saved_game_profile_input_preference_flags : uint32
 
 struct s_saved_game_profile_input_binds
 {
-	uint32 m_bind_count;
-	s_game_function_bind binds[5];
+	uint32 button_count;
+	s_input_button buttons[5];
 };
 
-#pragma pack(push, 1)
 struct s_saved_game_profile_input_preferences
 {
 	c_flags_no_init<e_saved_game_profile_input_preference_flags, uint32, k_saved_game_profile_input_preferences_count> flags;
-	int8 controller_button_layout;
-	int8 controller_thumbstick_layout;
+	e_button_preset_types controller_button_layout;
+	e_joystick_preset_types controller_thumbstick_layout;
 	int8 controller_sensitivity;
 	int8 mouse_sensitivity;
-	int8 data[4];
-	s_saved_game_profile_input_binds input_binds[57];
+	e_custom_keyboard_preset_types keyboard_preset_type;
+	int8 pad[3];
+	s_saved_game_profile_input_binds input_binds[NUMBER_OF_EXTENDED_CONTROL_BUTTONS];
 };
-#pragma pack(pop)
-
+ASSERT_STRUCT_SIZE(s_saved_game_profile_input_preferences, 3660);
 
 struct s_saved_game_player_profile
 {
@@ -62,7 +61,6 @@ ASSERT_STRUCT_SIZE(s_saved_game_player_profile, 4616);
 
 
 void __cdecl saved_game_player_profile_set_default_variant(void* saved_game_variant);
-void __cdecl saved_game_player_profile_set_input_preferences(s_gamepad_input_preferences* input_preferences, s_saved_game_profile_input_preferences* profile_input_preferences);
 
 void saved_game_player_profile_default_new(s_saved_game_player_profile* profile, int32 default_profile_type);
 bool saved_game_player_profile_read_file(uint32 enumerated_file_index, s_saved_game_player_profile* profile);

--- a/xlive/Blam/Engine/saved_games/player_profile.h
+++ b/xlive/Blam/Engine/saved_games/player_profile.h
@@ -14,13 +14,13 @@ struct s_saved_game_profile_variant_info
 
 enum e_saved_game_profile_input_preference_flags : uint32
 {
-	_saved_game_profile_input_preference_flag_controller_look_inversion = 0x1,
-	_saved_game_profile_input_preference_flag_mouse_look_inversion = 0x2,
-	_saved_game_profile_input_preference_flag_vibration_disabled = 0x3,
-	_saved_game_profile_input_preference_flag_4 = 0x4,
-	_saved_game_profile_input_preference_flag_controller_auto_look_centering = 0x5,
-	_saved_game_profile_input_preference_flag_mouse_auto_look_centering = 0x6,
-	_saved_game_profile_input_preference_flag_mouse_dual_wield_inversion = 0x7,
+	_saved_game_profile_input_preference_bit_controller_look_inversion = 0x0,
+	_saved_game_profile_input_preference_bit_mouse_look_inversion = 0x1,
+	_saved_game_profile_input_preference_bit_vibration_disabled = 0x2,
+	_saved_game_profile_input_preference_bit_4 = 0x3,
+	_saved_game_profile_input_preference_bit_controller_auto_look_centering = 0x4,
+	_saved_game_profile_input_preference_bit_mouse_auto_look_centering = 0x5,
+	_saved_game_profile_input_preference_bit_mouse_dual_wield_inversion = 0x6,
 	k_saved_game_profile_input_preferences_count
 };
 

--- a/xlive/Blam/Engine/text/text_group.cpp
+++ b/xlive/Blam/Engine/text/text_group.cpp
@@ -1,0 +1,78 @@
+#include "stdafx.h"
+#include "text_group.h"
+#include "cache/cache_files.h"
+#include "main/game_preferences.h"
+#include "game/game_globals.h"
+#include "tag_files/global_string_ids.h"
+
+
+/* structures */
+struct s_unicode_string_list_reference
+{
+	uint16 strings_index;
+	uint16 strings_count;
+};
+
+
+/* public code */
+
+bool c_language_pack::try_find_string_exists(string_id id, int32 starting_index, int32 max_count)
+{
+	return INVOKE_TYPE(0x3DF4C, 0x0, bool(__thiscall*)(c_language_pack*, string_id, int32, int32), this, id, starting_index, max_count);
+}
+
+utf8* c_language_pack::get_string_utf8(string_id id, int32 starting_index, int32 max_count)
+{
+	return INVOKE_TYPE(0x3DEFD, 0x0, utf8*(__thiscall*)(c_language_pack*, string_id, int32, int32), this, id, starting_index, max_count);
+}
+
+const int32 c_language_pack::get_num_of_strings() const
+{
+	ASSERT(m_strings_count < k_max_strings_per_language);
+
+	return m_strings_count;
+}
+
+void c_language_pack::string_list_get_normal_string(c_language_pack* locale, string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count)
+{
+	INVOKE_TYPE(0x3E332, 0x0, void(__thiscall*)(c_language_pack*, string_id, wchar_t*, int32, int32), locale, id, out_string, strings_start_index, strings_count);
+}
+
+void c_language_pack::get_string_ids(string_id* array, int32 array_size, int32 starting_index, int32 max_count)
+{
+	csmemset(array, _string_id_invalid, array_size);
+	if (data_loaded)
+	{
+		for (int32 itr = starting_index; itr < max_count + starting_index; itr++)
+		{
+			int32 index = itr - starting_index;
+			if (index < array_size)//prevent buffer overrun
+			{
+				array[index] = this->m_string_references[itr].string_id;
+			}
+		}
+	}
+}
+
+void __cdecl string_list_get_normal_string(datum unic_datum, string_id id, wchar_t* out_string)
+{
+	INVOKE(0x3E3AC, 0x0, string_list_get_normal_string, unic_datum, id, out_string);
+}
+
+void __cdecl string_list_get_string_id_list(datum unic_datum, string_id* array, int32 array_size)
+{
+	ASSERT(array);
+	ASSERT(array_size > 0);
+
+	if (unic_datum != NONE)
+	{
+		e_language current_language = get_current_language();
+		int8* unic_tag = (int8*)tag_get_fast(unic_datum);
+		unic_tag += 0x10;
+		s_unicode_string_list_reference list_reference = ((s_unicode_string_list_reference*)unic_tag)[current_language];
+
+
+		s_game_globals* game_globals = scenario_get_game_globals();
+		game_globals->language_pack[current_language].get_string_ids(array, array_size, list_reference.strings_index, list_reference.strings_count);
+	}
+}

--- a/xlive/Blam/Engine/text/text_group.cpp
+++ b/xlive/Blam/Engine/text/text_group.cpp
@@ -33,9 +33,9 @@ const int32 c_language_pack::get_num_of_strings() const
 	return m_strings_count;
 }
 
-void c_language_pack::string_list_get_normal_string(c_language_pack* locale, string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count)
+void c_language_pack::string_list_get_normal_string(string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count)
 {
-	INVOKE_TYPE(0x3E332, 0x0, void(__thiscall*)(c_language_pack*, string_id, wchar_t*, int32, int32), locale, id, out_string, strings_start_index, strings_count);
+	INVOKE_TYPE(0x3E332, 0x0, void(__thiscall*)(c_language_pack*, string_id, wchar_t*, int32, int32), this, id, out_string, strings_start_index, strings_count);
 }
 
 void c_language_pack::get_string_ids(string_id* array, int32 array_size, int32 starting_index, int32 max_count)

--- a/xlive/Blam/Engine/text/text_group.h
+++ b/xlive/Blam/Engine/text/text_group.h
@@ -1,22 +1,39 @@
 #pragma once
 #include "tag_files/string_id.h"
 
+#define k_max_strings_per_language 0x8000
+
+/* structures */
+
 struct s_string_reference
 {
 	string_id string_id;
-	int32 index;
+	int32 buffer_offset;
 };
 
 // TODO add member functions
 class c_language_pack
 {
+public:
+	bool try_find_string_exists(string_id id, int32 starting_index, int32 max_count);
+	utf8* get_string_utf8(string_id id, int32 starting_index, int32 max_count);
+	const int32 get_num_of_strings() const;
+	
+	void string_list_get_normal_string(c_language_pack* locale, string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count);
+	void get_string_ids(string_id* array, int32 array_size, int32 starting_index, int32 max_count);
+
 private:
 	s_string_reference* m_string_references;
-	char* m_string_data;						// this is utf8 string data
-	int32 string_references_size;
+	char** m_strings_buffer;					// this is utf8 string data
+	int32 m_strings_count;
 	int32 m_string_data_size;
-	int32 m_gap_10;
-	int32 m_offset;
-	bool m_loaded;
-	byte m_pad[3];
+	int32 m_string_reference_cache_offset;
+	int32 m_string_data_cache_offset;
+	bool data_loaded;
 };
+ASSERT_STRUCT_SIZE(c_language_pack, 28);
+
+/* public code */
+
+void __cdecl string_list_get_normal_string(datum unic_datum, string_id id, wchar_t* out_string);
+void __cdecl string_list_get_string_id_list(datum unic_datum, string_id* array, int32 array_size);

--- a/xlive/Blam/Engine/text/text_group.h
+++ b/xlive/Blam/Engine/text/text_group.h
@@ -19,7 +19,7 @@ public:
 	utf8* get_string_utf8(string_id id, int32 starting_index, int32 max_count);
 	const int32 get_num_of_strings() const;
 	
-	void string_list_get_normal_string(c_language_pack* locale, string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count);
+	void string_list_get_normal_string(string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count);
 	void get_string_ids(string_id* array, int32 array_size, int32 starting_index, int32 max_count);
 
 private:

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -483,6 +483,7 @@ static bool __cdecl OnMapLoad(s_game_options* options)
 		if (!Memory::IsDedicatedServer())
 		{
 			hud_patches_on_map_load();
+			screens_apply_patches_on_mp_map_load();
 			main_tag_fixes();
 			hud_draw_on_map_load();
 		}

--- a/xlive/H2MOD/GUI/imgui_integration/MOTD.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/MOTD.cpp
@@ -179,7 +179,7 @@ namespace ImGuiHandler
 
 				for (uint16 gamepad_index = 0; gamepad_index < k_number_of_users; gamepad_index++)
 				{
-					if (input_abstraction_globals->input_has_gamepad[gamepad_index] &&
+					if (g_input_abstraction_globals->input_has_gamepad[gamepad_index] &&
 						input_get_gamepad_state(gamepad_index)->button_frames_down[_xinput_gamepad_a])
 					{
 						ImGuiHandler::ToggleWindow(k_motd_window_name);

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -631,6 +631,7 @@
     <ClCompile Include="Blam\Engine\interface\new_hud_draw.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_4way_signin.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_about_dialog.cpp" />
+    <ClCompile Include="Blam\Engine\interface\screens\screen_button_settings.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_error_dialog.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_audio_settings.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_bungie_news.cpp" />
@@ -929,6 +930,7 @@
     <ClInclude Include="Blam\Engine\interface\screens\screens_patches.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_4way_signin.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_about_dialog.h" />
+    <ClInclude Include="Blam\Engine\interface\screens\screen_button_settings.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_error_dialog.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_audio_settings.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_bungie_news.h" />

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -1134,6 +1134,7 @@
     <ClCompile Include="Blam\Engine\text\draw_string.cpp" />
     <ClCompile Include="Blam\Engine\text\font_cache.cpp" />
     <ClCompile Include="Blam\Engine\text\font_group.cpp" />
+    <ClCompile Include="Blam\Engine\text\text_group.cpp" />
     <ClCompile Include="Blam\Engine\text\unicode.cpp" />
     <ClCompile Include="Blam\Engine\units\bipeds.cpp" />
     <ClCompile Include="Blam\Engine\units\biped_definitions.cpp" />

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -632,6 +632,7 @@
     <ClCompile Include="Blam\Engine\interface\screens\screen_4way_signin.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_about_dialog.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_button_settings.cpp" />
+    <ClCompile Include="Blam\Engine\interface\screens\screen_controller_settings_menu.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_error_dialog.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_audio_settings.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_bungie_news.cpp" />
@@ -931,6 +932,7 @@
     <ClInclude Include="Blam\Engine\interface\screens\screen_4way_signin.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_about_dialog.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_button_settings.h" />
+    <ClInclude Include="Blam\Engine\interface\screens\screen_controller_settings_menu.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_error_dialog.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_audio_settings.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_bungie_news.h" />

--- a/xlive/Project_Cartographer.vcxproj.filters
+++ b/xlive/Project_Cartographer.vcxproj.filters
@@ -449,6 +449,7 @@
     <ClCompile Include="Blam\Engine\networking\logic\life_cycle_manager.cpp" />
     <ClCompile Include="Blam\Engine\networking\network_utilities.cpp" />
     <ClCompile Include="Blam\Engine\cseries\cseries.cpp" />
+    <ClCompile Include="Blam\Engine\interface\screens\screen_button_settings.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="3rdparty\miniupnpc\include\miniupnpc\codelength.h" />
@@ -1900,6 +1901,7 @@
     <ClInclude Include="Blam\Engine\game\player_constants.h" />
     <ClInclude Include="3rdparty\SimpleIni\SimpleIni.h" />
     <ClInclude Include="Blam\Engine\networking\network_utilities.h" />
+    <ClInclude Include="Blam\Engine\interface\screens\screen_button_settings.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="resources\Resource.rc" />


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1fdcf095-47bc-462d-8c35-7da76a316e47)

> For those who like to bounce around like bunnies, we made it easier by mapping jump to the left trigger.
* yes it says "left trigger" but its actually "left shoulder" , blame bungie for putting that string ingame

- Added bumper jumper configuration in input_preferences
- Added bumper jumper window_pane to button_settings ui
- Updated `c_language_pack` to support fetching string_id identifier fetching
- Todo : add proper arrows for `Flashlight` and `Swap grenades` action labels in the bitmap