### PR TITLE
interpolation code cleanup and fixes

### DIFF
--- a/xlive/Blam/Engine/game/game.cpp
+++ b/xlive/Blam/Engine/game/game.cpp
@@ -235,15 +235,12 @@ void __cdecl game_initialize(void)
 	}
 
 	// Interpolation allocation
-	if (shell_tool_type() != _shell_tool_type_editing_tools && !shell_is_dedicated_server())
+	const bool initialize_interpolation = shell_tool_type() != _shell_tool_type_editing_tools && !shell_is_dedicated_server();
+	if (initialize_interpolation)
 	{
 		halo_interpolator_initialize();
-		halo_interpolator_set_interpolation_enabled(true);
 	}
-	else
-	{
-		halo_interpolator_set_interpolation_enabled(false);
-	}
+	halo_interpolator_set_interpolation_enabled(initialize_interpolation);
 	return;
 }
 
@@ -257,6 +254,8 @@ void __cdecl game_dispose(void)
         g_game_systems[system_index].dispose_proc();
     }
     
+	halo_interpolator_dispose();
+
     // reset time resolution to system default on game exit (initialization happens in main_game_time_initialize_hook())
     timeEndPeriod(SYSTEM_TIMER_RESOLUTION_MS);
     return;

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -631,7 +631,7 @@ int32 __cdecl first_person_weapon_build_models(int32 user_index, datum unit_inde
 					{
 						// Get the interpolated matrix and use it if we can interpolate
 						real_matrix4x3 interpolated_adjustment_matrix;
-						bool interpolated_matrix = halo_interpolator_get_interpolated_matrix_from_user_index(user_index, 1u, &interpolated_adjustment_matrix);
+						bool interpolated_matrix = halo_interpolator_get_interpolated_matrix_from_user_index(user_index, 1, &interpolated_adjustment_matrix);
 						real_matrix4x3* adjustment_matrix = (interpolated_matrix ? &interpolated_adjustment_matrix : &first_person_data->adjustment_matrix);
 
 						real_matrix4x3 inverse_adjustment_matrix;

--- a/xlive/Blam/Engine/interface/first_person_weapons.cpp
+++ b/xlive/Blam/Engine/interface/first_person_weapons.cpp
@@ -880,7 +880,7 @@ real_matrix4x3* first_person_weapon_get_relative_node_matrix_interpolated(int32 
 {
 	real_matrix4x3* result = NULL;
 	s_first_person_weapon* first_person_data = first_person_weapons_get(user_index);
-	int32 weapon_slot = first_person_weapon_slot_by_weapon_datum_index(user_index, weapon_index);
+	const int32 weapon_slot = first_person_weapon_slot_by_weapon_datum_index(user_index, weapon_index);
 	if (weapon_slot != NONE)
 	{
 		s_first_person_weapon_data* weapon_data = first_person_weapon_data_get(weapon_slot, first_person_data);

--- a/xlive/Blam/Engine/interface/first_person_weapons.h
+++ b/xlive/Blam/Engine/interface/first_person_weapons.h
@@ -1,11 +1,13 @@
 #pragma once
 #include "animations/animation_manager.h"
 #include "game/players.h"
-#include "math/matrix_math.h"
 
-#define MAXIMUM_NUMBER_OF_FIRST_PERSON_MODELS 4
-#define MAXIMUM_NODES_PER_FIRST_PERSON_MODEL 64
-#define k_first_person_max_weapons 2
+enum
+{
+	MAXIMUM_NUMBER_OF_FIRST_PERSON_MODELS = 4,
+	MAXIMUM_NODES_PER_FIRST_PERSON_MODEL = 64,
+	k_first_person_max_weapons = 2,
+};
 
 enum e_first_person_weapon_data_flags : uint32
 {

--- a/xlive/Blam/Engine/main/interpolator.cpp
+++ b/xlive/Blam/Engine/main/interpolator.cpp
@@ -29,8 +29,6 @@ static object_datum* halo_interpolator_object_can_interpolate(datum object_index
 
 static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position);
 
-static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position);
-
 static void halo_interpolator_clear_data_buffer(s_interpolation_data* interpolation_data);
 
 /* public code */
@@ -227,11 +225,12 @@ void halo_interpolator_setup_new_object(datum object_index)
 	return;
 }
 
-void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count)
+void halo_interpolator_setup_weapon_data(uint32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count)
 {
 	if (g_frame_data_storage && g_interpolation_update_in_progress)
 	{
 		ASSERT(node_matrices);
+		ASSERT(VALID_INDEX(weapon_slot, k_first_person_max_weapons));
 		ASSERT(VALID_INDEX(nodes_count, MAXIMUM_NODES_PER_MODEL));
 		ASSERT(VALID_INDEX(user_index, k_number_of_users));
 
@@ -348,7 +347,7 @@ bool halo_interpolator_get_interpolated_matrix_from_user_index(uint32 user_index
 	return result;
 }
 
-bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node)
+bool halo_interpolator_interpolate_weapon_node(int32 user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node)
 {
 	bool result = false;
 	if (g_interpolation_enabled && !cinematic_in_progress())
@@ -357,6 +356,8 @@ bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation
 			&& g_previous_interpolation_frame_data->initialized
 			&& user_index != NONE)
 		{
+			ASSERT(VALID_INDEX(user_index, k_number_of_users));
+			ASSERT(VALID_INDEX(weapon_slot, k_first_person_max_weapons));
 			datum target_animation_index = g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].animation_index;
 			datum previous_animation_index = g_previous_interpolation_frame_data->weapon_data[user_index][weapon_slot].animation_index;
 			int32 target_node_count = g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].node_count;
@@ -365,6 +366,8 @@ bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation
 			{
 				if (target_node_count > 0 && target_node_count == previous_node_count)
 				{
+					ASSERT(VALID_INDEX(node_index, MAXIMUM_NODES_PER_MODEL));
+
 					matrix4x3_interpolate(
 						&g_previous_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes[node_index],
 						&g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes[node_index],
@@ -378,7 +381,7 @@ bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation
 	return result;
 }
 
-bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_index, int32 weapon_slot, real_matrix4x3** nodes, int32* node_matrices_count)
+bool halo_interpolator_interpolate_weapon(int32 user_index, datum animation_index, int32 weapon_slot, real_matrix4x3** nodes, int32* node_matrices_count)
 {
 	bool result = false;
 	if (g_interpolation_enabled && !cinematic_in_progress())
@@ -390,6 +393,8 @@ bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_inde
 			&& g_previous_interpolation_frame_data->initialized
 			&& user_index != NONE)
 		{
+			ASSERT(VALID_INDEX(user_index, k_number_of_users));
+			ASSERT(VALID_INDEX(weapon_slot, k_first_person_max_weapons));
 			datum target_animation_index = g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].animation_index;
 			datum previous_animation_index = g_previous_interpolation_frame_data->weapon_data[user_index][weapon_slot].animation_index;
 			if (target_animation_index == animation_index && previous_animation_index == target_animation_index)
@@ -398,6 +403,7 @@ bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_inde
 				int32 previous_node_count = g_previous_interpolation_frame_data->weapon_data[user_index][weapon_slot].node_count;
 				if (target_node_count > 0 && target_node_count == previous_node_count)
 				{
+					ASSERT(nodes);
 					*nodes = g_frame_data_intermediate->weapon_data[user_index][weapon_slot].nodes;
 					for (int32 node_index = 0; node_index < target_node_count; node_index++)
 					{
@@ -407,6 +413,8 @@ bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_inde
 							g_interpolator_delta,
 							&g_frame_data_intermediate->weapon_data[user_index][weapon_slot].nodes[node_index]);
 					}
+
+					ASSERT(node_matrices_count);
 					*node_matrices_count = target_node_count;
 					result = true;
 				}
@@ -423,12 +431,14 @@ bool halo_interpolator_interpolate_object_node_matrix(datum object_index, int16 
 	int32 object_absolute_index;
 	if (halo_interpolator_object_can_interpolate(object_index, &object_absolute_index))
 	{
+		ASSERT(VALID_INDEX(node_index, MAXIMUM_NODES_PER_MODEL));
 		real32 distance = distance_squared3d(
 			&g_previous_interpolation_frame_data->object_data[object_absolute_index].node_matrices[node_index].position,
 			&g_target_interpolation_frame_data->object_data[object_absolute_index].node_matrices[node_index].position);
 
 		if (distance < k_interpolation_distance_cutoff)
 		{
+			ASSERT(out_matrix);
 			matrix4x3_interpolate(
 				&g_previous_interpolation_frame_data->object_data[object_absolute_index].node_matrices[node_index],
 				&g_target_interpolation_frame_data->object_data[object_absolute_index].node_matrices[node_index],
@@ -585,12 +595,12 @@ static void halo_interpolator_interpolate_position_data(int32 user_index, int32 
 static void halo_interpolator_clear_data_buffer(s_interpolation_data* interpolation_data)
 {
 	interpolation_data->initialized = false;
-	for (size_t i = 0; i < k_number_of_users; i++)
+	for (size_t user_num = 0; user_num < k_number_of_users; ++user_num)
 	{
-		for (size_t j = 0; j < k_interpolation_first_person_weapon_slot_count; j++)
+		for (size_t fp_weapon_num = 0; fp_weapon_num < k_first_person_max_weapons; ++fp_weapon_num)
 		{
-			interpolation_data->weapon_data[i][j].node_count = 0;
-			interpolation_data->weapon_data[i][j].animation_index = NONE;
+			interpolation_data->weapon_data[user_num][fp_weapon_num].node_count = 0;
+			interpolation_data->weapon_data[user_num][fp_weapon_num].animation_index = NONE;
 		}
 	}
 

--- a/xlive/Blam/Engine/main/interpolator.cpp
+++ b/xlive/Blam/Engine/main/interpolator.cpp
@@ -27,7 +27,7 @@ static real32 halo_interpolator_get_interpolation_time_internal(void);
 
 static object_datum* halo_interpolator_object_can_interpolate(datum object_index, int32* out_abs_object_index);
 
-static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position);
+static void halo_interpolator_interpolate_position_data(int32 user_index, uint32 position_index, real_point3d* position);
 
 static void halo_interpolator_clear_data_buffer(s_interpolation_data* interpolation_data);
 
@@ -225,7 +225,7 @@ void halo_interpolator_setup_new_object(datum object_index)
 	return;
 }
 
-void halo_interpolator_setup_weapon_data(uint32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count)
+void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count)
 {
 	if (g_frame_data_storage && g_interpolation_update_in_progress)
 	{
@@ -242,7 +242,7 @@ void halo_interpolator_setup_weapon_data(uint32 user_index, datum animation_inde
 	return;
 }
 
-void halo_interpolator_set_target_position_data(int32 user_index, int32 position_index, real_matrix4x3* matrix)
+void halo_interpolator_set_target_position_data(int32 user_index, uint32 position_index, real_matrix4x3* matrix)
 {
 	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
 	ASSERT(VALID_INDEX(user_index, k_number_of_users));
@@ -318,7 +318,7 @@ void halo_interpolator_object_populate_interpolation_data(
 	return;
 }
 
-bool halo_interpolator_get_interpolated_matrix_from_user_index(uint32 user_index, uint32 position_index, real_matrix4x3* out)
+bool halo_interpolator_get_interpolated_matrix_from_user_index(int32 user_index, uint32 position_index, real_matrix4x3* out)
 {
 	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
 	ASSERT(VALID_INDEX(user_index, k_number_of_users));
@@ -500,7 +500,7 @@ bool halo_interpolator_interpolate_biped_crouch(datum object_index, real32* out_
 	return interpolate_object;
 }
 
-bool halo_interpolator_interpolate_position_backwards(int32 user_index, int32 position_index, real_point3d* position)
+bool halo_interpolator_interpolate_position_backwards(int32 user_index, uint32 position_index, real_point3d* position)
 {
 	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
 	ASSERT(VALID_INDEX(user_index, k_number_of_users));
@@ -576,7 +576,7 @@ static object_datum* halo_interpolator_object_can_interpolate(datum object_index
 	return result;
 }
 
-static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position)
+static void halo_interpolator_interpolate_position_data(int32 user_index, uint32 position_index, real_point3d* position)
 {
 	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
 	ASSERT(VALID_INDEX(user_index, k_number_of_users));

--- a/xlive/Blam/Engine/main/interpolator.cpp
+++ b/xlive/Blam/Engine/main/interpolator.cpp
@@ -4,47 +4,73 @@
 #include "cutscene/cinematics.h"
 #include "game/game_time.h"
 #include "game/players.h"
+#include "math/matrix_math.h"
 #include "units/bipeds.h"
 
-s_frame_data_storage* g_frame_data_storage = NULL;
+/* globals */
+
+static s_frame_data_storage* g_frame_data_storage = NULL;
+static s_interpolation_data* g_previous_interpolation_frame_data = NULL;
+static s_interpolation_data* g_target_interpolation_frame_data = NULL;
+
+static real32 g_interpolator_delta = 0.f;
+static bool g_interpolation_update_in_progress = false;
+static bool g_interpolation_enabled = false;
+static c_static_flags_no_init<k_maximum_objects_per_map> g_interpolator_object_updated;
+static c_static_flags_no_init<k_maximum_objects_per_map> g_interpolator_object_interpolation_updated;
+
 s_interpolation_data* g_frame_data_intermediate = NULL;
-s_interpolation_data* g_previous_interpolation_frame_data = NULL;
-s_interpolation_data* g_target_interpolation_frame_data = NULL;
 
-real32 g_interpolator_delta = 0.0f;
-bool g_update_in_progress = false;
-bool interpolation_enabled = false;
-c_static_flags_no_init<k_maximum_objects_per_map> g_interpolator_object_updated;
-c_static_flags_no_init<k_maximum_objects_per_map> g_interpolator_object_interpolation_updated;
+/* prototypes */
 
-void halo_interpolator_initialize()
+static real32 halo_interpolator_get_interpolation_time_internal(void);
+
+static object_datum* halo_interpolator_object_can_interpolate(datum object_index, int32* out_abs_object_index);
+
+static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position);
+
+static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position);
+
+static void halo_interpolator_clear_data_buffer(s_interpolation_data* interpolation_data);
+
+/* public code */
+
+void halo_interpolator_initialize(void)
 {
-	g_frame_data_storage = (s_frame_data_storage*)VirtualAlloc(0, sizeof(s_frame_data_storage), MEM_COMMIT, PAGE_READWRITE);
-	g_frame_data_intermediate = (s_interpolation_data*)VirtualAlloc(0, sizeof(s_interpolation_data), MEM_COMMIT, PAGE_READWRITE);
+	g_frame_data_storage = (s_frame_data_storage*)CSERIES_MALLOC(sizeof(s_frame_data_storage));
+	g_frame_data_intermediate = (s_interpolation_data*)CSERIES_MALLOC(sizeof(s_interpolation_data));
 	g_previous_interpolation_frame_data = &g_frame_data_storage->previous_data;
 	g_target_interpolation_frame_data = &g_frame_data_storage->target_data;
+	return;
 }
 
-bool halo_interpolator_is_enabled(void)
+void halo_interpolator_dispose(void)
 {
-	return interpolation_enabled;
+	if (g_frame_data_storage)
+	{
+		CSERIES_FREE(g_frame_data_storage);
+	}
+
+	if (g_frame_data_intermediate)
+	{
+		CSERIES_FREE(g_frame_data_intermediate);
+	}
+
+	g_frame_data_storage = NULL;
+	g_frame_data_intermediate = NULL;
+	return;
 }
 
-bool halo_interpolator_update_in_progress()
+bool halo_interpolator_update_in_progress(void)
 {
-	return g_update_in_progress;
+	return g_interpolation_update_in_progress;
 }
 
 void halo_interpolator_set_interpolation_enabled(bool enabled)
 {
-	interpolation_enabled = enabled;
+	g_interpolation_enabled = enabled;
 	halo_interpolator_clear_buffers();
 	return;
-}
-
-real32 halo_interpolator_get_interpolation_time_internal(void)
-{
-	return MAX(0.0f, MIN(time_globals::get_ticks_fraction_leftover(), 1.0f));
 }
 
 void halo_interpolator_update_delta(void)
@@ -53,38 +79,17 @@ void halo_interpolator_update_delta(void)
 	return;
 }
 
-real32 halo_interpolator_get_update_delta(void)
-{
-	return g_interpolator_delta;
-}
-
 real32 halo_interpolator_get_interpolation_time(void)
 {
-	return (g_update_in_progress ? 0.0f : halo_interpolator_get_interpolation_time_internal());
-}
-
-void halo_interpolator_clear_data_buffer(s_interpolation_data* interpolation_data)
-{
-	interpolation_data->initialized = false;
-	for (size_t i = 0; i < k_number_of_users; i++)
-	{
-		for (size_t j = 0; j < k_interpolation_first_person_weapon_slot_count; j++)
-		{
-			interpolation_data->weapon_data[i][j].node_count = 0;
-			interpolation_data->weapon_data[i][j].animation_index = NONE;
-		}
-	}
-
-	csmemset(interpolation_data->position_data, 0, sizeof(interpolation_data->position_data));
-	return;
+	return (g_interpolation_update_in_progress ? 0.f : halo_interpolator_get_interpolation_time_internal());
 }
 
 void halo_interpolator_clear_buffers(void)
 {
-	if (interpolation_enabled)
+	if (g_interpolation_enabled)
 	{
-		g_update_in_progress = false;
-		g_interpolator_delta = 0.0f;
+		g_interpolation_update_in_progress = false;
+		g_interpolator_delta = 0.f;
 		csmemset(g_frame_data_storage, 0, sizeof(s_frame_data_storage));
 		csmemset(g_frame_data_intermediate, 0, sizeof(s_interpolation_data));
 		halo_interpolator_clear_data_buffer(g_previous_interpolation_frame_data);
@@ -98,12 +103,11 @@ void halo_interpolator_clear_buffers(void)
 
 void halo_interpolator_update_begin(void)
 {
-	s_interpolation_data* p_frame_data;
-
-	if (interpolation_enabled)
+	if (g_interpolation_enabled)
 	{
-		g_update_in_progress = true;
-		p_frame_data = g_previous_interpolation_frame_data;
+		ASSERT(!g_interpolation_update_in_progress);
+		g_interpolation_update_in_progress = true;
+		s_interpolation_data* p_frame_data = g_previous_interpolation_frame_data;
 		g_previous_interpolation_frame_data = g_target_interpolation_frame_data;
 		g_target_interpolation_frame_data = p_frame_data;
 		halo_interpolator_clear_data_buffer(p_frame_data);
@@ -133,42 +137,12 @@ void halo_interpolator_update_end(void)
 			}
 		}
 
-		g_update_in_progress = false;
+		ASSERT(g_interpolation_update_in_progress);
+
+		g_interpolation_update_in_progress = false;
 		g_target_interpolation_frame_data->initialized = true;
 	}
 	return;
-}
-
-object_datum* halo_interpolator_object_can_interpolate(datum object_index, int32* out_abs_object_index)
-{
-	*out_abs_object_index = NONE;
-	uint16 abs_object_index = DATUM_INDEX_TO_ABSOLUTE_INDEX(object_index);
-	if (!interpolation_enabled || cinematic_in_progress())
-		return NULL;
-	if (g_update_in_progress)
-		return NULL;
-	if (!g_target_interpolation_frame_data->initialized)
-		return NULL;
-	if (!g_previous_interpolation_frame_data->initialized)
-		return NULL;
-	if (abs_object_index >= k_maximum_objects_per_map)
-		return NULL;
-	if (g_interpolator_object_interpolation_updated.test(abs_object_index))
-		return NULL;
-
-	*out_abs_object_index = abs_object_index;
-
-	object_datum* result;
-	if (g_previous_interpolation_frame_data->object_data[abs_object_index].object_index != object_index
-		|| g_target_interpolation_frame_data->object_data[abs_object_index].object_index != object_index)
-	{
-		result = NULL;
-	}
-	else
-	{
-		result = (object_datum*)object_try_and_get_and_verify_type(object_index, _object_mask_all);
-	}
-	return result;
 }
 
 bool halo_interpolator_interpolate_center_of_mass(datum object_datum, real_point3d* center_of_mass)
@@ -178,7 +152,7 @@ bool halo_interpolator_interpolate_center_of_mass(datum object_datum, real_point
 
 	if (!halo_interpolator_object_can_interpolate(object_datum, &object_index)) { return 0; }
 
-	float distance = distance_squared3d(
+	const real32 distance = distance_squared3d(
 		&g_previous_interpolation_frame_data->object_data[object_index].center_of_mass,
 		&g_target_interpolation_frame_data->object_data[object_index].center_of_mass);
 
@@ -188,7 +162,7 @@ bool halo_interpolator_interpolate_center_of_mass(datum object_datum, real_point
 		points_interpolate(
 			&g_previous_interpolation_frame_data->object_data[object_index].center_of_mass,
 			&g_target_interpolation_frame_data->object_data[object_index].center_of_mass,
-			halo_interpolator_get_update_delta(),
+			g_interpolator_delta,
 			center_of_mass);
 	}
 	return mass_interpolated;
@@ -221,7 +195,7 @@ bool halo_interpolator_interpolate_object_node_matrices(datum object_index, real
 					matrix4x3_interpolate(
 						&g_previous_interpolation_frame_data->object_data[out_abs_object_index].node_matrices[node_index],
 						&g_target_interpolation_frame_data->object_data[out_abs_object_index].node_matrices[node_index],
-						halo_interpolator_get_update_delta(),
+						g_interpolator_delta,
 						&g_frame_data_intermediate->object_data[out_abs_object_index].node_matrices[node_index]);
 				}
 			}
@@ -238,9 +212,9 @@ bool halo_interpolator_interpolate_object_node_matrices(datum object_index, real
 
 void halo_interpolator_setup_new_object(datum object_index)
 {
-	uint16 abs_object_index = DATUM_INDEX_TO_ABSOLUTE_INDEX(object_index);
+	const uint16 abs_object_index = DATUM_INDEX_TO_ABSOLUTE_INDEX(object_index);
 
-	if (interpolation_enabled && g_update_in_progress && abs_object_index < k_maximum_objects_per_map)
+	if (g_interpolation_enabled && g_interpolation_update_in_progress && abs_object_index < k_maximum_objects_per_map)
 	{
 		if (g_previous_interpolation_frame_data->object_data[abs_object_index].object_index == object_index)
 		{
@@ -253,10 +227,15 @@ void halo_interpolator_setup_new_object(datum object_index)
 	return;
 }
 
-void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, real_matrix4x3* node_matrices, int32 nodes_count)
+void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count)
 {
-	if (g_frame_data_storage && g_update_in_progress)
+	if (g_frame_data_storage && g_interpolation_update_in_progress)
 	{
+		ASSERT(node_matrices);
+		ASSERT(VALID_INDEX(nodes_count, MAXIMUM_NODES_PER_MODEL));
+		ASSERT(VALID_INDEX(user_index, k_number_of_users));
+
+
 		csmemcpy(g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes, node_matrices, sizeof(real_matrix4x3) * nodes_count);
 		g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].animation_index = animation_index;
 		g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].node_count = nodes_count;
@@ -266,7 +245,10 @@ void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index
 
 void halo_interpolator_set_target_position_data(int32 user_index, int32 position_index, real_matrix4x3* matrix)
 {
-	if (g_frame_data_storage && g_update_in_progress)
+	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
+	ASSERT(VALID_INDEX(user_index, k_number_of_users));
+
+	if (g_frame_data_storage && g_interpolation_update_in_progress)
 	{
 		g_target_interpolation_frame_data->position_data[user_index][position_index].node = *matrix;
 		g_target_interpolation_frame_data->position_data[user_index][position_index].initialized = true;
@@ -277,7 +259,7 @@ void halo_interpolator_set_target_position_data(int32 user_index, int32 position
 void halo_interpolator_object_populate_interpolation_data(
 	datum object_index,
 	const real_matrix4x3* node_matrices,
-	int32 nodes_count,
+	uint32 nodes_count,
 	const real_point3d* position,
 	const real_vector3d* forward,
 	const real_vector3d* up,
@@ -285,11 +267,13 @@ void halo_interpolator_object_populate_interpolation_data(
 {
 	object_header_datum* object_header = (object_header_datum*)datum_get(object_header_data_get(), object_index);
 	uint16 abs_object_index = DATUM_INDEX_TO_ABSOLUTE_INDEX(object_index);
-	if (g_frame_data_storage && g_update_in_progress)
+	if (g_frame_data_storage && g_interpolation_update_in_progress)
 	{
+		ASSERT(node_matrices);
+
 		if (abs_object_index < k_maximum_objects_per_map)
 		{
-			object_datum* object = object_get_fast_unsafe(object_index);
+			object_datum* object = (object_datum*)object_get_and_verify_type(object_index, _object_mask_all);
 			if (object->object.flags.test(_object_hidden_bit))
 			{
 				g_target_interpolation_frame_data->object_data[abs_object_index].object_index = NONE;
@@ -299,23 +283,22 @@ void halo_interpolator_object_populate_interpolation_data(
 			}
 			else
 			{
-				bool object_is_biped = TEST_FLAG(FLAG(object_header->type), _object_mask_biped);
-				real32 crouch = 0.0f;
-				if (object_is_biped)
+				ASSERT(VALID_INDEX(nodes_count, MAXIMUM_NODES_PER_MODEL));
+				const unit_datum* unit = (unit_datum*)object_try_and_get_and_verify_type(object_index, _object_mask_unit);
+				if (unit)
 				{
-					biped_datum* biped = (biped_datum*)object;
-					crouch = biped->unit.crouching;
-
-					datum player_index = player_index_from_unit_index(object_index);
+					const datum player_index = player_index_from_unit_index(object_index);
 					if (player_index != NONE)
 					{
-						s_player* player = (s_player*)datum_get(s_player::get_data(), player_index);
+						const s_player* player = (s_player*)datum_get(s_player::get_data(), player_index);
 						if (player->user_index != NONE)
 						{
-							real_point3d point;
+							g_target_interpolation_frame_data->crouch[player->user_index] = unit->unit.crouching;
+
 							// during game update/tick, this will return the current sight position of the biped
 							// ### TODO a proper fix, remove all this backwards camera nonsense
 							// because all nodes/positions are calculated using interpolated values
+							real_point3d point;
 							biped_get_sight_position(object_index, _unit_estimate_none, NULL, NULL, NULL, &point);
 							halo_interpolator_interpolate_position_data(player->user_index, 0, &point);
 						}
@@ -328,7 +311,6 @@ void halo_interpolator_object_populate_interpolation_data(
 				g_target_interpolation_frame_data->object_data[abs_object_index].forward = *forward;
 				g_target_interpolation_frame_data->object_data[abs_object_index].up = *up;
 				g_target_interpolation_frame_data->object_data[abs_object_index].center_of_mass = *center_of_mass;
-				g_target_interpolation_frame_data->object_data[abs_object_index].crouch = crouch;
 				g_interpolator_object_updated.set(abs_object_index, true);
 				g_interpolator_object_interpolation_updated.set(abs_object_index, false);
 			}
@@ -337,8 +319,11 @@ void halo_interpolator_object_populate_interpolation_data(
 	return;
 }
 
-bool halo_interpolator_get_interpolated_matrix_from_user_index(int32 user_index, int32 position_index, real_matrix4x3* out)
+bool halo_interpolator_get_interpolated_matrix_from_user_index(uint32 user_index, uint32 position_index, real_matrix4x3* out)
 {
+	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
+	ASSERT(VALID_INDEX(user_index, k_number_of_users));
+	
 	bool result = false;
 
 	if (g_frame_data_storage)
@@ -348,14 +333,14 @@ bool halo_interpolator_get_interpolated_matrix_from_user_index(int32 user_index,
 		bool target_initialized = target->position_data[user_index][position_index].initialized;
 		if (previous->position_data[user_index][position_index].initialized == target_initialized
 			&& target_initialized
-			&& interpolation_enabled
+			&& g_interpolation_enabled
 			&& !cinematic_in_progress()
-			&& !g_update_in_progress)
+			&& !g_interpolation_update_in_progress)
 		{
 			matrix4x3_interpolate(
 				&previous->position_data[user_index][position_index].node, 
 				&target->position_data[user_index][position_index].node, 
-				halo_interpolator_get_update_delta(), 
+				g_interpolator_delta, 
 				out);
 			result = true;
 		}
@@ -366,7 +351,7 @@ bool halo_interpolator_get_interpolated_matrix_from_user_index(int32 user_index,
 bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node)
 {
 	bool result = false;
-	if (interpolation_enabled && !cinematic_in_progress())
+	if (g_interpolation_enabled && !cinematic_in_progress())
 	{
 		if (g_target_interpolation_frame_data->initialized
 			&& g_previous_interpolation_frame_data->initialized
@@ -383,7 +368,7 @@ bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation
 					matrix4x3_interpolate(
 						&g_previous_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes[node_index],
 						&g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes[node_index],
-						halo_interpolator_get_update_delta(),
+						g_interpolator_delta,
 						out_node);
 					result = true;
 				}
@@ -396,8 +381,11 @@ bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation
 bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_index, int32 weapon_slot, real_matrix4x3** nodes, int32* node_matrices_count)
 {
 	bool result = false;
-	if (interpolation_enabled && !cinematic_in_progress())
+	if (g_interpolation_enabled && !cinematic_in_progress())
 	{
+
+		ASSERT(!g_interpolation_update_in_progress);
+
 		if (g_target_interpolation_frame_data->initialized
 			&& g_previous_interpolation_frame_data->initialized
 			&& user_index != NONE)
@@ -416,7 +404,7 @@ bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_inde
 						matrix4x3_interpolate(
 							&g_previous_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes[node_index],
 							&g_target_interpolation_frame_data->weapon_data[user_index][weapon_slot].nodes[node_index],
-							halo_interpolator_get_update_delta(),
+							g_interpolator_delta,
 							&g_frame_data_intermediate->weapon_data[user_index][weapon_slot].nodes[node_index]);
 					}
 					*node_matrices_count = target_node_count;
@@ -444,7 +432,7 @@ bool halo_interpolator_interpolate_object_node_matrix(datum object_index, int16 
 			matrix4x3_interpolate(
 				&g_previous_interpolation_frame_data->object_data[object_absolute_index].node_matrices[node_index],
 				&g_target_interpolation_frame_data->object_data[object_absolute_index].node_matrices[node_index],
-				halo_interpolator_get_update_delta(),
+				g_interpolator_delta,
 				out_matrix);
 		}
 		result = true;
@@ -470,7 +458,7 @@ bool halo_interpolator_interpolate_object_position(datum object_index, real_poin
 			points_interpolate(
 				&g_previous_interpolation_frame_data->object_data[abs_object_index].position,
 				&g_target_interpolation_frame_data->object_data[abs_object_index].position,
-				halo_interpolator_get_update_delta(),
+				g_interpolator_delta,
 				point);
 		}
 	}
@@ -480,53 +468,42 @@ bool halo_interpolator_interpolate_object_position(datum object_index, real_poin
 bool halo_interpolator_interpolate_biped_crouch(datum object_index, real32* out_crouch)
 {
 	bool interpolate_object = false;
+	const datum player_index = player_index_from_unit_index(object_index);
 
 	// ### TODO add biped check?
 	int32 abs_object_index;
-	if (halo_interpolator_object_can_interpolate(object_index, &abs_object_index))
+	if (player_index != NONE && halo_interpolator_object_can_interpolate(object_index, &abs_object_index))
 	{
-		real32 distance =
-			g_previous_interpolation_frame_data->object_data[abs_object_index].crouch - g_target_interpolation_frame_data->object_data[abs_object_index].crouch;
-		distance *= distance;
-
-		if (distance < k_interpolation_distance_cutoff)
+		const s_player* player = (s_player*)datum_get(s_player::get_data(), player_index);
+		if (player->user_index != NONE)
 		{
-			interpolate_object = true;
-			scale_interpolate(
-				g_previous_interpolation_frame_data->object_data[abs_object_index].crouch,
-				g_target_interpolation_frame_data->object_data[abs_object_index].crouch,
-				halo_interpolator_get_update_delta(),
-				out_crouch);
+			real32 distance = g_previous_interpolation_frame_data->crouch[player->user_index] - g_target_interpolation_frame_data->crouch[player->user_index];
+			distance *= distance;
+			if (distance < k_interpolation_distance_cutoff)
+			{
+				interpolate_object = true;
+				scale_interpolate(g_previous_interpolation_frame_data->crouch[player->user_index], g_target_interpolation_frame_data->crouch[player->user_index], g_interpolator_delta, out_crouch);
+			}
 		}
+		
 	}
 	return interpolate_object;
 }
 
-void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position)
-{
-	if (g_frame_data_storage)
-	{
-		if (g_update_in_progress)
-		{
-			matrix4x3_identity(&g_target_interpolation_frame_data->position_data[user_index][position_index].node);
-			g_target_interpolation_frame_data->position_data[user_index][position_index].node.position = *position;
-			g_target_interpolation_frame_data->position_data[user_index][position_index].initialized = true;
-		}
-	}
-}
-
 bool halo_interpolator_interpolate_position_backwards(int32 user_index, int32 position_index, real_point3d* position)
 {
-	bool result = false;
+	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
+	ASSERT(VALID_INDEX(user_index, k_number_of_users));
 
+	bool result = false;
 	if (g_frame_data_storage)
 	{
 		bool initialized = g_target_interpolation_frame_data->position_data[user_index][position_index].initialized
 			&& g_previous_interpolation_frame_data->position_data[user_index][position_index].initialized;
 		if (initialized
-			&& interpolation_enabled
+			&& g_interpolation_enabled
 			&& !cinematic_in_progress()
-			&& !g_update_in_progress)
+			&& !g_interpolation_update_in_progress)
 		{
 			real32 distance = distance_squared3d(
 				&g_previous_interpolation_frame_data->position_data[user_index][position_index].node.position,
@@ -537,7 +514,7 @@ bool halo_interpolator_interpolate_position_backwards(int32 user_index, int32 po
 				points_interpolate(
 					&g_previous_interpolation_frame_data->position_data[user_index][position_index].node.position,
 					&g_target_interpolation_frame_data->position_data[user_index][position_index].node.position,
-					halo_interpolator_get_update_delta(),
+					g_interpolator_delta,
 					position);
 				result = true;
 			}
@@ -546,3 +523,78 @@ bool halo_interpolator_interpolate_position_backwards(int32 user_index, int32 po
 
 	return result;
 }
+
+/* private code */
+
+static real32 halo_interpolator_get_interpolation_time_internal(void)
+{
+	return MAX(0.0f, MIN(time_globals::get_ticks_fraction_leftover(), 1.0f));
+}
+
+static object_datum* halo_interpolator_object_can_interpolate(datum object_index, int32* out_abs_object_index)
+{
+	*out_abs_object_index = NONE;
+	uint16 abs_object_index = DATUM_INDEX_TO_ABSOLUTE_INDEX(object_index);
+	if (!g_interpolation_enabled || cinematic_in_progress())
+		return NULL;
+
+	ASSERT(object_index != NONE);
+
+	if (g_interpolation_update_in_progress)
+		return NULL;
+	if (!g_target_interpolation_frame_data->initialized)
+		return NULL;
+	if (!g_previous_interpolation_frame_data->initialized)
+		return NULL;
+	if (abs_object_index >= k_maximum_objects_per_map)
+		return NULL;
+	if (g_interpolator_object_interpolation_updated.test(abs_object_index))
+		return NULL;
+
+	*out_abs_object_index = abs_object_index;
+
+	object_datum* result;
+	if (g_previous_interpolation_frame_data->object_data[abs_object_index].object_index != object_index
+		|| g_target_interpolation_frame_data->object_data[abs_object_index].object_index != object_index)
+	{
+		result = NULL;
+	}
+	else
+	{
+		result = (object_datum*)object_try_and_get_and_verify_type(object_index, _object_mask_all);
+	}
+	return result;
+}
+
+static void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position)
+{
+	ASSERT(VALID_INDEX(position_index, k_interpolation_positions_count));
+	ASSERT(VALID_INDEX(user_index, k_number_of_users));
+
+	if (g_frame_data_storage)
+	{
+		if (g_interpolation_update_in_progress)
+		{
+			matrix4x3_identity(&g_target_interpolation_frame_data->position_data[user_index][position_index].node);
+			g_target_interpolation_frame_data->position_data[user_index][position_index].node.position = *position;
+			g_target_interpolation_frame_data->position_data[user_index][position_index].initialized = true;
+		}
+	}
+}
+
+static void halo_interpolator_clear_data_buffer(s_interpolation_data* interpolation_data)
+{
+	interpolation_data->initialized = false;
+	for (size_t i = 0; i < k_number_of_users; i++)
+	{
+		for (size_t j = 0; j < k_interpolation_first_person_weapon_slot_count; j++)
+		{
+			interpolation_data->weapon_data[i][j].node_count = 0;
+			interpolation_data->weapon_data[i][j].animation_index = NONE;
+		}
+	}
+
+	csmemset(interpolation_data->position_data, 0, sizeof(interpolation_data->position_data));
+	return;
+}
+

--- a/xlive/Blam/Engine/main/interpolator.h
+++ b/xlive/Blam/Engine/main/interpolator.h
@@ -88,9 +88,9 @@ bool halo_interpolator_interpolate_object_node_matrices(datum object_index, real
 
 void halo_interpolator_setup_new_object(datum object_datum);
 
-void halo_interpolator_setup_weapon_data(uint32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count);
+void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count);
 
-void halo_interpolator_set_target_position_data(int32 user_index, int32 position_index, real_matrix4x3* matrix);
+void halo_interpolator_set_target_position_data(int32 user_index, uint32 position_index, real_matrix4x3* matrix);
 
 void halo_interpolator_object_populate_interpolation_data(
 	datum object_index,
@@ -101,7 +101,7 @@ void halo_interpolator_object_populate_interpolation_data(
 	const real_vector3d* up,
 	const real_point3d* center_of_mass);
 
-bool halo_interpolator_get_interpolated_matrix_from_user_index(uint32 user_index, uint32 position_index, real_matrix4x3* out);
+bool halo_interpolator_get_interpolated_matrix_from_user_index(int32 user_index, uint32 position_index, real_matrix4x3* out);
 
 bool halo_interpolator_interpolate_weapon_node(int32 user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node);
 
@@ -113,4 +113,4 @@ bool halo_interpolator_interpolate_object_position(datum object_index, real_poin
 
 bool halo_interpolator_interpolate_biped_crouch(datum object_index, real32* out_crouch);
 
-bool halo_interpolator_interpolate_position_backwards(int32 user_index, int32 position_index, real_point3d* position);
+bool halo_interpolator_interpolate_position_backwards(int32 user_index, uint32 position_index, real_point3d* position);

--- a/xlive/Blam/Engine/main/interpolator.h
+++ b/xlive/Blam/Engine/main/interpolator.h
@@ -1,10 +1,19 @@
 #pragma once
 #include "game/player_constants.h"
 #include "models/render_models.h"
+#include "objects/objects.h"
 
-#define k_interpolation_first_person_weapon_slot_count 4
-#define k_interpolation_positions_count 2
+/* constants */
+
+enum
+{
+	k_interpolation_first_person_weapon_slot_count = 4,
+	k_interpolation_positions_count = 2
+};
+
 #define k_interpolation_distance_cutoff 900.0f
+
+/* structures */
 
 struct s_object_interpolation_data
 {
@@ -14,7 +23,6 @@ struct s_object_interpolation_data
 	real_vector3d up;
 	real_point3d center_of_mass;
 	real_matrix4x3 node_matrices[MAXIMUM_NODES_PER_MODEL];
-	real32 crouch;
 };
 //ASSERT_STRUCT_SIZE(s_object_interpolation_data, 0x3400);
 
@@ -39,6 +47,7 @@ struct s_interpolation_data
 	s_object_interpolation_data object_data[k_maximum_objects_per_map];
 	s_weapon_interpolation_data weapon_data[k_number_of_users][k_interpolation_first_person_weapon_slot_count];
 	s_position_interpolation_data position_data[k_number_of_users][k_interpolation_positions_count];
+	real32 crouch[k_number_of_users];
 };
 //ASSERT_STRUCT_SIZE(s_interpolation_data, 0x1A33F04);
 
@@ -49,17 +58,22 @@ struct s_frame_data_storage
 };
 //ASSERT_STRUCT_SIZE(s_frame_data_storage, 0x3467E08);
 
+/* globals */
+
 extern s_interpolation_data* g_frame_data_intermediate;
 
-void halo_interpolator_initialize();
+/* prototypes */
 
-bool halo_interpolator_is_enabled(void);
+void halo_interpolator_initialize(void);
+
+void halo_interpolator_dispose(void);
+
 bool halo_interpolator_update_in_progress(void);
+
 void halo_interpolator_set_interpolation_enabled(bool enabled);
 
 void halo_interpolator_update_delta(void);
 
-real32 halo_interpolator_get_update_delta(void);
 real32 halo_interpolator_get_interpolation_time(void);
 
 void halo_interpolator_clear_buffers(void);
@@ -71,24 +85,25 @@ void halo_interpolator_update_end(void);
 bool halo_interpolator_interpolate_center_of_mass(datum object_datum, real_point3d* center_of_mass);
 
 bool halo_interpolator_interpolate_object_node_matrices(datum object_index, real_matrix4x3** node_matrices, int32* out_node_count);
-bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node);
 
 void halo_interpolator_setup_new_object(datum object_datum);
 
-void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, real_matrix4x3* node_matrices, int32 nodes_count);
+void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count);
 
 void halo_interpolator_set_target_position_data(int32 user_index, int32 position_index, real_matrix4x3* matrix);
 
 void halo_interpolator_object_populate_interpolation_data(
 	datum object_index,
 	const real_matrix4x3* node_matrices,
-	int32 nodes_count,
+	uint32 nodes_count,
 	const real_point3d* position,
 	const real_vector3d* forward,
 	const real_vector3d* up,
 	const real_point3d* center_of_mass);
 
-bool halo_interpolator_get_interpolated_matrix_from_user_index(int32 user_index, int32 position_index, real_matrix4x3* out);
+bool halo_interpolator_get_interpolated_matrix_from_user_index(uint32 user_index, uint32 position_index, real_matrix4x3* out);
+
+bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node);
 
 bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_index, int32 weapon_slot, real_matrix4x3** nodes, int32* node_matrices_count);
 
@@ -97,7 +112,5 @@ bool halo_interpolator_interpolate_object_node_matrix(datum object_index, int16 
 bool halo_interpolator_interpolate_object_position(datum object_index, real_point3d* point);
 
 bool halo_interpolator_interpolate_biped_crouch(datum object_index, real32* out_crouch);
-
-void halo_interpolator_interpolate_position_data(int32 user_index, int32 position_index, real_point3d* position);
 
 bool halo_interpolator_interpolate_position_backwards(int32 user_index, int32 position_index, real_point3d* position);

--- a/xlive/Blam/Engine/main/interpolator.h
+++ b/xlive/Blam/Engine/main/interpolator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "game/player_constants.h"
+#include "interface/first_person_weapons.h"
 #include "models/render_models.h"
 #include "objects/objects.h"
 
@@ -7,7 +8,6 @@
 
 enum
 {
-	k_interpolation_first_person_weapon_slot_count = 4,
 	k_interpolation_positions_count = 2
 };
 
@@ -45,7 +45,7 @@ struct s_interpolation_data
 {
 	bool initialized;
 	s_object_interpolation_data object_data[k_maximum_objects_per_map];
-	s_weapon_interpolation_data weapon_data[k_number_of_users][k_interpolation_first_person_weapon_slot_count];
+	s_weapon_interpolation_data weapon_data[k_number_of_users][k_first_person_max_weapons];
 	s_position_interpolation_data position_data[k_number_of_users][k_interpolation_positions_count];
 	real32 crouch[k_number_of_users];
 };
@@ -88,7 +88,7 @@ bool halo_interpolator_interpolate_object_node_matrices(datum object_index, real
 
 void halo_interpolator_setup_new_object(datum object_datum);
 
-void halo_interpolator_setup_weapon_data(int32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count);
+void halo_interpolator_setup_weapon_data(uint32 user_index, datum animation_index, int32 weapon_slot, const real_matrix4x3* node_matrices, uint32 nodes_count);
 
 void halo_interpolator_set_target_position_data(int32 user_index, int32 position_index, real_matrix4x3* matrix);
 
@@ -103,9 +103,9 @@ void halo_interpolator_object_populate_interpolation_data(
 
 bool halo_interpolator_get_interpolated_matrix_from_user_index(uint32 user_index, uint32 position_index, real_matrix4x3* out);
 
-bool halo_interpolator_interpolate_weapon_node(datum user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node);
+bool halo_interpolator_interpolate_weapon_node(int32 user_index, datum animation_index, int32 node_index, int32 weapon_slot, real_matrix4x3* out_node);
 
-bool halo_interpolator_interpolate_weapon(datum user_index, datum animation_index, int32 weapon_slot, real_matrix4x3** nodes, int32* node_matrices_count);
+bool halo_interpolator_interpolate_weapon(int32 user_index, datum animation_index, int32 weapon_slot, real_matrix4x3** nodes, int32* node_matrices_count);
 
 bool halo_interpolator_interpolate_object_node_matrix(datum object_index, int16 node_index, real_matrix4x3* out_matrix);
 


### PR DESCRIPTION
- only setup crouching interpolation for k_number_of_users instead of for every object (only users need to use this code for fp camera)
- make sure we free the memory we allocate for the interpolation structs
- make some functions private