### PR TITLE
render changes and hud corruption fix when using the address sanitizer

### DIFF
--- a/xlive/Blam/Engine/cseries/cseries.h
+++ b/xlive/Blam/Engine/cseries/cseries.h
@@ -78,8 +78,17 @@ extern bool g_catch_exceptions;
 // ADDR_SERVER: file offset in h2server.exe
 // TYPE: function
 // __VA_ARGS__: arguments for the function we want to invoke
-#define INVOKE_BY_TYPE(_addr_client, _addr_server, _type, ...) \
+// NOTE:
+// if server or client is equal to 0 then we pass the same address for both (ONLY ON RELEASE BUILDS)
+// REASON:
+// optimizes out a cmov or related instruction when building release whenever we call a function that doesn't have a dedi address specified
+#ifdef NDEBUG
+#define INVOKE_BY_TYPE(_addr_client, _addr_server, _type, ...)	\
+Memory::GetAddress<_type>(_addr_client == 0 ? _addr_server : _addr_client, _addr_server == 0 ? _addr_client : _addr_server)(__VA_ARGS__)
+#else
+#define INVOKE_BY_TYPE(_addr_client, _addr_server, _type, ...)	\
 Memory::GetAddress<_type>(_addr_client, _addr_server)(__VA_ARGS__)
+#endif
 
 #define INVOKE(_addr_client, _addr_server, _fn_decl, ...) INVOKE_BY_TYPE(_addr_client, _addr_server, decltype(_fn_decl)*, __VA_ARGS__)
 // ### TODO find better name

