### PR TITLE
fix crash in crash reporter

### DIFF
--- a/xlive/Blam/Engine/cseries/cseries_windows_minidump_logs.cpp
+++ b/xlive/Blam/Engine/cseries/cseries_windows_minidump_logs.cpp
@@ -208,9 +208,13 @@ static void setup_game_options_text(const wchar_t* reports_path)
 
 	FILE* file;
 	errno_t error = _wfopen_s(&file, report_info_path_game_options->get_string(), L"w+");
-	const s_game_options* game_options = game_options_get();
-	if (!error && file != NULL && game_options != NULL)
+
+	const s_main_game_globals* main_game_globals = get_main_game_globals();
+
+	if (!error && file != NULL && main_game_globals != NULL)
 	{
+		const s_game_options* game_options = &main_game_globals->options;
+
 		fwprintf(file, L"GAME OPTIONS\n");
 		fwprintf(file, L"%ls", k_crash_message_header_break);
 


### PR DESCRIPTION
Added 8 to main game globals which was null.
Bypassed the null check we had previously