--- a/xlive/Blam/Engine/effects/effects.cpp
+++ b/xlive/Blam/Engine/effects/effects.cpp
@@ -45,7 +45,7 @@ void __cdecl effects_frame_advance(real32 dt)
 
 void __cdecl effect_update(datum effect_index, real32 dt)
 {
-	void* fn = Memory::GetAddress<void*>(0xAA9FF, 0x0);
+	void* fn = Memory::GetAddress<void*>(0xAA9FF);
 
 	__asm
 	{

--- a/xlive/Blam/Engine/geometry/geometry_definitions_new.h
+++ b/xlive/Blam/Engine/geometry/geometry_definitions_new.h
@@ -1,8 +1,9 @@
 #pragma once
 #include "math/color_math.h"
 #include "rasterizer/rasterizer_vertex_buffers.h"
-#include "tag_files/tag_reference.h"
 #include "tag_files/data_reference.h"
+#include "tag_files/tag_reference.h"
+#include "tag_files/tag_block.h"
 
 /* constants */
 

--- a/xlive/Blam/Engine/interface/new_hud.cpp
+++ b/xlive/Blam/Engine/interface/new_hud.cpp
@@ -67,7 +67,7 @@ s_new_hud_temporary_user_state* get_new_hud_temporary_user_state(int32 local_use
 	return &Memory::GetAddress<s_new_hud_temporary_user_state*>(0x9766D0, 0)[local_user_index];
 }
 
-void __cdecl new_hud_widget_anchor_calculate_point(e_hud_anchor anchor, real_point2d* out_point)
+void __cdecl new_hud_widget_anchor_calculate_point(int32 anchor, real_point2d* out_point)
 {
 	INVOKE(0x223969, 0, new_hud_widget_anchor_calculate_point, anchor, out_point);
 	return;

--- a/xlive/Blam/Engine/interface/new_hud.h
+++ b/xlive/Blam/Engine/interface/new_hud.h
@@ -116,7 +116,7 @@ void __cdecl new_hud_engine_globals_set_drawing_player_index(datum player_datum)
 s_hud_scripted_globals* get_hud_scripted_globals(void);
 s_new_hud_temporary_user_state* get_new_hud_temporary_user_state(int32 local_user_index);
 
-void __cdecl new_hud_widget_anchor_calculate_point(e_hud_anchor anchor, real_point2d* out_point);
+void __cdecl new_hud_widget_anchor_calculate_point(int32 anchor, real_point2d* out_point);
 
 uint32 __cdecl new_hud_text_get_split_screen_font_type(e_hud_anchor anchor);
 

--- a/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
@@ -228,7 +228,7 @@ void __declspec(naked) jmp_c_screen_virtual_keyboard__load_player_profile_edit()
 
 void c_screen_virtual_keyboard::apply_patches()
 {
-	DETOUR_ATTACH(p_load_player_profile_edit, Memory::GetAddress<t_load_player_profile_edit>(0x23C7B2, 0x0), jmp_c_screen_virtual_keyboard__load_player_profile_edit);
+	DETOUR_ATTACH(p_load_player_profile_edit, Memory::GetAddress<t_load_player_profile_edit>(0x23C7B2), jmp_c_screen_virtual_keyboard__load_player_profile_edit);
 }
 
 void ui_set_virtual_keyboard_in_use(bool state)

--- a/xlive/Blam/Engine/interface/user_interface.cpp
+++ b/xlive/Blam/Engine/interface/user_interface.cpp
@@ -105,7 +105,7 @@ void __cdecl user_interface_update(real32 dt)
 	user_interface_precise_accumulator_msec += (dt * 1000.f) - floor(dt * 1000.f);
 	if (user_interface_precise_accumulator_msec >= 1.f)
 	{
-		*Memory::GetAddress<int32*>(0x971900, 0x0) += (int32)user_interface_precise_accumulator_msec;
+		*Memory::GetAddress<int32*>(0x971900) += (int32)user_interface_precise_accumulator_msec;
 		user_interface_precise_accumulator_msec -= (int32)user_interface_precise_accumulator_msec;
 	}
 

--- a/xlive/Blam/Engine/objects/objects.cpp
+++ b/xlive/Blam/Engine/objects/objects.cpp
@@ -1208,7 +1208,7 @@ static void objects_apply_interpolation_patches(void)
 
 		PatchCall(Memory::GetAddress(0x4A53C, 0x437BA), objects_post_update);
 		PatchCall(Memory::GetAddress(0xCD744, 0xB8ABD), object_get_origin_interpolated);
-		PatchCall(Memory::GetAddress(0x1549AE, 0x0), object_get_origin_interpolated);
+		PatchCall(Memory::GetAddress(0x1549AE), object_get_origin_interpolated);
 		PatchCall(Memory::GetAddress(0x13D406, 0x12C255), object_get_center_of_mass_interpolated);
 
 		// Prevents the game from passing the runtime_node_flags to the animation manager when updating object_node_matricies
@@ -1240,8 +1240,8 @@ static void object_get_markers_by_string_id_replace_calls(void)
 	// PatchCall(Memory::GetAddress(0x138257, 0x1214CB), internal_object_get_markers_by_string_id);	(Disabled as this is not interpolated)	TODO: Add parameter to internal_object_get_markers_by_string_id instead of not patchcalling
 	// PatchCall(Memory::GetAddress(0x134C26, 0x123AF6), internal_object_get_markers_by_string_id);	// object_animation_callback
 
-	PatchCall(Memory::GetAddress(0xAAFA4, 0x0), object_get_markers_by_string_id);			// Function for creating effects at markers
-	PatchCall(Memory::GetAddress(0xFDF7D, 0x0), object_get_markers_by_string_id);			// effect_on_new_object_marker	
+	PatchCall(Memory::GetAddress(0xAAFA4), object_get_markers_by_string_id);			// Function for creating effects at markers
+	PatchCall(Memory::GetAddress(0xFDF7D), object_get_markers_by_string_id);			// effect_on_new_object_marker	
 	return;
 }
 

--- a/xlive/Blam/Engine/objects/scenery.h
+++ b/xlive/Blam/Engine/objects/scenery.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "object_definition.h"
-
+#include "objects.h"
 
 /* enums */
 
@@ -22,7 +22,8 @@ enum e_scenery_lightmapping_policy : int16
 {
 	_scenery_lightmapping_policy_per_vertex = 0,
 	_scenery_lightmapping_policy_per_pixel = 1,		// not implemented
-	_scenery_lightmapping_policy_dynamic = 2
+	_scenery_lightmapping_policy_dynamic = 2,
+	_scenery_lightmapping_policy_none = NONE
 };
 
 /* structures */
@@ -47,3 +48,21 @@ struct scenery_definition
 	_scenery_definition scenery;
 };
 ASSERT_STRUCT_SIZE(scenery_definition, 196);
+
+
+struct _scenery_datum
+{
+	uint32 flags;
+	int16 field_4;
+	e_scenery_pathfinding_policy pathfinding_policy;
+	int32 lightmapping_policy;	// e_scenery_lightmapping_policy
+	int32 field_C;
+};
+
+struct scenery_datum
+{
+	datum definition_index;
+	_object_datum object;
+	_scenery_datum scenery;
+};
+ASSERT_STRUCT_SIZE(scenery_datum, 316)

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_main.cpp
@@ -241,7 +241,7 @@ void rasterizer_dx9_main_apply_patches(void)
 	//PatchCall(Memory::GetAddress(0x2220CA), DrawPrimitiveUP_hook_get_vertex_decl);
 	//PatchCall(Memory::GetAddress(0x27D746), DrawPrimitiveUP_hook_get_vertex_decl);
 
-	DETOUR_ATTACH(p_rasterizer_dx9_set_texture_stage, Memory::GetAddress<rasterizer_dx9_set_texture_stage_t>(0x25F600, 0x0), rasterizer_dx9_set_texture_direct);
+	DETOUR_ATTACH(p_rasterizer_dx9_set_texture_stage, Memory::GetAddress<rasterizer_dx9_set_texture_stage_t>(0x25F600), rasterizer_dx9_set_texture_direct);
 
 	// Patch initialize code with our own to detect sm3 support
 	PatchCall(Memory::GetAddress(0x263526), rasterizer_dx9_device_initialize);

--- a/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_water.cpp
+++ b/xlive/Blam/Engine/rasterizer/dx9/rasterizer_dx9_water.cpp
@@ -19,8 +19,8 @@ bool __cdecl rasterizer_dx9_update_water_refraction_surface(void);
 
 void rasterizer_dx9_water_apply_patches(void)
 {
-	PatchCall(Memory::GetAddress(0x1A07B5, 0x0), rasterizer_dx9_update_water_refraction_surface);
-	PatchCall(Memory::GetAddress(0x28158F, 0x0), rasterizer_dx9_update_water_refraction_surface);
+	PatchCall(Memory::GetAddress(0x1A07B5), rasterizer_dx9_update_water_refraction_surface);
+	PatchCall(Memory::GetAddress(0x28158F), rasterizer_dx9_update_water_refraction_surface);
 	return;
 }
 

--- a/xlive/Blam/Engine/render/render.cpp
+++ b/xlive/Blam/Engine/render/render.cpp
@@ -120,11 +120,6 @@ int32 get_global_render_window_count()
 	return *Memory::GetAddress<int32*>(0x4E6974);
 }
 
-bool get_global_render_split_horizontally()
-{
-	return (*Memory::GetAddress<int32*>(0x4E6970) == 1);
-}
-
 e_controller_index global_render_current_controller_index()
 {
 	return g_render_current_controller_index;
@@ -384,26 +379,26 @@ void __cdecl render_scene(
 			* DO NOT ENABLE THIS (for now)
 			* Causes graphical issues on the start of outskirts with black geo being rendered
 			rasterizer_dx9_perf_event_begin("texaccum", NULL);
-			DRAW_RENDER_LAYER(_render_layer_texture_accumulate);
+			render_scene_geometry(_collection_type_0, _render_layer_texture_accumulate);
 			rasterizer_dx9_perf_event_end("texaccum");
 			*/
 
 			rasterizer_dx9_perf_event_begin("lightmap_indirect", NULL);
-			DRAW_RENDER_LAYER(_render_layer_lightmap_indirect);
+			render_scene_geometry(_collection_type_0, _render_layer_lightmap_indirect);
 			rasterizer_dx9_perf_event_end("lightmap_indirect");
 
 			rasterizer_dx9_perf_event_begin("sh_prt", NULL);
-			DRAW_RENDER_LAYER(_render_layer_spherical_harmonics_prt);
+			render_scene_geometry(_collection_type_0, _render_layer_spherical_harmonics_prt);
 			rasterizer_dx9_perf_event_end("sh_prt");
 
 			g_dx9_dont_draw_to_depth_target_if_mrt_is_used = true;
 
 			rasterizer_dx9_perf_event_begin("environment_map", NULL);
-			DRAW_RENDER_LAYER(_render_layer_enviroment_map);
+			render_scene_geometry(_collection_type_0, _render_layer_enviroment_map);
 			rasterizer_dx9_perf_event_end("environment_map");
 
 			rasterizer_dx9_perf_event_begin("decal", NULL);
-			DRAW_RENDER_LAYER(_render_layer_decal);
+			render_scene_geometry(_collection_type_0, _render_layer_decal);
 			rasterizer_dx9_perf_event_end("decal");
 
 
@@ -421,7 +416,7 @@ void __cdecl render_scene(
 			rasterizer_dx9_perf_event_end("render_cinematic_lightmap_shadows");
 
 			rasterizer_dx9_perf_event_begin("selfillumination", NULL);
-			DRAW_RENDER_LAYER(_render_layer_selfillumination);
+			render_scene_geometry(_collection_type_0, _render_layer_selfillumination);
 			rasterizer_dx9_perf_event_end("selfillumination");
 
 			rasterizer_dx9_perf_event_begin("render_lights_new", NULL);
@@ -438,7 +433,7 @@ void __cdecl render_scene(
 			rasterizer_dx9_perf_event_end("decals_alpha_blend");
 
 			rasterizer_dx9_perf_event_begin("overlay", NULL);
-			DRAW_RENDER_LAYER(_render_layer_overlay);
+			render_scene_geometry(_collection_type_0, _render_layer_overlay);
 			rasterizer_dx9_perf_event_end("overlay");
 
 			rasterizer_dx9_perf_event_begin("decals", NULL);
@@ -474,20 +469,20 @@ void __cdecl render_scene(
 			* DO NOT ENABLE THIS (for now)
 			* Causes graphical issues on the start of outskirts with black geo being rendered
 			rasterizer_dx9_perf_event_begin("texaccum", NULL);
-			DRAW_RENDER_LAYER(_render_layer_texture_accumulate);
+			render_scene_geometry(_collection_type_0, _render_layer_texture_accumulate);
 			rasterizer_dx9_perf_event_end("texaccum");
 			*/
 
 			rasterizer_dx9_perf_event_begin("lightmap_indirect", NULL);
-			DRAW_RENDER_LAYER(_render_layer_lightmap_indirect);
+			render_scene_geometry(_collection_type_0, _render_layer_lightmap_indirect);
 			rasterizer_dx9_perf_event_end("lightmap_indirect");
 
 			rasterizer_dx9_perf_event_begin("sh_prt", NULL);
-			DRAW_RENDER_LAYER(_render_layer_spherical_harmonics_prt);
+			render_scene_geometry(_collection_type_0, _render_layer_spherical_harmonics_prt);
 			rasterizer_dx9_perf_event_end("sh_prt");
 
 			rasterizer_dx9_perf_event_begin("overlay", NULL);
-			DRAW_RENDER_LAYER(_render_layer_overlay);
+			render_scene_geometry(_collection_type_0, _render_layer_overlay);
 			rasterizer_dx9_perf_event_end("overlay");
 		}
 
@@ -495,7 +490,7 @@ void __cdecl render_scene(
 		if (render_layer_debug_view == 2)
 		{
 render_layer_2:
-			DRAW_RENDER_LAYER(_render_layer_transparent);
+			render_scene_geometry(_collection_type_0, _render_layer_transparent);
 			
 			if (render_layer_debug_view != 2)
 			{
@@ -549,9 +544,9 @@ render_postprocess:
 					else
 					{
 						c_render_primitive_list* list_type = render_primitive_get_by_primitive_list_type(0);
-						list_type->m_field_4 = 0;
+						list_type->m_primitive_count = 0;
 						list_type->m_field_C = 0;
-						list_type->m_render_layer_flags.clear();
+						list_type->m_render_layer_flags = 0;
 						rasterizer_transparent_geometry_reset_counts();
 						render_camera_scene(
 							render_layer_debug_view,
@@ -573,7 +568,7 @@ render_postprocess:
 					goto render_scene_end;
 				}
 
-				DRAW_RENDER_LAYER(_render_layer_selfibloomination);
+				render_scene_geometry(_collection_type_0, _render_layer_selfibloomination);
 			}
 
 			if (effect_flag != 2)
@@ -620,8 +615,8 @@ render_postprocess:
 
 					*global_rasterizer_pixel_shader_index_get() = 1;
 
-					DRAW_RENDER_LAYER(_render_layer_lightmap_indirect);
-					DRAW_RENDER_LAYER(_render_layer_spherical_harmonics_prt);
+					render_scene_geometry(_collection_type_0, _render_layer_lightmap_indirect);
+					render_scene_geometry(_collection_type_0, _render_layer_spherical_harmonics_prt);
 
 					rasterizer_dx9_perf_event_end("render depth to backbuffer");
 				}
@@ -636,7 +631,7 @@ render_postprocess:
 				}
 
 				render_atmospheric_fog();
-				DRAW_RENDER_LAYER(_render_layer_fog);
+				render_scene_geometry(_collection_type_0, _render_layer_fog);
 			}
 		}
 
@@ -652,8 +647,8 @@ render_postprocess:
 			if (water_enabled)
 			{
 				const c_render_primitive_list* list_type = render_primitive_get_by_primitive_list_type(0);
-				clear_target = list_type->is_layer_different(_render_layer_water_alpha_masks);
-				DRAW_RENDER_LAYER(_render_layer_water_alpha_masks);
+				clear_target = list_type->test_layer(_render_layer_water_alpha_masks);
+				render_scene_geometry(_collection_type_0, _render_layer_water_alpha_masks);
 			}
 
 			render_water(water_enabled, clear_target);

--- a/xlive/Blam/Engine/render/render.cpp
+++ b/xlive/Blam/Engine/render/render.cpp
@@ -526,7 +526,7 @@ render_layer_2:
 				!g_fog_result->field_96)
 			{
 				rasterizer_dx9_perf_event_begin("patchy_fog", NULL);
-				render_patchy_fog(*visible_geometry_group_count_get() <= 0, true);
+				render_patchy_fog(render_section_visibility_get_model_group_count() <= 0, true);
 				rasterizer_dx9_perf_event_end("patchy_fog");
 			}
 
@@ -679,7 +679,7 @@ render_widgets:
 			{
 				render_patchy_fog(1, 1);
 			}
-			else if (*visible_geometry_group_count_get() > 0)
+			else if (render_section_visibility_get_model_group_count() > 0)
 			{
 				render_patchy_fog(1, 0);
 			}

--- a/xlive/Blam/Engine/render/render.h
+++ b/xlive/Blam/Engine/render/render.h
@@ -98,8 +98,6 @@ window_bound* get_user_window_bounds(int32 user_index);
 
 int32 get_global_render_window_count();
 
-bool get_global_render_split_horizontally();
-
 e_controller_index global_render_current_controller_index();
 
 uint32 global_render_current_user_index();

--- a/xlive/Blam/Engine/render/render_layers.h
+++ b/xlive/Blam/Engine/render/render_layers.h
@@ -52,14 +52,3 @@ bool __cdecl prepare_render_layer(e_render_layer layer);
 void __cdecl draw_render_layer(void);
 
 void __cdecl reset_after_render_layer_draw(void);
-
-
-/* macros */
-
-#define DRAW_RENDER_LAYER(layer)		\
-if (prepare_render_layer((layer)))		\
-{										\
-	draw_render_layer();				\
-	reset_after_render_layer_draw();	\
-}										\
-(void)0 // This forces the use of a semicolon after the macro is used

--- a/xlive/Blam/Engine/render/render_lod_new.cpp
+++ b/xlive/Blam/Engine/render/render_lod_new.cpp
@@ -13,6 +13,10 @@
 
 #include "H2MOD/Modules/Shell/Config.h"
 
+
+static e_scenery_lightmapping_policy render_lod_new_get_scenery_lightmapping_policy(datum object_index);
+
+
 uint32 render_object_cache_create_index()
 {
 	uint32 result = (*get_global_window_bound_index() << 30) | (*global_frame_num_get() & 0x3FFFFFFF);
@@ -21,7 +25,7 @@ uint32 render_object_cache_create_index()
 
 data_array* get_cached_object_render_states_array()
 {
-    return *Memory::GetAddress<data_array**>(0x4EC384, 0x0);
+    return *Memory::GetAddress<data_array**>(0x4EC384);
 }
 
 int8 render_object_cache_get_level_of_detail(datum object_index)
@@ -64,10 +68,6 @@ void __cdecl render_object_update_change_colors(datum object_index, bool a2)
     return;
 }
 
-// Disable illegal instruction size warnings,
-// It generates the correct code...
-#pragma warning( push )
-#pragma warning( disable : 4409)
 int16 __cdecl sub_59CC02_to_usercall(
     datum object_index,
     real32 a2,
@@ -82,9 +82,15 @@ int16 __cdecl sub_59CC02_to_usercall(
     void* sub_59CC02 = Memory::GetAddress<void*>(0x19CC02);
     __asm
     {
-        push a6
-        push a5
-        push first_person
+        mov esi, a6
+        push esi
+
+        mov al, a5
+        push eax
+        
+        mov esi, first_person
+        push esi
+        
         push a3
         push a2
         push object_index
@@ -106,13 +112,18 @@ bool __cdecl sub_59D024_to_usercall(
     int8 current_lod,
     bool* a8)
 {
-    bool result = false;
+    bool result;
     void* sub_59D024 = Memory::GetAddress<void*>(0x19D024);
     __asm
     {
         push a8
-        push current_lod
-        push first_person
+
+        mov dl, current_lod
+        push edx
+        
+        mov dl, first_person
+        push edx
+
         push object_index
         mov esi, render_model_index
         mov edi, section_indices
@@ -124,7 +135,6 @@ bool __cdecl sub_59D024_to_usercall(
     }
     return result;
 }
-#pragma warning( pop ) 
 
 int32 __cdecl sub_77DCF6_get_unk_count(datum model_index, int32 level_of_detail, uint8* region_section_indices)
 {
@@ -174,18 +184,6 @@ render_lighting* __cdecl sub_597370(datum object_index, real32 a2)
     return INVOKE(0x197370, 0x0, sub_597370, object_index, a2);
 }
 
-typedef void(__cdecl* t_object_build_render_cache_and_info)(
-    datum object_index,
-    int32 a2,
-    real32 a3,
-    real32 a4,
-    s_render_object_info* info,
-    int32 a6,
-    bool force_no_fp_object,
-    bool skinning_matrices);
-
-t_object_build_render_cache_and_info p_object_build_render_cache_and_info;
-
 void __cdecl object_build_render_cache_and_info(
     datum object_index,
     int32 a2,
@@ -198,7 +196,6 @@ void __cdecl object_build_render_cache_and_info(
 {
     int8 desired_object_lod = NONE;
     int32 skipped_object_count = 0;
-    info->object_count = 0;
 
     int16 render_model_count = sub_59CC02_to_usercall(
         object_index,
@@ -211,7 +208,7 @@ void __cdecl object_build_render_cache_and_info(
 
     info->level_of_detail = desired_object_lod;
 
-    ASSERT(render_model_count <= MAXIMUM_RENDER_MODELS_PER_OBJECT);
+    ASSERT(VALID_INDEX(render_model_count, MAXIMUM_RENDER_MODELS_PER_OBJECT));
 
     if (info->first_person 
         && *global_user_render_index_get() != NONE 
@@ -220,19 +217,10 @@ void __cdecl object_build_render_cache_and_info(
         render_model_count = 0;
     }
 
-    const object_header_datum* object = (object_header_datum*)datum_get(object_header_data_get(), object_index);
-
-    if (object->type == _object_type_scenery)
-    {
-        uint8* object_data = (uint8*)object_try_and_get_and_verify_type(object_index, _object_mask_scenery);
-        info->field_16A = *(int16*)(object_data + 308);
-    }
-    else
-    {
-        info->field_16A = NONE;
-    }
-
-    for (int32 i = 0; i < render_model_count; i++)
+    info->object_count = 0;
+    info->scenery_lightmapping_policy = render_lod_new_get_scenery_lightmapping_policy(object_index);
+   
+    for (int32 i = 0; i < render_model_count; ++i)
     {
         int32 render_model_storage_index = i - skipped_object_count;
 
@@ -264,8 +252,7 @@ void __cdecl object_build_render_cache_and_info(
         info->render_info[render_model_storage_index] = render_object_cache_get_render_state(info->object_index[render_model_storage_index]);
         info->field_70[render_model_storage_index] = TEST_BIT(flags, 0);
 
-        ASSERT(!info->render_info[render_model_storage_index] 
-            || info->render_info[render_model_storage_index]->context == info->object_index[render_model_storage_index]);
+        ASSERT(!info->render_info[render_model_storage_index] || info->render_info[render_model_storage_index]->context == info->object_index[render_model_storage_index]);
 
         // partial missing code from Halo 2 Vista
         object_is_cached = render_object_cache_storage_is_object_cached(info->render_info[render_model_storage_index]) && cached_lod != NONE;
@@ -446,9 +433,22 @@ __declspec(naked) void object_render_calculate_lod_nak_to_usercall()
     }
 }
 
+static e_scenery_lightmapping_policy render_lod_new_get_scenery_lightmapping_policy(datum object_index)
+{
+    e_scenery_lightmapping_policy result = _scenery_lightmapping_policy_none;
+    if (object_get_type(object_index) == _object_type_scenery)
+    {
+        const scenery_datum* scenery = (scenery_datum*)object_try_and_get_and_verify_type(object_index, _object_mask_scenery);
+        result = (e_scenery_lightmapping_policy)scenery->scenery.lightmapping_policy;
+    }
+
+    return result;
+}
+
 void render_lod_new_apply_patches()
 {
-    DETOUR_ATTACH(p_object_build_render_cache_and_info, Memory::GetAddress<t_object_build_render_cache_and_info>(0x19D165, 0x0), object_build_render_cache_and_info);
+    PatchCall(Memory::GetAddress(0xBCC69), object_build_render_cache_and_info);
+    PatchCall(Memory::GetAddress(0xBCFC3), object_build_render_cache_and_info);
 
     object_render_calculate_lod_usercall = Memory::GetAddress<void*>(0x19CA3E);
     PatchCall(Memory::GetAddress<void*>(0x19CDA3), object_render_calculate_lod_nak_to_usercall);

--- a/xlive/Blam/Engine/render/render_lod_new.h
+++ b/xlive/Blam/Engine/render/render_lod_new.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "render/render_lights.h"
+#include "objects/scenery.h"
 
 enum e_render_lod : int8
 {
@@ -37,7 +38,7 @@ struct s_render_object_info
 	int8 field_C6[160];
 	int16 object_count;
 	int16 level_of_detail;
-	int16 field_16A;
+	e_scenery_lightmapping_policy scenery_lightmapping_policy;
 	bool first_person;
 	uint8 gap_16D[3];
 	uint32 field_170;

--- a/xlive/Blam/Engine/render/render_primitive.cpp
+++ b/xlive/Blam/Engine/render/render_primitive.cpp
@@ -7,10 +7,25 @@ c_render_primitive_list g_render_primitives_by_primitive_list_type[3];	// Only u
 
 /* public code */
 
-bool c_render_primitive_list::is_layer_different(e_render_layer layer_index) const
+void c_render_primitive_list::backup_settings(void)
+{
+	m_render_layer_flags_backup = m_render_layer_flags;
+	m_render_layer_flags = 0;
+	m_field_C = m_primitive_count;
+	return;
+}
+
+void c_render_primitive_list::restore_backup(void)
+{
+	m_render_layer_flags = m_render_layer_flags_backup;
+	m_field_C = 0;
+	return;
+}
+
+bool c_render_primitive_list::test_layer(e_render_layer layer_index) const
 {
 	ASSERT(VALID_INDEX(layer_index, k_number_of_render_layers));
-	return !this->m_render_layer_flags.test(layer_index);
+	return !TEST_BIT(m_render_layer_flags, layer_index);
 }
 
 void __cdecl create_visible_render_primitives(int32 hologram_flag)

--- a/xlive/Blam/Engine/render/render_primitive.h
+++ b/xlive/Blam/Engine/render/render_primitive.h
@@ -21,13 +21,16 @@ class c_render_primitive_list
 {	
 public:
 	int32 m_max_primitive_count;
-	int32 m_field_4;
-	c_flags_no_init<e_render_layer, uint32, k_number_of_render_layers> m_render_layer_flags;
+	int32 m_primitive_count;
+	uint32 m_render_layer_flags;
 	int32 m_field_C;
-	c_flags_no_init<e_render_layer, uint32, k_number_of_render_layers> m_render_layer_flags_backup;
+	uint32 m_render_layer_flags_backup;
 	c_render_primitive* m_primitives;
 
-	bool is_layer_different(e_render_layer layer_index) const;
+	void backup_settings(void);
+	void restore_backup(void);
+
+	bool test_layer(e_render_layer layer_index) const;
 };
 ASSERT_STRUCT_SIZE(c_render_primitive_list, 24);
 
@@ -44,5 +47,6 @@ void __cdecl create_visible_render_primitives(int32 hologram_flag);
 inline c_render_primitive_list* render_primitive_get_by_primitive_list_type(uint8 primitive_list_type)
 {
 	ASSERT(VALID_INDEX(primitive_list_type, NUMBEROF(g_render_primitives_by_primitive_list_type)));
-	return &Memory::GetAddress<c_render_primitive_list*>(0x4F4EC0)[primitive_list_type];
+	c_render_primitive_list* lists = Memory::GetAddress<c_render_primitive_list*>(0x4F4EC0);
+	return &lists[primitive_list_type];
 }

--- a/xlive/Blam/Engine/render/render_submit.cpp
+++ b/xlive/Blam/Engine/render/render_submit.cpp
@@ -34,7 +34,7 @@ void __cdecl render_submit_transparent_geometry(s_model_group_submit_data* model
 	uint32 v1 = 0x40000;
 
 	s_scenario_fog_result* g_fog_result = global_fog_result_get();
-	if (g_fog_result->patchy_fog_tag_index != NONE && !g_fog_result->sort_behind_transparents)
+	if (g_fog_result->patchy_fog_tag_index != NONE && !g_fog_result->field_96)
 	{
 		real32 result = (g_fog_result->field_88.lower > g_fog_result->field_88.upper ? g_fog_result->field_88.lower : g_fog_result->field_88.upper);
 
@@ -45,9 +45,7 @@ void __cdecl render_submit_transparent_geometry(s_model_group_submit_data* model
 	render_layer_globals->transparent_submit_in_progress = true;
 
 	c_render_primitive_list* primitive_list = render_primitive_get_by_primitive_list_type(0);
-	primitive_list->m_render_layer_flags_backup = primitive_list->m_render_layer_flags;
-	primitive_list->m_render_layer_flags.clear();
-	primitive_list->m_field_C = primitive_list->m_field_4;
+	primitive_list->backup_settings();
 
 	// Copy render primary viewport to active camo
 	// Make sure to create a rect so that only the content in the viewport is copied over rather than the whole screen
@@ -64,9 +62,9 @@ void __cdecl render_submit_transparent_geometry(s_model_group_submit_data* model
 	}
 
 
-	for (uint8 i = 0; i < model_data->count; i++)
+	for (int8 i = 0; i < model_data->count; ++i)
 	{
-		render_section_visibility_compute(0, NONE, model_data->model_group_index[i], 0x11818E, v1, INT16_MAX+1, 0x40000, 0);
+		render_section_visibility_compute(0, NONE, model_data->model_group_index[i], 0x11818E, v1, INT16_MAX+1, 0x40000, false);
 	}
 
 	bool* g_rasterizer_dx9_disable_stencil = rasterizer_dx9_disable_stencil_get();
@@ -104,8 +102,7 @@ void __cdecl render_submit_transparent_geometry(s_model_group_submit_data* model
 	}
 
 	render_scene_geometry(_collection_type_0, _render_layer_transparent);
-	primitive_list->m_render_layer_flags = primitive_list->m_render_layer_flags_backup;
-	primitive_list->m_field_C = 0;
+	primitive_list->restore_backup();
 
 	render_layer_globals->transparent_submit_in_progress = false;
 	return;
@@ -116,9 +113,7 @@ void __cdecl render_submit_transparent_hologram_geometry(uint32* a1)
 	const uint32 model_group_index = a1[0];
 	const uint32 flags = a1[1];
 	c_render_primitive_list* primitive_list = render_primitive_get_by_primitive_list_type(0);
-	primitive_list->m_render_layer_flags_backup = primitive_list->m_render_layer_flags;
-	primitive_list->m_render_layer_flags.clear();
-	primitive_list->m_field_C = primitive_list->m_field_4;
+	primitive_list->backup_settings();
 
 	// Copy render primary viewport to active camo
 	// Make sure to create a rect so that only the content in the viewport is copied over rather than the whole screen
@@ -148,7 +143,6 @@ void __cdecl render_submit_transparent_hologram_geometry(uint32* a1)
 	render_scene_geometry(_collection_type_0, _render_layer_transparent);
 	render_scene_geometry(_collection_type_0, _render_layer_hologram);
 
-	primitive_list->m_render_layer_flags = primitive_list->m_render_layer_flags_backup;
-	primitive_list->m_field_C = 0;
+	primitive_list->restore_backup();
 	return;
 }

--- a/xlive/Blam/Engine/render/render_submit.h
+++ b/xlive/Blam/Engine/render/render_submit.h
@@ -2,13 +2,16 @@
 
 /* constants */
 
-#define k_render_visible_section_model_group_count 31
-#define k_render_visible_section_model_group_none 32
+enum
+{
+	k_render_visible_section_model_group_count = 31,
+	k_render_visible_section_model_group_none = 32,
+};
 
 /* structures */
 struct s_model_group_submit_data
 {
-	uint8 count;
+	int8 count;
 	uint8 model_group_index[k_render_visible_section_model_group_count];
 };
 ASSERT_STRUCT_SIZE(s_model_group_submit_data, 32);

--- a/xlive/Blam/Engine/render/render_visible_geometry.cpp
+++ b/xlive/Blam/Engine/render/render_visible_geometry.cpp
@@ -1,9 +1,51 @@
 #include "stdafx.h"
 #include "render_visible_geometry.h"
 
+/* prototypes */
+
+static s_render_visible_globals* render_visible_globals_get(void);
+
 /* public code */
 
-uint32* visible_geometry_group_count_get(void)
+uint32 render_section_visibility_get_model_group_count(void)
 {
-	return Memory::GetAddress<uint32*>(0x4F4324);
+	return render_visible_globals_get()->model_group_count;
+}
+
+s_render_visible_section* render_visible_section_get(int16 array_index)
+{
+	s_render_visible_globals* g_render_visible_globals = render_visible_globals_get();
+	ASSERT(VALID_INDEX(array_index, g_render_visible_globals->render_visible_section_count));
+	return &g_render_visible_globals->render_visible_sections[array_index];
+}
+
+int8 render_visible_section_extern_shader_override_get(int16 array_index)
+{
+	s_render_visible_globals* g_render_visible_globals = render_visible_globals_get();
+	ASSERT(VALID_INDEX(array_index, g_render_visible_globals->render_visible_section_count));
+	return g_render_visible_globals->render_visible_section_extern_shader_override[array_index];
+}
+
+datum render_visible_section_shader_index_get(int16 array_index)
+{
+	s_render_visible_globals* g_render_visible_globals = render_visible_globals_get();
+	ASSERT(VALID_INDEX(array_index, g_render_visible_globals->render_visible_section_count));
+	const int8 shader_index_index = g_render_visible_globals->render_visible_section_shader_index_indices[array_index];
+
+	datum result = NONE;
+
+	if (shader_index_index != NONE)
+	{
+		ASSERT(VALID_INDEX(shader_index_index, g_render_visible_globals->section_extern_shader_count));
+		result = g_render_visible_globals->render_visible_section_shader_index[shader_index_index];
+	}
+
+	return result;
+}
+
+/* private code */
+
+static s_render_visible_globals* render_visible_globals_get(void)
+{
+	return Memory::GetAddress<s_render_visible_globals*>(0x4ECAB0);
 }

--- a/xlive/Blam/Engine/render/render_visible_geometry.h
+++ b/xlive/Blam/Engine/render/render_visible_geometry.h
@@ -1,5 +1,58 @@
 #pragma once
 
+/* structures */
+
+struct s_render_visibility_data
+{
+	int8 gap_0[36];
+};
+
+struct s_render_visible_section
+{
+	uint32 flags;
+	datum model_tag_index;
+	int32 pool_index;
+	uint32 part;
+	void* field_10;
+	int32 subpart_bitvector;
+	int16 visibility_region_cluster_memory;
+	int8 field_1A;
+	int8 model_zsort_offset;
+	real_matrix4x3* matrix;
+};
+ASSERT_STRUCT_SIZE(s_render_visible_section, 32);
+
+struct s_render_visible_globals
+{
+	c_static_array<s_render_visible_section, 850> render_visible_sections;
+	int32 render_visible_section_count;
+	int32 last_render_visible_section_index;
+	void* visibility_collection;
+	c_static_array<int8, 850> render_visible_section_extern_shader_override;
+	c_static_array<int8, 850> render_visible_section_shader_index_indices;
+	c_static_array<datum, 192> render_visible_section_shader_index;
+	int32 section_extern_shader_count;
+	c_static_array<s_render_visibility_data, 32> visibility_data;
+	int32 model_group_count;
+// Don't enable this until we have full control of the global
+// The global isnt' present in the release version of the game
+//#ifdef _DEBUG
+//	bool print_debug_text;
+//#endif
+
+	bool force_max_floats;	// TODO: better name
+	bool unk_1;
+	bool ran_out_of_section_extern_shader_overrides;
+	int8 pad;
+};
+ASSERT_STRUCT_SIZE(s_render_visible_globals, 30844);
+
 /* prototypes */
 
-uint32* visible_geometry_group_count_get(void);
+uint32 render_section_visibility_get_model_group_count(void);
+
+s_render_visible_section* render_visible_section_get(int16 array_index);
+
+int8 render_visible_section_extern_shader_override_get(int16 array_index);
+
+datum render_visible_section_shader_index_get(int16 array_index);

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -674,7 +674,7 @@ static void h2mod_apply_hooks(void)
 		}
 
 		// ### TODO dedi offset
-		Codecave(Memory::GetAddress(0x15E8DC, 0x0), object_function_value_adjust_primary_firing, 4);
+		Codecave(Memory::GetAddress(0x15E8DC), object_function_value_adjust_primary_firing, 4);
 
 		DETOUR_ATTACH(p_show_error_screen, Memory::GetAddress<show_error_screen_t>(0x20E15A), showErrorScreen);
 		DETOUR_ATTACH(p_user_interface_controller_set_desired_team_index, Memory::GetAddress<user_interface_controller_set_desired_team_index_t>(0x2068F2), user_interface_controller_set_desired_team_index_hook);

--- a/xlive/Util/Memory.h
+++ b/xlive/Util/Memory.h
@@ -27,23 +27,6 @@ public:
 		ASSERT(g_memory_is_dedicated_server || client != 0);
 		ASSERT(!g_memory_is_dedicated_server || server != 0);
 		
-	// NOTE:
-	// if server or client is equal to 0 then we pass the same address for both (ONLY ON RELEASE BUILDS)
-	// REASON:
-	// optimizes out a cmov or related instruction when building release whenever we call a function that doesn't have a dedi address specified
-#ifdef NDEBUG
-		// FIXME: Enabling this will break things, there's some form of corruption in the project that gets triggered when this optimization is used
-		/*
-		if (server == 0)
-		{
-			server = client;
-		}
-		else if (client == 0)
-		{
-			client = server;
-		}
-		*/
-#endif
 		const uintptr_t address = g_memory_is_dedicated_server ? server : client;
 		return GetBaseAddress() + address;
 	}


### PR DESCRIPTION
- hud corruption issue caused since new_hud_widget_anchor_calculate_point should take a int32 instead of an int16 enum
- add scenery_datum structure
- fix illegal size warnings in inlined asm
- label scenery lightmap policy member and add scenery lightmap function
- add render visibility structures and functions
- remove DRAW_RENDER_LAYER macro, replace with render_scene_geometry as that's how it's originally setup (get's inlined on debug and release builds)
- add backup and restore member functions that get inlined
