### PR TITLE
Restore rename squad option and some UI debug commands 

### DIFF
--- a/xlive/Blam/Engine/interface/channel_with_history.h
+++ b/xlive/Blam/Engine/interface/channel_with_history.h
@@ -11,6 +11,9 @@ struct s_user_interface_widget_stack
 };
 ASSERT_STRUCT_SIZE(s_user_interface_widget_stack, 0x28);
 
+
+/* classes */
+
 class c_channel_with_history : public c_user_interface_channel
 {
 private:

--- a/xlive/Blam/Engine/interface/channel_with_history.h
+++ b/xlive/Blam/Engine/interface/channel_with_history.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "user_interface_channel.h"
+
+/* structures */
+
+struct s_user_interface_widget_stack
+{
+	s_user_interface_widget_stack* old_stack_item;
+	s_screen_parameters parameters;
+	int32 screen_menu_id;
+};
+ASSERT_STRUCT_SIZE(s_user_interface_widget_stack, 0x28);
+
+class c_channel_with_history : public c_user_interface_channel
+{
+private:
+	s_user_interface_widget_stack* m_widget_stack;
+	int8 field_40;
+	int8 field_41;
+	int16 field_42;
+
+public:
+
+	// c_channel_with_history virtual functions
+
+	virtual ~c_channel_with_history();
+	virtual void dispose_screens() override;
+	virtual void register_incoming_screen(c_screen_widget* new_screen, s_screen_parameters* parameters) override;
+	virtual void  retreat_one_step() override;
+	virtual void construct_parameters_from_active_screen() override;
+	virtual void  load_screen_from_incoming_parameters() override;
+
+	// c_channel_with_history addons
+
+	virtual void retreat_steps(int16 number_of_steps);
+	virtual void try_retreat_to_menu(e_user_interface_screen_id menu_id);
+
+
+};
+ASSERT_STRUCT_SIZE(c_channel_with_history, 0x44);

--- a/xlive/Blam/Engine/interface/dialog_channel.h
+++ b/xlive/Blam/Engine/interface/dialog_channel.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "channel_with_history.h"
+
+/* structures */
+
+class c_dialog_channel : public c_channel_with_history
+{
+
+public:
+
+	// c_dialog_channel virtual functions
+
+	virtual ~c_dialog_channel();
+
+};
+ASSERT_STRUCT_SIZE(c_dialog_channel, 0x44);

--- a/xlive/Blam/Engine/interface/dialog_channel.h
+++ b/xlive/Blam/Engine/interface/dialog_channel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "channel_with_history.h"
 
-/* structures */
+/* classes */
 
 class c_dialog_channel : public c_channel_with_history
 {

--- a/xlive/Blam/Engine/interface/game_error_dialog_channel.h
+++ b/xlive/Blam/Engine/interface/game_error_dialog_channel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "user_interface_channel.h"
 
-/* structures */
+/* classes */
 
 class c_game_error_dialog_channel : public c_user_interface_channel
 {

--- a/xlive/Blam/Engine/interface/game_error_dialog_channel.h
+++ b/xlive/Blam/Engine/interface/game_error_dialog_channel.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "user_interface_channel.h"
+
+/* structures */
+
+class c_game_error_dialog_channel : public c_user_interface_channel
+{
+
+public:
+
+	// c_game_error_dialog_channel virtual functions
+
+	virtual ~c_game_error_dialog_channel();
+
+};
+ASSERT_STRUCT_SIZE(c_game_error_dialog_channel, 0x3C);

--- a/xlive/Blam/Engine/interface/gameshell_background_channel.h
+++ b/xlive/Blam/Engine/interface/gameshell_background_channel.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "user_interface_channel.h"
+
+/* structures */
+
+class c_gameshell_background_channel : public c_user_interface_channel
+{
+private:
+	float gap_3C[10];
+	int32 field_64;
+	int32 field_68;
+
+public:
+
+	// c_gameshell_background_channel virtual functions
+	virtual ~c_gameshell_background_channel();
+	virtual void sub_637627() override;
+	virtual void dispose_screens() override;
+	virtual void update_channel() override;
+
+	// c_gameshell_background_channel addons
+
+	virtual void dispose_screens_wrapper2();
+	virtual void sub_637627_wrapper();
+
+};
+ASSERT_STRUCT_SIZE(c_gameshell_background_channel, 0x6C);

--- a/xlive/Blam/Engine/interface/gameshell_background_channel.h
+++ b/xlive/Blam/Engine/interface/gameshell_background_channel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "user_interface_channel.h"
 
-/* structures */
+/* classes */
 
 class c_gameshell_background_channel : public c_user_interface_channel
 {

--- a/xlive/Blam/Engine/interface/gameshell_channel.h
+++ b/xlive/Blam/Engine/interface/gameshell_channel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "channel_with_history.h"
 
-/* structures */
+/* classes */
 
 class c_gameshell_channel : public c_channel_with_history
 {

--- a/xlive/Blam/Engine/interface/gameshell_channel.h
+++ b/xlive/Blam/Engine/interface/gameshell_channel.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "channel_with_history.h"
+
+/* structures */
+
+class c_gameshell_channel : public c_channel_with_history
+{
+
+public:
+
+	// c_gameshell_channel virtual functions
+
+	virtual ~c_gameshell_channel();
+
+};
+ASSERT_STRUCT_SIZE(c_gameshell_channel, 0x44);

--- a/xlive/Blam/Engine/interface/hardware_error_dialog_channel.h
+++ b/xlive/Blam/Engine/interface/hardware_error_dialog_channel.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "user_interface_channel.h"
+
+/* structures */
+
+class c_hardware_error_dialog_channel : public c_user_interface_channel
+{
+private:
+	int32 field3C;
+	int32 field40;
+
+public:
+
+	// c_hardware_error_dialog_channel virtual functions
+
+	virtual ~c_hardware_error_dialog_channel();
+	virtual void update_channel() override;
+
+};
+ASSERT_STRUCT_SIZE(c_hardware_error_dialog_channel, 0x44);

--- a/xlive/Blam/Engine/interface/hardware_error_dialog_channel.h
+++ b/xlive/Blam/Engine/interface/hardware_error_dialog_channel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "user_interface_channel.h"
 
-/* structures */
+/* classes */
 
 class c_hardware_error_dialog_channel : public c_user_interface_channel
 {

--- a/xlive/Blam/Engine/interface/online_menu_channel.h
+++ b/xlive/Blam/Engine/interface/online_menu_channel.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "user_interface_channel.h"
+
+/* structures */
+
+
+//stubbing for now
+class c_online_menu_channel : public c_user_interface_channel
+{
+private:
+	/*
+	
+	c_screen_widget* m_collapsed_online_menu_tab;
+	c_screen_widget* m_online_beeper_ui;
+	s_online_menu_channel_notification m_user_notifications[k_number_of_users];
+	int32 m_notification_update_time;
+	
+	*/
+
+};
+

--- a/xlive/Blam/Engine/interface/online_menu_channel.h
+++ b/xlive/Blam/Engine/interface/online_menu_channel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "user_interface_channel.h"
 
-/* structures */
+/* classes */
 
 
 //stubbing for now

--- a/xlive/Blam/Engine/interface/screens/screen_4way_signin.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_4way_signin.cpp
@@ -519,7 +519,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 			{
 				if (this->m_call_context == _4_way_signin_type_crossgame_invite)
 				{
-					user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+					user_interface_error_ok_cancle_dialog_show_confirmation(
 						_user_interface_channel_type_gameshell_dialog,
 						_window_4,
 						FLAG(event->controller),
@@ -528,7 +528,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 				}
 				else
 				{
-					user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+					user_interface_error_ok_cancle_dialog_show_confirmation(
 						_user_interface_channel_type_gameshell_dialog,
 						_window_4,
 						FLAG(event->controller),
@@ -569,7 +569,7 @@ bool c_screen_4way_signin::handle_invalid_controller_event(s_event_record* event
 		|| event->component == _user_interface_controller_component_button_back)
 		&& !user_interface_controller_get_signed_in_controller_count())
 	{
-		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+		user_interface_error_ok_cancle_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG(event->controller),

--- a/xlive/Blam/Engine/interface/screens/screen_4way_signin.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_4way_signin.cpp
@@ -490,7 +490,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 
 			//this needs further research
 
-			screen_error_ok_dialog_show(_user_interface_channel_type_dialog, _ui_error_cant_join_gameinvite_without_signon, _window_4, FLAG(event->controller), 0, 0);
+			screen_error_ok_dialog_show(_user_interface_channel_type_gameshell_dialog, _ui_error_cant_join_gameinvite_without_signon, _window_4, FLAG(event->controller), 0, 0);
 
 			break;
 		}
@@ -520,7 +520,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 				if (this->m_call_context == _4_way_signin_type_crossgame_invite)
 				{
 					user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-						_user_interface_channel_type_dialog,
+						_user_interface_channel_type_gameshell_dialog,
 						_window_4,
 						FLAG(event->controller),
 						user_interface_mainmenu_sign_out_controller_callback,
@@ -529,7 +529,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 				else
 				{
 					user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-						_user_interface_channel_type_dialog,
+						_user_interface_channel_type_gameshell_dialog,
 						_window_4,
 						FLAG(event->controller),
 						user_interface_sign_out_controller_default_callback,
@@ -538,7 +538,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 			}
 			else
 			{
-				screen_error_ok_dialog_show(_user_interface_channel_type_dialog, _ui_error_cant_sign_out_master_with_guests, _window_4, FLAG(event->controller), NULL, NULL);
+				screen_error_ok_dialog_show(_user_interface_channel_type_gameshell_dialog, _ui_error_cant_sign_out_master_with_guests, _window_4, FLAG(event->controller), NULL, NULL);
 
 			}
 			this->m_controllers_mask |= FLAG(event->controller);
@@ -570,7 +570,7 @@ bool c_screen_4way_signin::handle_invalid_controller_event(s_event_record* event
 		&& !user_interface_controller_get_signed_in_controller_count())
 	{
 		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-			_user_interface_channel_type_dialog,
+			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG(event->controller),
 			user_interface_decline_invite_callback,

--- a/xlive/Blam/Engine/interface/screens/screen_4way_signin.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_4way_signin.cpp
@@ -519,7 +519,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 			{
 				if (this->m_call_context == _4_way_signin_type_crossgame_invite)
 				{
-					user_interface_error_ok_cancle_dialog_show_confirmation(
+					user_interface_error_ok_cancel_dialog_show_confirmation(
 						_user_interface_channel_type_gameshell_dialog,
 						_window_4,
 						FLAG(event->controller),
@@ -528,7 +528,7 @@ bool c_screen_4way_signin::handle_controller_button_pressed_event(s_event_record
 				}
 				else
 				{
-					user_interface_error_ok_cancle_dialog_show_confirmation(
+					user_interface_error_ok_cancel_dialog_show_confirmation(
 						_user_interface_channel_type_gameshell_dialog,
 						_window_4,
 						FLAG(event->controller),
@@ -569,7 +569,7 @@ bool c_screen_4way_signin::handle_invalid_controller_event(s_event_record* event
 		|| event->component == _user_interface_controller_component_button_back)
 		&& !user_interface_controller_get_signed_in_controller_count())
 	{
-		user_interface_error_ok_cancle_dialog_show_confirmation(
+		user_interface_error_ok_cancel_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG(event->controller),

--- a/xlive/Blam/Engine/interface/screens/screen_error_dialog.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_error_dialog.cpp
@@ -60,6 +60,11 @@ void c_screen_error_dialog_ok::apply_patches()
 	WritePointer(Memory::GetAddress(0x20E173) + 1, c_screen_error_dialog_ok::load_for_active_users);
 }
 
+void c_screen_error_dialog_ok_cancel::show_dialog(e_user_interface_channel_type channel_type, e_ui_error_types error_type, e_user_interface_render_window window_index, uint16 user_flags, void* ok_callback, void* fallback, int a7, int a8)
+{
+	p_ok_cancel_dialog(channel_type, error_type, window_index, user_flags, ok_callback, fallback, a7, a8);
+}
+
 void c_screen_error_dialog_ok_cancel::apply_patches()
 {
 	DETOUR_ATTACH(p_ok_cancel_dialog, Memory::GetAddress<ok_cancel_dialog_t>(0x20E243), ok_cancel_dialog_show_hook);	

--- a/xlive/Blam/Engine/interface/screens/screen_error_dialog.h
+++ b/xlive/Blam/Engine/interface/screens/screen_error_dialog.h
@@ -1,5 +1,8 @@
 #pragma once
 
+enum e_user_interface_channel_type;
+enum e_user_interface_render_window;
+enum e_ui_error_types : uint32;
 struct s_screen_parameters;
 
 class c_screen_error_dialog_ok
@@ -13,5 +16,6 @@ public:
 class c_screen_error_dialog_ok_cancel
 {
 public:
+	static void show_dialog(e_user_interface_channel_type channel_type, e_ui_error_types error_type, e_user_interface_render_window window_index, uint16 user_flags, void* ok_callback, void* fallback, int a7, int a8);
 	static void apply_patches();
 };

--- a/xlive/Blam/Engine/interface/screens/screen_main_menu.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_main_menu.cpp
@@ -250,7 +250,7 @@ void c_main_menu_list::handle_item_campaign(s_event_record** pevent)
 		params.m_window_index = _window_4;
 		params.m_context = 0;
 		params.m_user_flags = FLAG((*pevent)->controller);
-		params.m_channel_type = _user_interface_channel_type_dialog;
+		params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 		params.m_screen_state.field_0 = NONE;
 		params.m_screen_state.m_last_focused_item_order = NONE;
 		params.m_screen_state.m_last_focused_item_index = NONE;
@@ -260,7 +260,7 @@ void c_main_menu_list::handle_item_campaign(s_event_record** pevent)
 	else
 	{
 		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-			_user_interface_channel_type_dialog,
+			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
 			screen_show_campaign_options_without_achievement,
@@ -337,7 +337,7 @@ void c_main_menu_list::handle_item_splitscreen(s_event_record** pevent)
 	else if (online_connected_to_xbox_live())
 	{
 		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-			_user_interface_channel_type_dialog,
+			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
 			screen_show_screen_4way_signin_splitscreen_offline,
@@ -366,7 +366,7 @@ void c_main_menu_list::handle_item_system_link(s_event_record** pevent)
 	else if (online_connected_to_xbox_live())
 	{
 		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-			_user_interface_channel_type_dialog,
+			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
 			screen_show_screen_4way_signin_system_link_offline,
@@ -417,7 +417,7 @@ static bool __cdecl screen_show_campaign_options_without_achievement(e_controlle
 	params.m_window_index = _window_4;
 	params.m_context = 0;
 	params.m_user_flags = user_interface_controller_get_signed_in_controllers_mask(); //replacing 0xFF with active_controllers so that controller-removed-handler stops panicking here
-	params.m_channel_type = _user_interface_channel_type_dialog;
+	params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 	params.m_screen_state.field_0 = NONE;
 	params.m_screen_state.m_last_focused_item_order = NONE;
 	params.m_screen_state.m_last_focused_item_index = NONE;

--- a/xlive/Blam/Engine/interface/screens/screen_main_menu.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_main_menu.cpp
@@ -259,7 +259,7 @@ void c_main_menu_list::handle_item_campaign(s_event_record** pevent)
 	}
 	else
 	{
-		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+		user_interface_error_ok_cancle_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
@@ -336,7 +336,7 @@ void c_main_menu_list::handle_item_splitscreen(s_event_record** pevent)
 	}
 	else if (online_connected_to_xbox_live())
 	{
-		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+		user_interface_error_ok_cancle_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
@@ -365,7 +365,7 @@ void c_main_menu_list::handle_item_system_link(s_event_record** pevent)
 	}
 	else if (online_connected_to_xbox_live())
 	{
-		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+		user_interface_error_ok_cancle_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),

--- a/xlive/Blam/Engine/interface/screens/screen_main_menu.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_main_menu.cpp
@@ -259,7 +259,7 @@ void c_main_menu_list::handle_item_campaign(s_event_record** pevent)
 	}
 	else
 	{
-		user_interface_error_ok_cancle_dialog_show_confirmation(
+		user_interface_error_ok_cancel_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
@@ -336,7 +336,7 @@ void c_main_menu_list::handle_item_splitscreen(s_event_record** pevent)
 	}
 	else if (online_connected_to_xbox_live())
 	{
-		user_interface_error_ok_cancle_dialog_show_confirmation(
+		user_interface_error_ok_cancel_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),
@@ -365,7 +365,7 @@ void c_main_menu_list::handle_item_system_link(s_event_record** pevent)
 	}
 	else if (online_connected_to_xbox_live())
 	{
-		user_interface_error_ok_cancle_dialog_show_confirmation(
+		user_interface_error_ok_cancel_dialog_show_confirmation(
 			_user_interface_channel_type_gameshell_dialog,
 			_window_4,
 			FLAG((*pevent)->controller),

--- a/xlive/Blam/Engine/interface/screens/screen_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_settings.cpp
@@ -275,7 +275,7 @@ void c_settings_list::handle_item_network(s_event_record** pevent)
 	params.m_window_index = _window_4;
 	params.m_context = NULL;
 	params.m_user_flags = FLAG((*pevent)->controller);
-	params.m_channel_type = _user_interface_channel_type_dialog;
+	params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 	params.m_screen_state.field_0 = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_order = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_index = 0xFFFFFFFF;
@@ -290,7 +290,7 @@ void c_settings_list::handle_item_about(s_event_record** pevent)
 	params.m_window_index = _window_4;
 	params.m_context = NULL;
 	params.m_user_flags = FLAG((*pevent)->controller);
-	params.m_channel_type = _user_interface_channel_type_dialog;
+	params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 	params.m_screen_state.field_0 = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_order = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_index = 0xFFFFFFFF;

--- a/xlive/Blam/Engine/interface/screens/screen_squad_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_squad_settings.cpp
@@ -420,7 +420,7 @@ void c_squad_settings_list::handle_item_change_level(s_event_record** pevent)
 	params.m_window_index = _window_4;
 	params.m_context = 0;
 	params.m_user_flags = FLAG((*pevent)->controller);
-	params.m_channel_type = _user_interface_channel_type_dialog;
+	params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 	params.m_screen_state.field_0 = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_order = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_index = 0xFFFFFFFF;
@@ -434,7 +434,7 @@ void c_squad_settings_list::handle_item_change_difficulty(s_event_record** peven
 	params.m_window_index = _window_4;
 	params.m_context = 0;
 	params.m_user_flags = FLAG((*pevent)->controller);
-	params.m_channel_type = _user_interface_channel_type_dialog;
+	params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 	params.m_screen_state.field_0 = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_order = 0xFFFFFFFF;
 	params.m_screen_state.m_last_focused_item_index = 0xFFFFFFFF;
@@ -455,7 +455,7 @@ void c_squad_settings_list::handle_item_switch_to_coop(s_event_record** pevent)
 		|| network_squad_session_get_session_class() == _network_session_class_xbox_live)
 	{
 		screen_error_ok_dialog_with_custom_text(
-			_user_interface_channel_type_dialog,
+			_user_interface_channel_type_gameshell_dialog,
 			_ui_error_generic, _window_4,
 			FLAG((*pevent)->controller), NULL, NULL, L"Access Denied", L"Coming Soon....");
 	}
@@ -482,7 +482,7 @@ void c_squad_settings_list::handle_item_switch_to_optimatch(s_event_record** pev
 	//return INVOKE_TYPE(0x211BA1, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
 
 	screen_error_ok_dialog_with_custom_text(
-		_user_interface_channel_type_dialog,
+		_user_interface_channel_type_gameshell_dialog,
 		_ui_error_generic, _window_4,
 		FLAG((*pevent)->controller), nullptr, nullptr, L"Alert", L"This feature is not currently available");
 }

--- a/xlive/Blam/Engine/interface/screens/screen_squad_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_squad_settings.cpp
@@ -149,12 +149,15 @@ static const char k_squad_setting_list_name[] = "squad setting list";
 
 /* globals */
 
-datum new_xbox_live_bitmap_datum = NONE;
-datum xbox_live_menu_bitmap_datum = NONE;
-datum variant_bitmap_datum = NONE;
-wchar_t session_name_tmp[32] = L"<insert-name-here>";
-c_maximum_interface_text rename_squad_header;
-c_maximum_interface_text rename_squad_help;
+static datum new_xbox_live_bitmap_datum = NONE;
+static datum xbox_live_menu_bitmap_datum = NONE;
+static datum variant_bitmap_datum = NONE;
+static wchar_t session_name_tmp[32] = L"<insert-name-here>";
+static c_maximum_interface_text rename_squad_header;
+static c_maximum_interface_text rename_squad_help;
+
+
+/* public code */
 
 c_squad_settings_list::c_squad_settings_list(int16 user_flags) :
 	c_list_widget(user_flags),
@@ -727,11 +730,13 @@ void c_screen_squad_settings::update()
 
 	}
 
-	if (option_help_text_block && value_string != _string_id_invalid)
+	const bool value_string_set = value_string != _string_id_invalid;
+
+	if (option_help_text_block && value_string_set)
 		option_help_text_block->set_text_from_string_id(help_string);
-	if (option_header_text_block && value_string != _string_id_invalid)
+	if (option_header_text_block && value_string_set)
 		option_header_text_block->set_text_from_string_id(header_string);
-	if (option_value_text_block && value_string != _string_id_invalid)
+	if (option_value_text_block && value_string_set)
 		option_value_text_block->set_text_from_string_id(value_string);
 	
 	if (option_bitmap)

--- a/xlive/Blam/Engine/interface/screens/screen_squad_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_squad_settings.cpp
@@ -2,6 +2,7 @@
 #include "screen_squad_settings.h"
 #include "screen_single_player_difficulty_select.h"
 #include "screen_single_player_level_select.h"
+#include "screen_virtual_keyboard.h"
 
 #include "bitmaps/bitmap_group.h"
 #include "cache/cache_files.h"
@@ -10,6 +11,7 @@
 #include "interface/user_interface_memory.h"
 #include "interface/user_interface_bitmap_block.h"
 #include "interface/user_interface_globals.h"
+#include "interface/user_interface_utilities.h"
 #include "main/levels.h"
 #include "main/level_definitions.h"
 #include "networking/network_event.h"
@@ -17,10 +19,8 @@
 #include "saved_games/game_variant.h"
 #include "tag_files/global_string_ids.h"
 #include "tag_files/tag_loader/tag_injection.h"
+#include "text/text_group.h"
 
-/* macro defines */
-
-#define k_squad_setting_list_name "squad setting list"
 
 /* enums */
 
@@ -50,7 +50,8 @@ enum e_squad_list_items : uint16
 	
 	//h2v addition
 	_item_party_management,	
-	k_total_no_of_squad_list_items = 0xA
+	_item_rename_squad,
+	k_total_no_of_squad_list_items
 };
 
 enum e_squad_settings_dialog_text_blocks
@@ -140,11 +141,20 @@ enum e_settings_variant_bitmap_type
 	k_number_of_settings_variant_bitmap_types,
 };
 
+
+/* constants */
+
+static const char k_squad_setting_list_name[] = "squad setting list";
+
+
 /* globals */
 
 datum new_xbox_live_bitmap_datum = NONE;
 datum xbox_live_menu_bitmap_datum = NONE;
 datum variant_bitmap_datum = NONE;
+wchar_t session_name_tmp[32] = L"<insert-name-here>";
+c_maximum_interface_text rename_squad_header;
+c_maximum_interface_text rename_squad_help;
 
 c_squad_settings_list::c_squad_settings_list(int16 user_flags) :
 	c_list_widget(user_flags),
@@ -163,11 +173,17 @@ c_squad_settings_list::c_squad_settings_list(int16 user_flags) :
 	switch (active_protocol)
 	{
 	case _session_protocol_splitscreen_custom:
+		SQUAD_ITEM_GET_NEW()->item_id = _item_change_map;
+		SQUAD_ITEM_GET_NEW()->item_id = _item_change_variant;
+		SQUAD_ITEM_GET_NEW()->item_id = _item_quick_options;
+		SQUAD_ITEM_GET_NEW()->item_id = _item_switch_to_coop;
+		break;
 	case _session_protocol_system_link_custom:
 		SQUAD_ITEM_GET_NEW()->item_id = _item_change_map;
 		SQUAD_ITEM_GET_NEW()->item_id = _item_change_variant;
 		SQUAD_ITEM_GET_NEW()->item_id = _item_quick_options;
 		SQUAD_ITEM_GET_NEW()->item_id = _item_switch_to_coop;
+		SQUAD_ITEM_GET_NEW()->item_id = _item_rename_squad;
 		break;
 
 	case _session_protocol_xbox_live_custom:
@@ -176,6 +192,7 @@ c_squad_settings_list::c_squad_settings_list(int16 user_flags) :
 		SQUAD_ITEM_GET_NEW()->item_id = _item_quick_options;
 		SQUAD_ITEM_GET_NEW()->item_id = _item_switch_to_coop;
 		SQUAD_ITEM_GET_NEW()->item_id = _item_switch_to_optimatch;
+		SQUAD_ITEM_GET_NEW()->item_id = _item_rename_squad;
 
 		if (user_interface_squad_local_peer_is_leader() && user_interface_squad_get_player_count() > 1)
 		{
@@ -223,6 +240,20 @@ c_squad_settings_list::c_squad_settings_list(int16 user_flags) :
 #undef SQUAD_ITEM_GET_NEW
 
 	linker_type2.link(&this->m_slot);
+
+	const datum vkbd_screen_tag_index = user_interface_get_widget_tag_index_from_screen_id(_screen_virtual_keyboard);
+	const s_user_interface_screen_widget_definition* vkbd_tag = (s_user_interface_screen_widget_definition*)tag_get_fast(vkbd_screen_tag_index);
+
+	c_maximum_interface_text tmp_string;
+	string_list_get_normal_string(vkbd_tag->string_list_tag.index, _string_id_squad_name_entry, &tmp_string);
+	string_list_get_normal_string(vkbd_tag->string_list_tag.index, _string_id_squad_name_help_text, &rename_squad_help);
+	
+
+	//capitalise rename_squad's first character
+	rename_squad_header.clear();
+	tmp_string.to_lower();
+	wchar_t start = utoupper(tmp_string.get_string()[0]);
+	rename_squad_header.append_print(L"%c%ls", start, &tmp_string.get_string()[1]);
 }
 
 int16 c_squad_settings_list::get_last_item_type()
@@ -271,22 +302,57 @@ void c_squad_settings_list::update_list_items(c_list_item_widget* item, int32 sk
 {
 	//INVOKE_TYPE(0x24EEEF, 0x0, void(__thiscall*)(c_squad_settings_list*, c_list_item_widget*, int32), this, item, skin_index);
 
-	s_item_text_mapping items_map[k_total_no_of_squad_list_items] =
+	ASSERT(item);
+	c_text_widget* item_text = item->try_find_text_widget(_default_list_skin_text_main);
+
+	if (item->get_last_data_index() != NONE)
 	{
-		{_item_change_map			, _string_id_change_map				},
-		{_item_change_variant		, _string_id_change_variant			},
-		{_item_change_level			, _string_id_change_level			},
-		{_item_change_difficulty	, _string_id_change_difficulty		},
-		{_item_quick_options		, _string_id_quick_options			},
-		{_item_switch_to_coop		, _string_id_switch_to_coop			},
-		{_item_switch_to_arranged	, _string_id_switch_to_arranged		},
-		{_item_switch_to_optimatch 	, _string_id_switch_to_optimatch	},
-		{_item_change_hopper		, _string_id_change_hopper			},
-		{_item_party_management		, _string_id_party_management		}
-	};
+		s_list_item_datum* item_datum = (s_list_item_datum*)datum_try_and_get(m_list_data, item->get_last_data_index());
+		e_squad_list_items item_type = (e_squad_list_items)item_datum->item_id;
 
-	this->update_list_items_from_mapping(item, skin_index, 0, items_map, k_total_no_of_squad_list_items);
+		if (item_text)
+		{
+			switch (item_type)
+			{
 
+			case _item_change_map:
+				item_text->set_text_from_string_id(_string_id_change_map);
+				break;
+			case _item_change_variant:
+				item_text->set_text_from_string_id(_string_id_change_variant);
+				break;
+			case _item_change_level:
+				item_text->set_text_from_string_id(_string_id_change_level);
+				break;
+			case _item_change_difficulty:
+				item_text->set_text_from_string_id(_string_id_change_difficulty);
+				break;
+			case _item_quick_options:
+				item_text->set_text_from_string_id(_string_id_quick_options);
+				break;
+			case _item_switch_to_coop:
+				item_text->set_text_from_string_id(_string_id_switch_to_coop);
+				break;
+			case _item_switch_to_arranged:
+				item_text->set_text_from_string_id(_string_id_switch_to_arranged);
+				break;
+			case _item_switch_to_optimatch:
+				item_text->set_text_from_string_id(_string_id_switch_to_optimatch);
+				break;
+			case _item_change_hopper:
+				item_text->set_text_from_string_id(_string_id_change_hopper);
+				break;
+			case _item_party_management:
+				item_text->set_text_from_string_id(_string_id_party_management);
+				break;
+			case _item_rename_squad:
+				item_text->set_text(rename_squad_header.get_string());
+				break;
+			default:
+				unreachable();
+			}
+		}
+	}
 }
 
 void c_squad_settings_list::handle_item_pressed_event(s_event_record** pevent, datum* pitem_index)
@@ -329,19 +395,23 @@ void c_squad_settings_list::handle_item_pressed_event(s_event_record** pevent, d
 			break;
 		case _item_party_management:
 			this->handle_item_party_management(pevent);
+			break;		
+		case _item_rename_squad:
+			this->handle_item_rename_squad(pevent);
 			break;
-
+		default:
+			unreachable();
 		}
 	}
 }
 
 void c_squad_settings_list::handle_item_change_map(s_event_record** pevent)
 {
-	return INVOKE_TYPE(0x24F9A1, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
+	INVOKE_TYPE(0x24F9A1, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
 }
 void c_squad_settings_list::handle_item_change_variant(s_event_record** pevent)
 {
-	return INVOKE_TYPE(0x24F9DD, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
+	INVOKE_TYPE(0x24F9DD, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
 }
 void c_squad_settings_list::handle_item_change_level(s_event_record** pevent)
 {
@@ -373,7 +443,7 @@ void c_squad_settings_list::handle_item_change_difficulty(s_event_record** peven
 }
 void c_squad_settings_list::handle_item_quick_options(s_event_record** pevent)
 {
-	return INVOKE_TYPE(0x24EF79, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
+	INVOKE_TYPE(0x24EF79, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
 }
 void c_squad_settings_list::handle_item_switch_to_coop(s_event_record** pevent)
 {
@@ -404,7 +474,7 @@ void c_squad_settings_list::handle_item_switch_to_coop(s_event_record** pevent)
 }
 void c_squad_settings_list::handle_item_switch_to_arranged(s_event_record** pevent)
 {
-	return INVOKE_TYPE(0x24F015, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
+	INVOKE_TYPE(0x24F015, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
 }
 void c_squad_settings_list::handle_item_switch_to_optimatch(s_event_record** pevent)
 {
@@ -423,7 +493,13 @@ void c_squad_settings_list::handle_item_change_hopper(s_event_record** pevent)
 void c_squad_settings_list::handle_item_party_management(s_event_record** pevent)
 {
 	// TODO : figure out why this is broken or invoke a custom menu to handle this
-	return INVOKE_TYPE(0x24F5FD, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
+	INVOKE_TYPE(0x24F5FD, 0x0, void(__thiscall*)(c_squad_settings_list*, s_event_record**), this, pevent);
+}
+void c_squad_settings_list::handle_item_rename_squad(s_event_record** pevent)
+{
+	s_session_interface_globals* session_interface_globals = s_session_interface_globals::get();	
+	ustrncpy(session_name_tmp, session_interface_globals->session_name, NUMBEROF(session_name_tmp));
+	ui_load_virtual_keyboard(session_name_tmp, NUMBEROF(session_name_tmp), _vkbd_context_squad_name_entry);
 }
 
 
@@ -622,6 +698,26 @@ void c_screen_squad_settings::update()
 		header_string = _string_id_party_management_header;
 		value_string = _string_id_player_options;
 		bitm_index = _xbox_live_bitmap_type_party_management;
+		break;	
+	case _item_rename_squad:
+		help_string = _string_id_invalid;
+		header_string = _string_id_invalid;
+		value_string = _string_id_invalid;
+		bitm_index = _xbox_live_bitmap_type_unknown_map;
+
+		if (option_header_text_block)
+		{
+			option_header_text_block->set_text(rename_squad_header.get_string());
+		}
+		if (option_help_text_block)
+		{
+			option_help_text_block->set_text(rename_squad_help.get_string());
+		}
+		if (option_value_text_block)
+		{
+			option_value_text_block->set_text(s_session_interface_globals::get()->session_name);
+		}
+
 		break;
 	default:
 		help_string = _string_id_empty_string;
@@ -631,12 +727,13 @@ void c_screen_squad_settings::update()
 
 	}
 
-	if (option_help_text_block)
+	if (option_help_text_block && value_string != _string_id_invalid)
 		option_help_text_block->set_text_from_string_id(help_string);
-	if (option_header_text_block)
+	if (option_header_text_block && value_string != _string_id_invalid)
 		option_header_text_block->set_text_from_string_id(header_string);
-	if (option_value_text_block)
+	if (option_value_text_block && value_string != _string_id_invalid)
 		option_value_text_block->set_text_from_string_id(value_string);
+	
 	if (option_bitmap)
 	{
 		option_bitmap->verify_and_change_sprite(bitm_index);

--- a/xlive/Blam/Engine/interface/screens/screen_squad_settings.h
+++ b/xlive/Blam/Engine/interface/screens/screen_squad_settings.h
@@ -31,6 +31,7 @@ protected:
 	void handle_item_switch_to_optimatch(s_event_record** pevent);
 	void handle_item_change_hopper(s_event_record** pevent);
 	void handle_item_party_management(s_event_record** pevent);
+	void handle_item_rename_squad(s_event_record** pevent);
 
 
 public:

--- a/xlive/Blam/Engine/interface/screens/screen_video_settings.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_video_settings.cpp
@@ -210,7 +210,7 @@ void c_video_settings_list::handle_item_pressed_event(s_event_record** pevent, d
 	params.m_window_index = _window_4;
 	params.m_context = 0;
 	params.m_user_flags = FLAG((*pevent)->controller);
-	params.m_channel_type = _user_interface_channel_type_dialog;
+	params.m_channel_type = _user_interface_channel_type_gameshell_dialog;
 	params.m_screen_state.field_0 = NONE;
 	params.m_screen_state.m_last_focused_item_order = NONE;
 	params.m_screen_state.m_last_focused_item_index = NONE;

--- a/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
@@ -44,6 +44,12 @@ const s_keyboard_custom_labels k_keyboard_custom_label_globals[k_language_count]
 
 bool g_vkbd_create_open_profile_config = true;
 
+/* prototypes */
+
+static void get_keyboard_labels(e_vkbd_context_type context, const wchar_t** out_header_text, const wchar_t** out_subheader_text);
+static void apply_rename_squad_entry_patches();
+
+
 /* private code */
 
 // header & subheader

--- a/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
@@ -197,7 +197,7 @@ void* ui_load_virtual_keyboard(wchar_t* out_keyboard_text, uint32 out_keyboard_t
 {
 	s_screen_parameters virtual_keyboard_params;
 	virtual_keyboard_params.m_context = nullptr;
-	virtual_keyboard_params.data_new(0, FLAG(0), _user_interface_channel_type_keyboard, _window_4, c_screen_virtual_keyboard::load);
+	virtual_keyboard_params.data_new(0, FLAG(0), _user_interface_channel_type_virtual_keyboard, _window_4, c_screen_virtual_keyboard::load);
 	c_screen_virtual_keyboard* virtual_keyboard = (c_screen_virtual_keyboard*)virtual_keyboard_params.ui_screen_load_proc_exec();
 
 	virtual_keyboard->set_context(keyboard_type);

--- a/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
@@ -57,6 +57,45 @@ static void get_keyboard_labels(e_vkbd_context_type context, const wchar_t** out
 	return;
 }
 
+static void apply_rename_squad_entry_patches()
+{
+    static uint8 accentsPatchCode[] =
+    {
+        0x83,0xF9,_vkbd_context_message_entry,
+        0x0F,0x8C,0x03,0xFF,0xFF,0xFF,
+        0x83,0xF9,_vkbd_context_search_description,
+        0x0F,0x8F,0xFA,0xFE,0xFF,0xFF,
+        0x90
+    };
+
+    static uint8 symbolsPatchCode[] =
+    {
+        0x83,0xF9,_vkbd_context_message_entry,
+        0x0F,0x8C,0xE4,0xFE,0xFF,0xFF,
+        0x83,0xF9,_vkbd_context_search_description,
+        0x0F,0x8F,0xDB,0xFE,0xFF,0xFF,
+        0x90
+    };
+
+    /*
+    
+          if ( vkbd_context == _vkbd_context_type_message_entry
+          || vkbd_context == _vkbd_context_type_message_entry2
+          || vkbd_context == _vkbd_context_type_search_description )
+
+          with
+
+          if ( vkbd_context >= _vkbd_context_type_message_entry 
+          && vkbd_context <= _vkbd_context_type_search_description )
+
+    */
+
+    WriteBytes(Memory::GetAddress(0x23CED1), accentsPatchCode, NUMBEROF(accentsPatchCode));// case _vkbd_button_type_accents_0:
+    WriteBytes(Memory::GetAddress(0x23CEF0), symbolsPatchCode, NUMBEROF(symbolsPatchCode));// case _vkbd_button_type_symbols_0:
+
+}
+
+
 /* public code */
 
 c_virtual_keyboard_button::c_virtual_keyboard_button():
@@ -233,9 +272,8 @@ void __declspec(naked) jmp_c_screen_virtual_keyboard__load_player_profile_edit()
 void c_screen_virtual_keyboard::apply_patches()
 {
 	DETOUR_ATTACH(p_load_player_profile_edit, Memory::GetAddress<t_load_player_profile_edit>(0x23C7B2), jmp_c_screen_virtual_keyboard__load_player_profile_edit);
-	
-	//remove 16 character check for squad-name-entry
-	NopFill(Memory::GetAddress(0x23B1D1), 3);
+
+    apply_rename_squad_entry_patches();
 }
 
 void ui_set_virtual_keyboard_in_use(bool state)

--- a/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
+++ b/xlive/Blam/Engine/interface/screens/screen_virtual_keyboard.cpp
@@ -44,6 +44,8 @@ const s_keyboard_custom_labels k_keyboard_custom_label_globals[k_language_count]
 
 bool g_vkbd_create_open_profile_config = true;
 
+/* private code */
+
 // header & subheader
 static void get_keyboard_labels(e_vkbd_context_type context, const wchar_t** out_header_text, const wchar_t** out_subheader_text)
 {
@@ -54,6 +56,8 @@ static void get_keyboard_labels(e_vkbd_context_type context, const wchar_t** out
 	*out_subheader_text = k_keyboard_custom_label_globals[_language_english][context - k_virtual_keyboard_custom_context_start].subheader_text;
 	return;
 }
+
+/* public code */
 
 c_virtual_keyboard_button::c_virtual_keyboard_button():
 	c_button_widget(NONE,0)
@@ -229,6 +233,9 @@ void __declspec(naked) jmp_c_screen_virtual_keyboard__load_player_profile_edit()
 void c_screen_virtual_keyboard::apply_patches()
 {
 	DETOUR_ATTACH(p_load_player_profile_edit, Memory::GetAddress<t_load_player_profile_edit>(0x23C7B2), jmp_c_screen_virtual_keyboard__load_player_profile_edit);
+	
+	//remove 16 character check for squad-name-entry
+	NopFill(Memory::GetAddress(0x23B1D1), 3);
 }
 
 void ui_set_virtual_keyboard_in_use(bool state)

--- a/xlive/Blam/Engine/interface/user_interface.cpp
+++ b/xlive/Blam/Engine/interface/user_interface.cpp
@@ -1,12 +1,369 @@
 #include "stdafx.h"
 #include "user_interface.h"
 
+#include "main/console.h"
+#include "screens/screen_error_dialog.h"
+#include "user_interface_globals.h"
 #include "user_interface_widget_window.h"
 
 #include "cutscene/cinematics.h"
 #include "game/game.h"
 
+#include "H2MOD/GUI/imgui_integration/Console/ImGui_ConsoleImpl.h"
 #include "XLive/xbox/xbox.h"
+
+#define ERROR_STRING_CREATE(_value)\
+				_value,STRINGIFY(_value)
+
+/* constants */
+
+struct error_code_string_mapping
+{
+	e_ui_error_types error_code;
+	const char* string;
+};
+
+static error_code_string_mapping table[] =
+{
+	{ERROR_STRING_CREATE(_ui_error_unknown)},
+	{ERROR_STRING_CREATE(_ui_error_generic)},
+	{ERROR_STRING_CREATE(_ui_error_generic_networking)},
+	{ERROR_STRING_CREATE(_ui_error_system_link_generic_join_failure)},
+	{ERROR_STRING_CREATE(_ui_error_system_link_no_network_connection)},
+	{ERROR_STRING_CREATE(_ui_error_system_link_connection_lost)},
+	{ERROR_STRING_CREATE(_ui_error_network_game_oos)},
+	{ERROR_STRING_CREATE(_ui_error_xbox_live_sign_out_confirmation)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_revert_to_last_save)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_quit_without_save)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_delete_player_profile)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_delete_variant)},
+	{ERROR_STRING_CREATE(_ui_error_player_profile_creation_failed)},
+	{ERROR_STRING_CREATE(_ui_error_variant_profile_creation_failed)},
+	{ERROR_STRING_CREATE(_ui_error_playlist_creation_failed)},
+	{ERROR_STRING_CREATE(_ui_error_core_file_load_failed)},
+	{ERROR_STRING_CREATE(_ui_error_mu_removed_during_player_profile_save)},
+	{ERROR_STRING_CREATE(_ui_error_mu_removed_during_variant_save)},
+	{ERROR_STRING_CREATE(_ui_error_mu_removed_during_playlist_save)},
+	{ERROR_STRING_CREATE(_ui_error_message_saving_to_mu)},
+	{ERROR_STRING_CREATE(_ui_error_message_saving_file)},
+	{ERROR_STRING_CREATE(_ui_error_message_creating_player_profile)},
+	{ERROR_STRING_CREATE(_ui_error_message_creating_variant_profile)},
+	{ERROR_STRING_CREATE(_ui_error_message_saving_checkpoint)},
+	{ERROR_STRING_CREATE(_ui_error_failed_to_load_player_profile)},
+	{ERROR_STRING_CREATE(_ui_error_failed_to_load_variant)},
+	{ERROR_STRING_CREATE(_ui_error_failed_to_load_playlist)},
+	{ERROR_STRING_CREATE(_ui_error_failed_to_load_save_game)},
+	{ERROR_STRING_CREATE(_ui_error_controller1_removed)},
+	{ERROR_STRING_CREATE(_ui_error_controller2_removed)},
+	{ERROR_STRING_CREATE(_ui_error_controller3_removed)},
+	{ERROR_STRING_CREATE(_ui_error_controller4_removed)},
+	{ERROR_STRING_CREATE(_ui_error_need_more_free_blocks_to_save)},
+	{ERROR_STRING_CREATE(_ui_error_maximum_saved_game_files_already_exist)},
+	{ERROR_STRING_CREATE(_ui_error_dirty_disk)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_cannot_access_service)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_title_update_required)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_servers_too_busy)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_duplicate_logon)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_account_management_required)},
+	{ERROR_STRING_CREATE(_ui_error_warning_xblive_recommended_messages_available)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_invalid_match_session)},
+	{ERROR_STRING_CREATE(_ui_error_warning_xblive_poor_network_performance)},
+	{ERROR_STRING_CREATE(_ui_error_not_enough_open_slots_to_join_match_session)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_corrupt_download_content)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_xblive_corrupt_saved_game_file_removal)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_invalid_user_account)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_boot_clan_member)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_controller_sign_out)},
+	{ERROR_STRING_CREATE(_ui_error_beta_xblive_service_qos_report)},
+	{ERROR_STRING_CREATE(_ui_error_beta_feature_disabled)},
+	{ERROR_STRING_CREATE(_ui_error_beta_network_connection_required)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_friend_removal)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_boot_to_dash)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_launch_xdemos)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_connection_to_xbox_live_lost)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_message_send_failure)},
+	{ERROR_STRING_CREATE(_ui_error_network_link_lost)},
+	{ERROR_STRING_CREATE(_ui_error_network_link_required)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_invalid_passcode)},
+	{ERROR_STRING_CREATE(_ui_error_join_aborted)},
+	{ERROR_STRING_CREATE(_ui_error_join_session_not_found)},
+	{ERROR_STRING_CREATE(_ui_error_join_qos_failure)},
+	{ERROR_STRING_CREATE(_ui_error_join_data_decode_failure)},
+	{ERROR_STRING_CREATE(_ui_error_join_game_full)},
+	{ERROR_STRING_CREATE(_ui_error_join_game_closed)},
+	{ERROR_STRING_CREATE(_ui_error_join_version_mismatch)},
+	{ERROR_STRING_CREATE(_ui_error_join_failed_unknown_reason)},
+	{ERROR_STRING_CREATE(_ui_error_join_failed_friend_in_matchmade_game)},
+	{ERROR_STRING_CREATE(_ui_error_player_profile_name_must_be_unique)},
+	{ERROR_STRING_CREATE(_ui_error_variant_name_must_be_unique)},
+	{ERROR_STRING_CREATE(_ui_error_playlist_name_must_be_unique)},
+	{ERROR_STRING_CREATE(_ui_error_saved_film_name_must_be_unique)},
+	{ERROR_STRING_CREATE(_ui_error_no_free_slots_player_profile)},
+	{ERROR_STRING_CREATE(_ui_error_no_free_slots_variant)},
+	{ERROR_STRING_CREATE(_ui_error_no_free_slots_playlist)},
+	{ERROR_STRING_CREATE(_ui_error_no_free_slots_saved_film)},
+	{ERROR_STRING_CREATE(_ui_error_need_more_space_for_player_profile)},
+	{ERROR_STRING_CREATE(_ui_error_need_more_space_for_variant)},
+	{ERROR_STRING_CREATE(_ui_error_need_more_space_for_playlist)},
+	{ERROR_STRING_CREATE(_ui_error_need_more_space_for_saved_film)},
+	{ERROR_STRING_CREATE(_ui_error_cannot_set_privileges_on_member_whose_data_not_known)},
+	{ERROR_STRING_CREATE(_ui_error_cant_delete_default_profile)},
+	{ERROR_STRING_CREATE(_ui_error_cant_delete_default_variant)},
+	{ERROR_STRING_CREATE(_ui_error_cant_delete_default_playlist)},
+	{ERROR_STRING_CREATE(_ui_error_cant_delete_default_saved_film)},
+	{ERROR_STRING_CREATE(_ui_error_cant_delete_profile_in_use)},
+	{ERROR_STRING_CREATE(_ui_error_player_profile_name_must_have_alphanumeric_characters)},
+	{ERROR_STRING_CREATE(_ui_error_variant_name_must_have_alphanumeric_characters)},
+	{ERROR_STRING_CREATE(_ui_error_playlist_name_must_have_alphanumeric_characters)},
+	{ERROR_STRING_CREATE(_ui_error_saved_film_name_must_have_alphanumeric_characters)},
+	{ERROR_STRING_CREATE(_ui_error_teams_not_a_member)},
+	{ERROR_STRING_CREATE(_ui_error_teams_insufficient_privileges)},
+	{ERROR_STRING_CREATE(_ui_error_teams_server_busy)},
+	{ERROR_STRING_CREATE(_ui_error_teams_team_full)},
+	{ERROR_STRING_CREATE(_ui_error_teams_member_pending)},
+	{ERROR_STRING_CREATE(_ui_error_teams_too_many_requests)},
+	{ERROR_STRING_CREATE(_ui_error_teams_user_already_exists)},
+	{ERROR_STRING_CREATE(_ui_error_teams_user_not_found)},
+	{ERROR_STRING_CREATE(_ui_error_teams_user_teams_full)},
+	{ERROR_STRING_CREATE(_ui_error_teams_no_task)},
+	{ERROR_STRING_CREATE(_ui_error_teams_too_many_teams)},
+	{ERROR_STRING_CREATE(_ui_error_teams_team_already_exists)},
+	{ERROR_STRING_CREATE(_ui_error_teams_team_not_found)},
+	{ERROR_STRING_CREATE(_ui_error_teams_name_contains_bad_words)},
+	{ERROR_STRING_CREATE(_ui_error_teams_description_contains_bad_words)},
+	{ERROR_STRING_CREATE(_ui_error_teams_motto_contains_bad_words)},
+	{ERROR_STRING_CREATE(_ui_error_teams_url_contains_bad_words)},
+	{ERROR_STRING_CREATE(_ui_error_teams_no_admin)},
+	{ERROR_STRING_CREATE(_ui_error_teams_cannot_set_privileges_on_member_whose_data_not_known)},
+	{ERROR_STRING_CREATE(_ui_error_live_unknown)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_delete_profile)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_delete_playlist)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_delete_saved_film)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_live_sign_out)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_confirm_friend_removal)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_promotion_to_superuser)},
+	{ERROR_STRING_CREATE(_ui_error_warn_no_more_clan_superusers)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_corrupt_profile)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_xbox_live_sign_out)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_corrupt_game_variant)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_leave_clan)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_corrupt_playlist)},
+	{ERROR_STRING_CREATE(_ui_error_cant_join_gameinvite_without_signon)},
+	{ERROR_STRING_CREATE(_ui_confirm_proceed_to_crossgame_invite)},
+	{ERROR_STRING_CREATE(_ui_confirm_decline_crossgame_invite)},
+	{ERROR_STRING_CREATE(_ui_warn_insert_cd_for_crossgame_invite)},
+	{ERROR_STRING_CREATE(_ui_error_need_more_space_for_saved_game)},
+	{ERROR_STRING_CREATE(_ui_error_saved_game_cannot_be_loaded)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_controller_signout_with_guests)},
+	{ERROR_STRING_CREATE(_ui_error_warning_party_closed)},
+	{ERROR_STRING_CREATE(_ui_error_warning_party_required)},
+	{ERROR_STRING_CREATE(_ui_error_warning_party_full)},
+	{ERROR_STRING_CREATE(_ui_error_warning_player_in_mm_game)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_failed_to_sign_in)},
+	{ERROR_STRING_CREATE(_ui_error_cant_sign_out_master_with_guests)},
+	{ERROR_STRING_CREATE(_ui_error_this_dot_command_is_obsolete)},
+	{ERROR_STRING_CREATE(_ui_error_this_has_not_been_unlocked)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_leave_lobby)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_party_leader_leave_matchmaking)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_single_box_leave_matchmaking)},
+	{ERROR_STRING_CREATE(_ui_error_clan_name_not_valid)},
+	{ERROR_STRING_CREATE(_ui_error_player_list_full)},
+	{ERROR_STRING_CREATE(_ui_error_recipient_has_blocked_you)},
+	{ERROR_STRING_CREATE(_ui_error_friend_pending)},
+	{ERROR_STRING_CREATE(_ui_error_too_many_requests)},
+	{ERROR_STRING_CREATE(_ui_error_player_already_in_list)},
+	{ERROR_STRING_CREATE(_ui_error_gamertag_not_found)},
+	{ERROR_STRING_CREATE(_ui_error_cannot_message_self)},
+	{ERROR_STRING_CREATE(_ui_error_warning_last_overlord_cant_leave_clan)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_boot_player)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_party_member_leave_pcr)},
+	{ERROR_STRING_CREATE(_ui_error_cannot_sign_in_during_countdown)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_invalid_user)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_user_not_authorized)},
+	{ERROR_STRING_CREATE(_ui_error_OBSOLETE)},
+	{ERROR_STRING_CREATE(_ui_error_OBSOLETE2)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_banned_xbox)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_banned_user)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_banned_title)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_leader)},
+	{ERROR_STRING_CREATE(_ui_error_message_objectionable_content)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_enter_downloader)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_block_user)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_negative_feedback)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_change_clan_member_level)},
+	{ERROR_STRING_CREATE(_ui_error_blank_gamertag)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_save_and_exit_campaign)},
+	{ERROR_STRING_CREATE(_ui_error_cant_join_during_matchmaking)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_restart_level)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failure_generic)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failure_missing_content)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failure_aborted)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failure_membership_changed)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_end_game_session)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_only_player)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_ranked_leader)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_ranked)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_leader)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_only_player)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live)},
+	{ERROR_STRING_CREATE(_ui_error_recipient_list_full)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_campaign)},
+	{ERROR_STRING_CREATE(_ui_error_xblive_connection_to_xbox_live_lost_save_and_quit)},
+	{ERROR_STRING_CREATE(_ui_error_booted_from_session)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_guest)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_ranked_only_player)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_unranked_only_player)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_unranked_leader)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_exit_game_session_xbox_live_unranked)},
+	{ERROR_STRING_CREATE(_ui_error_cant_join_friend_while_in_matchmade_game)},
+	{ERROR_STRING_CREATE(_ui_error_map_load_failure)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_campaign_without_achievements)},
+	{ERROR_STRING_CREATE(_ui_error_no_live_menu_branch_without_signin)},
+	{ERROR_STRING_CREATE(_ui_error_map_out_of_hard_disk_space)},
+	{ERROR_STRING_CREATE(_ui_error_device_not_supported)},
+	{ERROR_STRING_CREATE(_ui_error_achievements_interrupted)},
+	{ERROR_STRING_CREATE(_confirm_lose_progress)},
+	{ERROR_STRING_CREATE(_ui_error_beta_achievements_disabled)},
+	{ERROR_STRING_CREATE(_ui_error_cannot_connect_versions_wrong)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_booted_from_session)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_boot_player_from_squad)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_leave_system_link_lobby)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_party_member_leave_matchmaking)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_quit_single_player)},
+	{ERROR_STRING_CREATE(_ui_error_controller_removed)},
+	{ERROR_STRING_CREATE(_ui_error_download_in_progress)},
+	{ERROR_STRING_CREATE(_ui_error_download_fail)},
+	{ERROR_STRING_CREATE(_ui_error_failed_to_load_map)},
+	{ERROR_STRING_CREATE(_ui_error_feature_requires_gold)},
+	{ERROR_STRING_CREATE(_ui_error_keyboard_mapping)},
+	{ERROR_STRING_CREATE(_ui_error_keyboard_removed)},
+	{ERROR_STRING_CREATE(_ui_error_live_game_unavailable)},
+	{ERROR_STRING_CREATE(_ui_error_map_missing)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failed_generic)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failed_missing_content)},
+	{ERROR_STRING_CREATE(_ui_error_mouse_removed)},
+	{ERROR_STRING_CREATE(_ui_error_party_not_all_on_live)},
+	{ERROR_STRING_CREATE(_ui_error_party_subnet_not_shared)},
+	{ERROR_STRING_CREATE(_ui_error_required_game_update)},
+	{ERROR_STRING_CREATE(_ui_error_saved_game_cannot_be_saved)},
+	{ERROR_STRING_CREATE(_ui_error_sound_microphone_not_supported)},
+	{ERROR_STRING_CREATE(_ui_error_system_link_direct_IP)},
+	{ERROR_STRING_CREATE(_ui_error_text_chat_muted)},
+	{ERROR_STRING_CREATE(_ui_error_text_chat_parental_controls)},
+	{ERROR_STRING_CREATE(_ui_error_update_start)},
+	{ERROR_STRING_CREATE(_ui_error_update_fail)},
+	{ERROR_STRING_CREATE(_ui_error_update_fail_blocks)},
+	{ERROR_STRING_CREATE(_ui_error_update_exists)},
+	{ERROR_STRING_CREATE(_ui_error_insert_original)},
+	{ERROR_STRING_CREATE(_ui_error_update_fail_network_lost)},
+	{ERROR_STRING_CREATE(_ui_error_update_mp_out_of_sync)},
+	{ERROR_STRING_CREATE(_ui_error_update_must_upgrade)},
+	{ERROR_STRING_CREATE(_ui_error_voice_gold_required)},
+	{ERROR_STRING_CREATE(_ui_error_voice_parental_controls)},
+	{ERROR_STRING_CREATE(_ui_error_warning_xblive_poor_network_perofrmance)},
+	{ERROR_STRING_CREATE(_ui_error_you_missing_map)},
+	{ERROR_STRING_CREATE(_ui_error_someone_missing_map)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_no_source)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_disk_read)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_no_engine_running)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_signature_verification)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_drive_removed)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_disk_full)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_permissions)},
+	{ERROR_STRING_CREATE(_ui_error_tnp_unknown)},
+	{ERROR_STRING_CREATE(_ui_error_continue_install)},
+	{ERROR_STRING_CREATE(_ui_error_cancel_install)},
+	{ERROR_STRING_CREATE(_ui_error_confirm_upsell_gold)},
+	{ERROR_STRING_CREATE(_ui_error_add_to_favorites)},
+	{ERROR_STRING_CREATE(_ui_error_remove_from_favorites)},
+	{ERROR_STRING_CREATE(_ui_error_updating_favorites)},
+	{ERROR_STRING_CREATE(_ui_error_choose_exisiting_checkpoint_location)},
+	{ERROR_STRING_CREATE(_ui_error_choose_new_checkpoint_location_checkpoints_exist_on_live_and_locally)},
+	{ERROR_STRING_CREATE(_ui_error_choose_new_checkpoint_location_checkpoints_exist_on_live)},
+	{ERROR_STRING_CREATE(_ui_error_choose_new_checkpoint_location_checkpoints_exist_locally)},
+	{ERROR_STRING_CREATE(_ui_error_download_map)},
+	{ERROR_STRING_CREATE(_ui_error_want_to_download_map)},
+	{ERROR_STRING_CREATE(_ui_error_ok_download_map)},
+	{ERROR_STRING_CREATE(_ui_error_cancel_download_map)},
+	{ERROR_STRING_CREATE(_ui_error_not_gold_no_map_download)},
+	{ERROR_STRING_CREATE(_ui_error_map_download_connection_lost)},
+	{ERROR_STRING_CREATE(_ui_error_map_download_collision)},
+	{ERROR_STRING_CREATE(_ui_error_map_download_disk_write_error)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failed_no_games)},
+	{ERROR_STRING_CREATE(_ui_error_matchmaking_failed_timeout)},
+	{ERROR_STRING_CREATE(_ui_error_live_checkpoint_connection_dropped)},
+	{ERROR_STRING_CREATE(_ui_error_live_checkpoint_hash_mismatch)},
+	{ERROR_STRING_CREATE(_ui_error_join_gold_game_not_allowed)},
+	{ERROR_STRING_CREATE(_ui_error_join_locked_game_not_allowed)},
+	{ERROR_STRING_CREATE(_ui_error_system_link_port_in_use)},
+	{ERROR_STRING_CREATE(_ui_error_invite_requires_signin)},
+	{ERROR_STRING_CREATE(_ui_error_overwrite_custom_keyboard_mappings)},
+	{ERROR_STRING_CREATE(_ui_error_profile_version_mismatch)},
+	{ERROR_STRING_CREATE(_ui_error_profane_map_name)},
+	{ERROR_STRING_CREATE(_ui_error_profane_variant_name)},
+	{ERROR_STRING_CREATE(_ui_error_demo_version_no_more_for_you)},
+	{ERROR_STRING_CREATE(_ui_error_no_fullscreen_res)},
+	{ERROR_STRING_CREATE(_ui_error_install_not_complete)},
+	{ERROR_STRING_CREATE(_ui_error_lan_fail_download_map)},
+	{ERROR_STRING_CREATE(_ui_error_locater_service_failed)},
+	{ERROR_STRING_CREATE(_ui_error_double_mapping_actions)},
+	{ERROR_STRING_CREATE(_ui_error_no_multiplayer_achievements_for_silver)},
+	{ERROR_STRING_CREATE(_ui_error_map_download_in_game)},
+	{ERROR_STRING_CREATE(_ui_error_locator_service_timed_out)},
+	{ERROR_STRING_CREATE(_ui_error_connection_to_host_lost)},
+	{ERROR_STRING_CREATE(_ui_error_map_download_profane_name) },
+
+};
+
+
+/* private code */
+
+const char* user_interface_error_codes_get_name(e_ui_error_types error_code)
+{
+	ASSERT(IN_RANGE(error_code, _ui_error_unknown, k_last_ui_error_code));
+	ASSERT(table[error_code].error_code == error_code);
+	return table[error_code].string;
+}
+
+void ui_test_error_code(e_ui_error_types error_id, bool use_cancel, bool confirmation)
+{
+	if (error_id > k_last_ui_error_code)
+	{
+		error(_error_silent, "error code must be between 0 & %d", (int32)k_last_ui_error_code);
+	}
+	else
+	{		
+		 //console_printf("error code #%d= '%s'", error_id, user_interface_error_codes_get_name(error_id));
+		CartographerConsole::LogToMainTabCb(StringFlag_None, "error code #%d= '%s'", error_id, user_interface_error_codes_get_name(error_id));
+	
+		if (confirmation)
+		{
+			user_interface_error_ok_cancle_dialog_show_confirmation(
+				_user_interface_channel_type_game_error,
+				_window_4,
+				NONE,
+				nullptr,
+				error_id);
+		}
+		else if (use_cancel)
+		{
+			c_screen_error_dialog_ok_cancel::show_dialog(
+				_user_interface_channel_type_game_error,
+				error_id,
+				_window_4,
+				(uint16)NONE,
+				nullptr,
+				nullptr,
+				0,
+				0);
+		}
+		else
+		{
+			screen_error_ok_dialog_show(_user_interface_channel_type_game_error, error_id, _window_4, NONE, nullptr, nullptr);
+		}
+	}
+}
 
 /* public code */
 
@@ -66,9 +423,9 @@ void __cdecl screen_error_ok_dialog_with_custom_text(e_user_interface_channel_ty
 	return INVOKE(0x20E1DA, 0x0, screen_error_ok_dialog_with_custom_text, channel_type, ui_error_index, window_index, user_flags, ok_callback, fallback, custom_title, custom_body);
 }
 
-void __cdecl user_interface_error_display_ok_cancel_dialog_with_ok_callback(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type)
+void __cdecl user_interface_error_ok_cancle_dialog_show_confirmation(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type)
 {
-	INVOKE(0x20E3BB, 0x0, user_interface_error_display_ok_cancel_dialog_with_ok_callback, channel_type, window_index, user_flags, ok_callback_handle, error_type);
+	INVOKE(0x20E3BB, 0x0, user_interface_error_ok_cancle_dialog_show_confirmation, channel_type, window_index, user_flags, ok_callback_handle, error_type);
 	return;
 }
 
@@ -119,3 +476,52 @@ uint32 user_interface_set_context_presence(e_context_presence game_mode)
 {
 	return XUserSetContext(0, X_CONTEXT_PRESENCE, game_mode);
 }
+
+void user_interface_debug_load_main_menu()
+{
+	user_interface_enter_game_shell(0);
+}
+
+void user_interface_debug_text_bounds(bool value)
+{
+	*Memory::GetAddress<bool*>(0x977370) = value;
+}
+
+void user_interface_debug_show_title_safe_bounds(bool value)
+{
+	user_interface_globals_get()->render_title_safe_bounds = value;
+}
+
+void user_interface_debug_element_bounds(bool value)
+{
+	user_interface_globals_get()->render_element_bounds = value;
+}
+
+void user_interface_transition_out_console_window()
+{
+	if (user_interface_globals_get()->gameshell_channel[_window_4].active_or_incoming_screen_exists())
+		user_interface_globals_get()->gameshell_channel[_window_4].transition_out();
+
+	if (user_interface_globals_get()->gameshell_background_channel.active_or_incoming_screen_exists())
+		user_interface_globals_get()->gameshell_background_channel.transition_out();
+}
+
+void user_interface_set_beta(bool value)
+{
+	user_interface_globals_get()->build_is_beta = value;
+}
+
+void user_interface_test_error_ok(int16 id)
+{
+	ui_test_error_code((e_ui_error_types)id, false, false);
+}
+
+void user_interface_test_error_ok_cancel(int16 id)
+{
+	ui_test_error_code((e_ui_error_types)id, true, false);
+}
+void user_interface_test_confirmation(int16 id)
+{
+	ui_test_error_code((e_ui_error_types)id, false, true);
+}
+

--- a/xlive/Blam/Engine/interface/user_interface.cpp
+++ b/xlive/Blam/Engine/interface/user_interface.cpp
@@ -334,8 +334,10 @@ void ui_test_error_code(e_ui_error_types error_id, bool use_cancel, bool confirm
 	}
 	else
 	{		
+#ifdef TERMINAL_ENABLED
 		 //console_printf("error code #%d= '%s'", error_id, user_interface_error_codes_get_name(error_id));
 		CartographerConsole::LogToMainTabCb(StringFlag_None, "error code #%d= '%s'", error_id, user_interface_error_codes_get_name(error_id));
+#endif
 	
 		if (confirmation)
 		{

--- a/xlive/Blam/Engine/interface/user_interface.cpp
+++ b/xlive/Blam/Engine/interface/user_interface.cpp
@@ -12,16 +12,20 @@
 #include "H2MOD/GUI/imgui_integration/Console/ImGui_ConsoleImpl.h"
 #include "XLive/xbox/xbox.h"
 
+/* macros */
+
 #define ERROR_STRING_CREATE(_value)\
 				_value,STRINGIFY(_value)
 
-/* constants */
+/* structures */
 
 struct error_code_string_mapping
 {
 	e_ui_error_types error_code;
 	const char* string;
 };
+
+/* constants */
 
 static error_code_string_mapping table[] =
 {

--- a/xlive/Blam/Engine/interface/user_interface.cpp
+++ b/xlive/Blam/Engine/interface/user_interface.cpp
@@ -339,7 +339,7 @@ void ui_test_error_code(e_ui_error_types error_id, bool use_cancel, bool confirm
 	
 		if (confirmation)
 		{
-			user_interface_error_ok_cancle_dialog_show_confirmation(
+			user_interface_error_ok_cancel_dialog_show_confirmation(
 				_user_interface_channel_type_game_error,
 				_window_4,
 				NONE,
@@ -423,9 +423,9 @@ void __cdecl screen_error_ok_dialog_with_custom_text(e_user_interface_channel_ty
 	return INVOKE(0x20E1DA, 0x0, screen_error_ok_dialog_with_custom_text, channel_type, ui_error_index, window_index, user_flags, ok_callback, fallback, custom_title, custom_body);
 }
 
-void __cdecl user_interface_error_ok_cancle_dialog_show_confirmation(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type)
+void __cdecl user_interface_error_ok_cancel_dialog_show_confirmation(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type)
 {
-	INVOKE(0x20E3BB, 0x0, user_interface_error_ok_cancle_dialog_show_confirmation, channel_type, window_index, user_flags, ok_callback_handle, error_type);
+	INVOKE(0x20E3BB, 0x0, user_interface_error_ok_cancel_dialog_show_confirmation, channel_type, window_index, user_flags, ok_callback_handle, error_type);
 	return;
 }
 

--- a/xlive/Blam/Engine/interface/user_interface.h
+++ b/xlive/Blam/Engine/interface/user_interface.h
@@ -299,9 +299,11 @@ enum e_user_interface_channel_type
 {
 	_user_interface_channel_type_hardware_error = 0,
 	_user_interface_channel_type_game_error,
-	_user_interface_channel_type_keyboard,
-	_user_interface_channel_type_dialog,
-	_user_interface_channel_type_online_menu,
+	_user_interface_channel_type_virtual_keyboard,
+	_user_interface_channel_type_gameshell_dialog,
+	/*_user_interface_channel_type_online_menu,*/
+	// got replaced with dialog_history_channel in h2v
+	_user_interface_channel_type_gameshell_dialog_history,
 	_user_interface_channel_type_gameshell_screen,
 	_user_interface_channel_type_gameshell_background,
 	k_number_of_user_interface_channels

--- a/xlive/Blam/Engine/interface/user_interface.h
+++ b/xlive/Blam/Engine/interface/user_interface.h
@@ -382,7 +382,7 @@ bool __cdecl user_interface_error_screen_is_active(e_user_interface_channel_type
 void __cdecl screen_error_ok_dialog_show(e_user_interface_channel_type channel_type, e_ui_error_types ui_error_index, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback, void* fallback);
 void __cdecl screen_error_ok_dialog_with_custom_text(e_user_interface_channel_type channel_type, e_ui_error_types ui_error_index, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback, void* fallback, const wchar_t* custom_title, const wchar_t* custom_body);
 
-void __cdecl user_interface_error_ok_cancle_dialog_show_confirmation(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type);
+void __cdecl user_interface_error_ok_cancel_dialog_show_confirmation(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type);
 void __cdecl user_interface_back_out_from_channel(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index);
 void __cdecl user_interface_enter_game_shell(int32 context);
 

--- a/xlive/Blam/Engine/interface/user_interface.h
+++ b/xlive/Blam/Engine/interface/user_interface.h
@@ -293,6 +293,7 @@ enum e_ui_error_types : uint32
 	_ui_error_locator_service_timed_out = 0x11D,
 	_ui_error_connection_to_host_lost = 0x11E,
 	_ui_error_map_download_profane_name = 0x11F,
+	k_last_ui_error_code = _ui_error_map_download_profane_name
 };
 
 enum e_user_interface_channel_type
@@ -381,7 +382,7 @@ bool __cdecl user_interface_error_screen_is_active(e_user_interface_channel_type
 void __cdecl screen_error_ok_dialog_show(e_user_interface_channel_type channel_type, e_ui_error_types ui_error_index, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback, void* fallback);
 void __cdecl screen_error_ok_dialog_with_custom_text(e_user_interface_channel_type channel_type, e_ui_error_types ui_error_index, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback, void* fallback, const wchar_t* custom_title, const wchar_t* custom_body);
 
-void __cdecl user_interface_error_display_ok_cancel_dialog_with_ok_callback(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type);
+void __cdecl user_interface_error_ok_cancle_dialog_show_confirmation(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index, int16 user_flags, void* ok_callback_handle, e_ui_error_types error_type);
 void __cdecl user_interface_back_out_from_channel(e_user_interface_channel_type channel_type, e_user_interface_render_window window_index);
 void __cdecl user_interface_enter_game_shell(int32 context);
 
@@ -392,3 +393,13 @@ void __cdecl user_interface_return_to_mainmenu(bool a1);
 void __cdecl user_interface_update(real32 dt);
 
 uint32 user_interface_set_context_presence(e_context_presence game_mode);
+
+void user_interface_debug_load_main_menu();
+void user_interface_debug_text_bounds(bool value);
+void user_interface_debug_show_title_safe_bounds(bool value);
+void user_interface_debug_element_bounds(bool value);
+void user_interface_transition_out_console_window();
+void user_interface_set_beta(bool value);
+void user_interface_test_error_ok(int16 id);
+void user_interface_test_error_ok_cancel(int16 id);
+void user_interface_test_confirmation(int16 id);

--- a/xlive/Blam/Engine/interface/user_interface.h
+++ b/xlive/Blam/Engine/interface/user_interface.h
@@ -315,7 +315,7 @@ enum e_user_interface_render_window
 	_window_3,
 	_window_4,
 
-	k_number_of_render_windows = 4
+	k_number_of_render_windows = 5
 };
 
 /* typedefs */

--- a/xlive/Blam/Engine/interface/user_interface_channel.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_channel.cpp
@@ -1,0 +1,16 @@
+#include "stdafx.h"
+#include "user_interface_channel.h"
+#include "user_interface_widget_window.h"
+
+bool c_user_interface_channel::active_or_incoming_screen_exists()
+{
+    return this->m_active_screen || this->m_incoming_screen;
+}
+
+void c_user_interface_channel::transition_out()
+{
+    if (m_active_screen)
+    {
+        m_active_screen->start_widget_animation(3);
+    }
+}

--- a/xlive/Blam/Engine/interface/user_interface_channel.h
+++ b/xlive/Blam/Engine/interface/user_interface_channel.h
@@ -32,6 +32,9 @@ private:
 
 public:
 
+	bool active_or_incoming_screen_exists();
+	void transition_out();
+
 	// c_user_interface_channel virtual functions
 
 	virtual ~c_user_interface_channel();

--- a/xlive/Blam/Engine/interface/user_interface_channel.h
+++ b/xlive/Blam/Engine/interface/user_interface_channel.h
@@ -17,12 +17,12 @@ enum e_focussed_widget_type : int32
 };
 
 
-/* structures */
+/* classes */
 
 class c_user_interface_channel
 {
 private:
-	/*c_user_interface_channel::_vftable* vtable;*/
+
 	int32 m_window_index;
 	c_screen_widget* m_active_screen;
 	c_screen_widget* m_incoming_screen;

--- a/xlive/Blam/Engine/interface/user_interface_channel.h
+++ b/xlive/Blam/Engine/interface/user_interface_channel.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "user_interface.h"
+
+/* forward declarations */
+
+class c_screen_widget;
+class c_user_interface_widget;
+
+
+/* enums */
+
+enum e_focussed_widget_type : int32
+{
+	_focussed_widget_type_selected = 0x0,
+	_focussed_widget_type_hovered = 0x1, //doesnt exist in h2x
+	k_focussed_widget_types
+};
+
+
+/* structures */
+
+class c_user_interface_channel
+{
+private:
+	/*c_user_interface_channel::_vftable* vtable;*/
+	int32 m_window_index;
+	c_screen_widget* m_active_screen;
+	c_screen_widget* m_incoming_screen;
+	s_screen_parameters m_incoming_screen_parameters;
+	c_screen_widget* m_outgoing_screen;
+	c_user_interface_widget* m_focussed_widgets[k_focussed_widget_types];
+
+public:
+
+	// c_user_interface_channel virtual functions
+
+	virtual ~c_user_interface_channel();
+	virtual void dispose_screens_wrapper();
+	virtual void sub_637627();
+	virtual void dispose_screens();
+	virtual void update_channel();
+	virtual c_screen_widget* sub_638025(rectangle2d* bounds);
+	virtual void register_incoming_screen(c_screen_widget* new_screen, s_screen_parameters* parameters);
+	virtual void  retreat_one_step();
+	virtual int32  destroy_target_screen(c_screen_widget* a2);
+	virtual void construct_parameters_from_active_screen();
+	virtual void  load_screen_from_incoming_parameters();
+};
+ASSERT_STRUCT_SIZE(c_user_interface_channel, 0x3C);

--- a/xlive/Blam/Engine/interface/user_interface_controller.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_controller.cpp
@@ -573,7 +573,7 @@ static void user_interface_controller_boot_to_dash_check(void)
 			exit_callback = user_interface_save_map_and_exit;
 		}
 
-		user_interface_error_ok_cancle_dialog_show_confirmation(
+		user_interface_error_ok_cancel_dialog_show_confirmation(
 			//_user_interface_channel_type_gameshell_dialog, //orignally this , but changed to hardware_error so it can overrule disconnection screen
 			_user_interface_channel_type_hardware_error,
 			_window_4,

--- a/xlive/Blam/Engine/interface/user_interface_controller.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_controller.cpp
@@ -574,7 +574,7 @@ static void user_interface_controller_boot_to_dash_check(void)
 		}
 
 		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
-			//_user_interface_channel_type_dialog, //orignally this , but changed to hardware_error so it can overrule disconnection screen
+			//_user_interface_channel_type_gameshell_dialog, //orignally this , but changed to hardware_error so it can overrule disconnection screen
 			_user_interface_channel_type_hardware_error,
 			_window_4,
 			NONE,

--- a/xlive/Blam/Engine/interface/user_interface_controller.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_controller.cpp
@@ -573,7 +573,7 @@ static void user_interface_controller_boot_to_dash_check(void)
 			exit_callback = user_interface_save_map_and_exit;
 		}
 
-		user_interface_error_display_ok_cancel_dialog_with_ok_callback(
+		user_interface_error_ok_cancle_dialog_show_confirmation(
 			//_user_interface_channel_type_gameshell_dialog, //orignally this , but changed to hardware_error so it can overrule disconnection screen
 			_user_interface_channel_type_hardware_error,
 			_window_4,

--- a/xlive/Blam/Engine/interface/user_interface_controller.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_controller.cpp
@@ -382,11 +382,11 @@ void __cdecl user_interface_controller_update_player_name(e_controller_index con
 		if (online_xuid_is_guest_account(*controller_xuid))
 		{
 			uint8 guest_no = online_xuid_get_guest_account_number(*controller_xuid);
-			wchar_t format[512];
-			user_interface_global_string_get(_string_id_guest_of_ascii_gamertag_unicode_format_string, format);// %d %hs
+			c_maximum_interface_text format;
+			user_interface_global_string_get(_string_id_guest_of_ascii_gamertag_unicode_format_string, &format);// %d %hs
 			usnprintf(controller->player_name,
 				NUMBEROF(controller->player_name),
-				format,
+				format.get_string(),
 				guest_no,
 				guide->m_gamertag);
 		}

--- a/xlive/Blam/Engine/interface/user_interface_globals.cpp
+++ b/xlive/Blam/Engine/interface/user_interface_globals.cpp
@@ -57,3 +57,8 @@ void __cdecl user_interface_globals_set_edit_player_profile(e_controller_index c
 {
 	INVOKE(0x209B72, 0x0, user_interface_globals_set_edit_player_profile, controller_index, profile_index, profile);
 }
+
+s_user_interface_globals* user_interface_globals_get(void)
+{
+	return Memory::GetAddress<s_user_interface_globals*>(0x9718E0);
+}

--- a/xlive/Blam/Engine/interface/user_interface_globals.h
+++ b/xlive/Blam/Engine/interface/user_interface_globals.h
@@ -132,3 +132,4 @@ void __cdecl user_interface_globals_commit_edit_profile_changes();
 void __cdecl user_interface_globals_save_profile_changes_to_disk();
 void __cdecl user_interface_globals_finish_saving_profile_changes();
 void __cdecl user_interface_globals_set_edit_player_profile(e_controller_index controller_index, uint32 profile_index, struct s_saved_game_player_profile* profile);
+s_user_interface_globals* user_interface_globals_get(void);

--- a/xlive/Blam/Engine/interface/user_interface_globals.h
+++ b/xlive/Blam/Engine/interface/user_interface_globals.h
@@ -3,10 +3,32 @@
 
 #include "tag_files/tag_block.h"
 #include "tag_files/tag_reference.h"
+#include "saved_games/game_variant.h"
+#include "saved_games/player_profile.h"
+
+#include "dialog_channel.h"
+#include "game_error_dialog_channel.h"
+#include "gameshell_background_channel.h"
+#include "gameshell_channel.h"
+#include "hardware_error_dialog_channel.h"
+#include "user_interface_channel.h"
+#include "user_interface_main_menu_music.h"
+#include "user_interface_text_chat_receiver.h"
+#include "user_interface_text_chat_sender.h"
 
 /* forward declarations */
 
 enum e_scenario_type : int16;
+
+
+/* enums */
+
+enum
+{
+	k_maximum_number_of_active_screens = 36,
+};
+
+
 
 /* structures */
 
@@ -25,6 +47,69 @@ struct s_user_interface_tag_globals
 	tag_reference game_hopper_descriptions;	// unic
 };
 ASSERT_STRUCT_SIZE(s_user_interface_tag_globals, 32);
+
+#pragma pack(push,1)
+struct s_user_interface_globals
+{
+	int32 field_0;
+	bool game_shell_active;
+	bool render_title_safe_bounds;
+	bool render_screen_tag_path;
+	bool render_element_bounds;
+	bool build_is_beta;
+	int8 gap_9[3];
+	int32 field_C;
+	/*e_scenario_type*/int8 map_type;
+	int8 gap_11[3];
+	float m_near_clip_distance;
+	float m_projection_plane_distance;
+	float m_far_clip_distance;
+	int32 field_20;
+	int32 field_24;
+	int32 field_28;
+	c_gameshell_background_channel gameshell_background_channel;
+	c_gameshell_channel gameshell_channel[k_number_of_render_windows];
+	c_user_interface_channel dialog_channel[k_number_of_render_windows];
+	c_game_error_dialog_channel game_error_channel[k_number_of_render_windows];
+	c_dialog_channel dialog_history_channel[k_number_of_render_windows];
+	c_hardware_error_dialog_channel hardware_errror_channel;
+	c_user_interface_channel virtual_keyboard_channel;
+	c_screen_widget* screen_collection[k_maximum_number_of_active_screens];
+	int8 field_6A8[104];
+	int32 online_task_datum;
+	int32 field_714;
+	int8 field_718[1694];
+	int8 field_DB6[142];
+	int32 field_E44;
+	int32 field_E48;
+	int8 gap_E4C[8];
+	int32 edit_saved_game_variant_index;
+	s_game_variant edit_saved_game_variant;
+	int32 m_controller_index;
+	int32 edit_player_profile_index;
+	s_saved_game_player_profile m_player_profile;
+	int8 field_2198;
+	int8 gap_2199[3];
+	int32 field_219C;
+	int32 m_game_campaign_id;
+	int32 m_game_map_id;
+	int32 m_game_difficulty;
+	bool load_from_persistent_storage;
+	int8 field_21AD;
+	int32 current_year;
+	int32 field_21B2;
+	int32 time_in_hours;
+	int32 field_21BA;
+	int8 gap_21BE[2];
+	c_user_interface_main_menu_music main_menu_music;
+	int32 field_21D8;
+	bool xbox_live_active;
+	int8 gap_21DD[3];
+	c_user_interface_text_chat_sender text_chat_sender;
+	c_user_interface_text_chat_receiver text_chat_receiver;
+};
+#pragma pack(pop)
+ASSERT_STRUCT_SIZE(s_user_interface_globals, 0x3FED);
 
 /* prototypes */
 

--- a/xlive/Blam/Engine/interface/user_interface_main_menu_music.h
+++ b/xlive/Blam/Engine/interface/user_interface_main_menu_music.h
@@ -1,0 +1,20 @@
+#pragma once
+
+
+/* structures */
+
+class c_user_interface_main_menu_music
+{
+private:
+	int32 old_state;
+	int32 new_state;
+	int32 music_playing;
+	int32 state_change_start_time_ms;
+	uint32 m_looping_sound_index;
+	int32 music_end_time_stamp;
+
+public:
+	void update();
+	void update_game_shell_music_state();
+};
+ASSERT_STRUCT_SIZE(c_user_interface_main_menu_music, 0x18);

--- a/xlive/Blam/Engine/interface/user_interface_main_menu_music.h
+++ b/xlive/Blam/Engine/interface/user_interface_main_menu_music.h
@@ -1,7 +1,7 @@
 #pragma once
 
 
-/* structures */
+/* classes */
 
 class c_user_interface_main_menu_music
 {

--- a/xlive/Blam/Engine/interface/user_interface_text_chat.h
+++ b/xlive/Blam/Engine/interface/user_interface_text_chat.h
@@ -1,0 +1,30 @@
+#pragma once
+
+/* enums */
+
+enum e_text_chat_type : int32
+{
+	_text_chat_type_0 = 0x0,
+	_text_chat_type_all = 0x1,
+	_text_chat_type_team = 0x2,
+	_text_chat_type_target_player = 0x3,
+	_text_chat_type_propose = 0x4,
+	_text_chat_type_vote = 0x5,
+	_text_chat_type_6 = 0x6,
+	_text_chat_type_voting_error = 0x7,
+};
+
+
+/* structures */
+
+struct s_text_chat_message
+{
+	int32 field_0;
+	int32 field_4;
+	int32 source;
+	int32 destinations;
+	e_text_chat_type m_chat_type;
+	wchar_t message[121];
+	int8 gap_106[2];
+};
+ASSERT_STRUCT_SIZE(s_text_chat_message, 0x108);

--- a/xlive/Blam/Engine/interface/user_interface_text_chat_receiver.h
+++ b/xlive/Blam/Engine/interface/user_interface_text_chat_receiver.h
@@ -2,7 +2,7 @@
 #include "user_interface_text_chat.h"
 #include "tag_files/string_id.h"
 
-/* structures */
+/* classes */
 
 #pragma pack(push,1)
 class c_user_interface_text_chat_receiver
@@ -21,7 +21,7 @@ class c_user_interface_text_chat_receiver
 public:
 	string_id get_vote_error_message();
 	void post_incoming_messages();
-	void post_vote_error(wchar_t* Source);
+	void post_vote_error(const wchar_t* Source);
 	void add_chat_message(s_text_chat_message* message);
 };
 #pragma pack(pop)

--- a/xlive/Blam/Engine/interface/user_interface_text_chat_receiver.h
+++ b/xlive/Blam/Engine/interface/user_interface_text_chat_receiver.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "user_interface_text_chat.h"
+#include "tag_files/string_id.h"
+
+/* structures */
+
+#pragma pack(push,1)
+class c_user_interface_text_chat_receiver
+{
+	int32 m_line_no;
+	int32 field_4;
+	int32 field_8;
+	int32 m_message_time;
+	wchar_t* m_message_line[30];
+	int16 field_88;
+	int8 gap_8A[7538];
+	string_id m_vote_error_message;
+	void* raw_string_ptr;
+	bool m_valid;
+
+public:
+	string_id get_vote_error_message();
+	void post_incoming_messages();
+	void post_vote_error(wchar_t* Source);
+	void add_chat_message(s_text_chat_message* message);
+};
+#pragma pack(pop)
+ASSERT_STRUCT_SIZE(c_user_interface_text_chat_receiver, 0x1E05);

--- a/xlive/Blam/Engine/interface/user_interface_text_chat_sender.h
+++ b/xlive/Blam/Engine/interface/user_interface_text_chat_sender.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "user_interface_text_chat.h"
 
-/* structures */
+/* classes */
 
 class c_user_interface_text_chat_sender
 {
@@ -11,6 +11,6 @@ private:
 
 public:
 	void set_chat_data(e_text_chat_type chat_type, int32 players_mask);
-	void process_raw_message(wchar_t* raw_msg);
+	void process_raw_message(const wchar_t* raw_msg);
 };
 ASSERT_STRUCT_SIZE(c_user_interface_text_chat_sender, 0x8);

--- a/xlive/Blam/Engine/interface/user_interface_text_chat_sender.h
+++ b/xlive/Blam/Engine/interface/user_interface_text_chat_sender.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "user_interface_text_chat.h"
+
+/* structures */
+
+class c_user_interface_text_chat_sender
+{
+private:
+	e_text_chat_type m_chat_type;
+	int m_destination_players;
+
+public:
+	void set_chat_data(e_text_chat_type chat_type, int32 players_mask);
+	void process_raw_message(wchar_t* raw_msg);
+};
+ASSERT_STRUCT_SIZE(c_user_interface_text_chat_sender, 0x8);

--- a/xlive/Blam/Engine/memory/static_arrays.h
+++ b/xlive/Blam/Engine/memory/static_arrays.h
@@ -610,6 +610,9 @@ const wchar_t* c_static_wchar_string<T>::append_print(const wchar_t* format, ...
 
 /* globals */
 
+typedef c_static_wchar_string<512> c_maximum_interface_text;
+
+
 #ifdef ASSERTS_ENABLED
 extern c_static_string<256> g_static_string_assert_text;
 #endif

--- a/xlive/Blam/Engine/memory/static_arrays.h
+++ b/xlive/Blam/Engine/memory/static_arrays.h
@@ -603,7 +603,7 @@ const wchar_t* c_static_wchar_string<T>::append_print(const wchar_t* format, ...
 	ASSERT(format);
 	ASSERT(current_length >= 0 && current_length < NUMBEROF(m_string));
 
-	uvsnprintf(&m_string[current_length], T - current_length, a2, args);
+	uvsnprintf(&m_string[current_length], T - current_length, format, args);
 	va_end(args);
 	return m_string;
 }

--- a/xlive/Blam/Engine/tag_files/string_id.cpp
+++ b/xlive/Blam/Engine/tag_files/string_id.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "string_id.h"
 
-void __cdecl user_interface_global_string_get(string_id id, wchar_t* dest)
+void __cdecl user_interface_global_string_get(string_id id, c_maximum_interface_text* dest)
 {
 	INVOKE(0x21DC38, 0x6AA91, user_interface_global_string_get, id, dest);
 	return;

--- a/xlive/Blam/Engine/tag_files/string_id.h
+++ b/xlive/Blam/Engine/tag_files/string_id.h
@@ -11,4 +11,4 @@
 
 typedef int32 string_id;
 
-void __cdecl user_interface_global_string_get(string_id id, wchar_t* dest);
+void __cdecl user_interface_global_string_get(string_id id, c_maximum_interface_text* dest);

--- a/xlive/Blam/Engine/text/text_group.cpp
+++ b/xlive/Blam/Engine/text/text_group.cpp
@@ -33,9 +33,9 @@ const int32 c_language_pack::get_num_of_strings() const
 	return m_strings_count;
 }
 
-void c_language_pack::string_list_get_normal_string(string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count)
+void c_language_pack::string_list_get_normal_string(string_id id, c_maximum_interface_text* out_string, int32 strings_start_index, int32 strings_count)
 {
-	INVOKE_TYPE(0x3E332, 0x0, void(__thiscall*)(c_language_pack*, string_id, wchar_t*, int32, int32), this, id, out_string, strings_start_index, strings_count);
+	INVOKE_TYPE(0x3E332, 0x0, void(__thiscall*)(c_language_pack*, string_id, c_maximum_interface_text*, int32, int32), this, id, out_string, strings_start_index, strings_count);
 }
 
 void c_language_pack::get_string_ids(string_id* out_ids, int32 out_count, int32 starting_index, int32 max_count)
@@ -54,7 +54,7 @@ void c_language_pack::get_string_ids(string_id* out_ids, int32 out_count, int32 
 	}
 }
 
-void __cdecl string_list_get_normal_string(datum unic_datum, string_id id, wchar_t* out_string)
+void __cdecl string_list_get_normal_string(datum unic_datum, string_id id, c_maximum_interface_text* out_string)
 {
 	INVOKE(0x3E3AC, 0x0, string_list_get_normal_string, unic_datum, id, out_string);
 }

--- a/xlive/Blam/Engine/text/text_group.h
+++ b/xlive/Blam/Engine/text/text_group.h
@@ -19,7 +19,7 @@ public:
 	utf8* get_string_utf8(string_id id, int32 starting_index, int32 max_count);
 	const int32 get_num_of_strings() const;
 	
-	void string_list_get_normal_string(string_id id, wchar_t* out_string, int32 strings_start_index, int32 strings_count);
+	void string_list_get_normal_string(string_id id, c_maximum_interface_text* out_string, int32 strings_start_index, int32 strings_count);
 	void get_string_ids(string_id* array, int32 array_size, int32 starting_index, int32 max_count);
 
 private:
@@ -35,5 +35,5 @@ ASSERT_STRUCT_SIZE(c_language_pack, 28);
 
 /* public code */
 
-void __cdecl string_list_get_normal_string(datum unic_datum, string_id id, wchar_t* out_string);
+void __cdecl string_list_get_normal_string(datum unic_datum, string_id id, c_maximum_interface_text* out_string);
 void __cdecl string_list_get_string_id_list(datum unic_datum, string_id* out_ids, int32 out_count);

--- a/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
+++ b/xlive/H2MOD/GUI/imgui_integration/Console/CommandCollection.cpp
@@ -9,6 +9,7 @@
 #include "game/cheats.h"
 #include "game/game.h"
 #include "game/players.h"
+#include "interface/user_interface.h"
 #include "main/main.h"
 #include "main/main_game.h"
 #include "main/main_game_time.h"
@@ -91,6 +92,17 @@ namespace CommandCollection
 	static int net_event_display_category_evaluate(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
 	static int net_event_log_category_evaluate(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
 	static int net_event_list_categories_evaluate(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+#endif
+#ifdef UI_DEBUG
+	static int ui_debug_load_main_menu(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_debug_text_bounds(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_debug_show_title_safe_bounds(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_debug_element_bounds(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_transition_out_console_window(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_set_beta(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_test_error_ok(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_test_error_ok_cancel(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
+	static int ui_test_confirmation(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx);
 #endif
 
 	// misc
@@ -176,6 +188,18 @@ void CommandCollection::InitializeCommands()
 	InsertCommand(new ConsoleCommand("net_event_log_category", "sets the log level for a named category of network events", 2, 2, net_event_log_category_evaluate));
 	InsertCommand(new ConsoleCommand("net_event_list_categories", "lists all categories that exist under a particular category string", 1, 1, net_event_list_categories_evaluate));
 #endif
+#ifdef UI_DEBUG
+	InsertCommand(new ConsoleCommand("ui_debug_load_main_menu", "loads the main menu screen", 0, 0, CommandCollection::ui_debug_load_main_menu));
+	InsertCommand(new ConsoleCommand("ui_debug_text_bounds", "toggle rendering of ui text boundaries", 1, 1, CommandCollection::ui_debug_text_bounds));
+	InsertCommand(new ConsoleCommand("ui_debug_show_title_safe_bounds", "toggle display of title safe boundary", 1, 1, CommandCollection::ui_debug_show_title_safe_bounds));
+	InsertCommand(new ConsoleCommand("ui_debug_element_bounds", "toggle rendering of widget tag block bounds ", 1, 1, CommandCollection::ui_debug_element_bounds));
+	InsertCommand(new ConsoleCommand("ui_transition_out_console_window", "transition out any ui on the console window", 0, 0, CommandCollection::ui_transition_out_console_window));
+	InsertCommand(new ConsoleCommand("ui_set_beta", "set ui beta testing on/off", 1, 1, CommandCollection::ui_set_beta));
+	InsertCommand(new ConsoleCommand("ui_test_error_ok", "test error code display w/ ok dialog", 1, 1, CommandCollection::ui_test_error_ok));
+	InsertCommand(new ConsoleCommand("ui_test_error_ok_cancel", "test error code display w/ ok-cancel dialog", 1, 1, CommandCollection::ui_test_error_ok_cancel));
+	InsertCommand(new ConsoleCommand("ui_test_confirmation", "test confirmation dialog display", 1, 1, CommandCollection::ui_test_confirmation));
+#endif
+
 
 	atexit([]() -> void {
 		for (auto command : commandTable)
@@ -1047,6 +1071,168 @@ static int CommandCollection::net_event_log_category_evaluate(const std::vector<
 static int CommandCollection::net_event_list_categories_evaluate(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
 {
 	network_event_dump_categories(tokens[1].c_str());
+	return 0;
+}
+#endif
+
+#ifdef UI_DEBUG
+static int CommandCollection::ui_debug_load_main_menu(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	user_interface_debug_load_main_menu();
+	return 0;
+}
+
+static int CommandCollection::ui_debug_text_bounds(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	bool value;
+
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	std::string exception;
+	if (!ComVar(&value).SetFromStr(tokens[1], exception))
+	{
+		outputCb(StringFlag_None, command_error_bad_arg);
+		outputCb(StringFlag_None, "\t%s", exception.c_str());
+		return 0;
+	}
+
+	user_interface_debug_text_bounds(value);
+	return 0;
+}
+
+static int CommandCollection::ui_debug_show_title_safe_bounds(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	bool value;
+
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	std::string exception;
+	if (!ComVar(&value).SetFromStr(tokens[1], exception))
+	{
+		outputCb(StringFlag_None, command_error_bad_arg);
+		outputCb(StringFlag_None, "\t%s", exception.c_str());
+		return 0;
+	}
+
+	user_interface_debug_show_title_safe_bounds(value);
+	return 0;
+}
+
+static int CommandCollection::ui_debug_element_bounds(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	bool value;
+
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	std::string exception;
+	if (!ComVar(&value).SetFromStr(tokens[1], exception))
+	{
+		outputCb(StringFlag_None, command_error_bad_arg);
+		outputCb(StringFlag_None, "\t%s", exception.c_str());
+		return 0;
+	}
+
+	user_interface_debug_element_bounds(value);
+	return 0;
+}
+
+static int CommandCollection::ui_transition_out_console_window(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	user_interface_transition_out_console_window();
+	return 0;
+}
+
+static int CommandCollection::ui_set_beta(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	bool value;
+
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	std::string exception;
+	if (!ComVar(&value).SetFromStr(tokens[1], exception))
+	{
+		outputCb(StringFlag_None, command_error_bad_arg);
+		outputCb(StringFlag_None, "\t%s", exception.c_str());
+		return 0;
+	}
+
+	user_interface_set_beta(value);
+	return 0;
+}
+
+static int CommandCollection::ui_test_error_ok(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	int32 error_id;
+	std::string exception;
+	ComVar(&error_id).SetFromStr(tokens[1], 0, exception);
+
+	user_interface_test_error_ok((int16)error_id);
+	return 0;
+}
+
+static int CommandCollection::ui_test_error_ok_cancel(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	int32 error_id;
+	std::string exception;
+	ComVar(&error_id).SetFromStr(tokens[1], 0, exception);
+
+	user_interface_test_error_ok_cancel((int16)error_id);
+	return 0;
+}
+
+static int CommandCollection::ui_test_confirmation(const std::vector<std::string>& tokens, ConsoleCommandCtxData ctx)
+{
+	TextOutputCb* outputCb = ctx.outputCb;
+	if (shell_is_dedicated_server()) {
+		outputCb(StringFlag_None, "# command unavailable on dedicated servers");
+		return 0;
+	}
+
+	int32 error_id;
+	std::string exception;
+	ComVar(&error_id).SetFromStr(tokens[1], 0, exception);
+
+	user_interface_test_confirmation((int16)error_id);
 	return 0;
 }
 #endif

--- a/xlive/H2MOD/Modules/CustomMenu/CustomMenuGlobals.cpp
+++ b/xlive/H2MOD/Modules/CustomMenu/CustomMenuGlobals.cpp
@@ -44,7 +44,7 @@ void* ui_custom_cartographer_load_menu(proc_ui_screen_load_cb_t p_ui_screen_proc
 	s_screen_parameters new_screen_params;
 	switch (open_method) {
 	case 3:
-		new_screen_params.data_new(0, FLAG(0), _user_interface_channel_type_dialog, _window_4, p_ui_screen_proc_cb);
+		new_screen_params.data_new(0, FLAG(0), _user_interface_channel_type_gameshell_dialog, _window_4, p_ui_screen_proc_cb);
 		break;
 	case 0:
 	default:

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -327,7 +327,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>WIN32;LLVM;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;NDEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ERRORS_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;LLVM;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;NDEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ERRORS_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;UI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -401,7 +401,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>WIN32;LLVM;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;LLVM;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;NDEBUG;_WINDOWS;_USRDLL;UI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -531,7 +531,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;LLVM;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;_DEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ASSERTS_ENABLED;EVENTS_ENABLED;ERRORS_ENABLED;DEBUG_MEMORY_ENABLED;RASTERIZER_PROFILE_ENABLED;VALIDATE_REAL_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;LLVM;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;_DEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ASSERTS_ENABLED;EVENTS_ENABLED;ERRORS_ENABLED;DEBUG_MEMORY_ENABLED;RASTERIZER_PROFILE_ENABLED;VALIDATE_REAL_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;UI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -1347,7 +1347,13 @@
     <ClInclude Include="Blam\Engine\input\input_process.h" />
     <ClInclude Include="Blam\Engine\input\input_windows.h" />
     <ClInclude Include="Blam\Engine\input\input_xinput.h" />
+    <ClInclude Include="Blam\Engine\interface\channel_with_history.h" />
+    <ClInclude Include="Blam\Engine\interface\dialog_channel.h" />
     <ClInclude Include="Blam\Engine\interface\first_person_weapons.h" />
+    <ClInclude Include="Blam\Engine\interface\gameshell_background_channel.h" />
+    <ClInclude Include="Blam\Engine\interface\gameshell_channel.h" />
+    <ClInclude Include="Blam\Engine\interface\game_error_dialog_channel.h" />
+    <ClInclude Include="Blam\Engine\interface\hardware_error_dialog_channel.h" />
     <ClInclude Include="Blam\Engine\interface\hud.h" />
     <ClInclude Include="Blam\Engine\interface\hud_draw.h" />
     <ClInclude Include="Blam\Engine\interface\hud_messaging.h" />
@@ -1357,6 +1363,7 @@
     <ClInclude Include="Blam\Engine\interface\motion_sensor.h" />
     <ClInclude Include="Blam\Engine\interface\new_hud.h" />
     <ClInclude Include="Blam\Engine\interface\new_hud_draw.h" />
+    <ClInclude Include="Blam\Engine\interface\online_menu_channel.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screens_patches.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_4way_signin.h" />
     <ClInclude Include="Blam\Engine\interface\screens\screen_about_dialog.h" />
@@ -1393,11 +1400,13 @@
     <ClInclude Include="Blam\Engine\interface\signal_slot.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_bitmap_block.h" />
+    <ClInclude Include="Blam\Engine\interface\user_interface_channel.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_controller.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_globals.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_group_widget.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_guide.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_hud_block.h" />
+    <ClInclude Include="Blam\Engine\interface\user_interface_main_menu_music.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_memory.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_model_block.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_networking.h" />
@@ -1408,6 +1417,9 @@
     <ClInclude Include="Blam\Engine\interface\new_hud_definitions.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_screen_widget_definition.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_text_block.h" />
+    <ClInclude Include="Blam\Engine\interface\user_interface_text_chat.h" />
+    <ClInclude Include="Blam\Engine\interface\user_interface_text_chat_receiver.h" />
+    <ClInclude Include="Blam\Engine\interface\user_interface_text_chat_sender.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_utilities.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_widget.h" />
     <ClInclude Include="Blam\Engine\interface\user_interface_widget_button.h" />

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -178,7 +178,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>WIN32;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;NDEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ERRORS_ENABLED;EVENTS_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;NDEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ERRORS_ENABLED;EVENTS_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;UI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -471,7 +471,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;_DEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ASSERTS_ENABLED;EVENTS_ENABLED;ERRORS_ENABLED;DEBUG_MEMORY_ENABLED;RASTERIZER_PROFILE_ENABLED;VALIDATE_REAL_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;MINIUPNP_STATICLIB;NGHTTP2_STATICLIB;CURL_STATICLIB;_DEBUG;_WINDOWS;_USRDLL;TERMINAL_ENABLED;ASSERTS_ENABLED;EVENTS_ENABLED;ERRORS_ENABLED;DEBUG_MEMORY_ENABLED;RASTERIZER_PROFILE_ENABLED;VALIDATE_REAL_ENABLED;OBJECT_OVERRIDE_ENABLED;OBJECT_DEBUG;UI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -943,6 +943,7 @@
     <ClCompile Include="Blam\Engine\interface\screens\screen_video_settings.cpp" />
     <ClCompile Include="Blam\Engine\interface\screens\screen_vsync_setting.cpp" />
     <ClCompile Include="Blam\Engine\interface\user_interface_bitmap_block.cpp" />
+    <ClCompile Include="Blam\Engine\interface\user_interface_channel.cpp" />
     <ClCompile Include="Blam\Engine\interface\user_interface_controller.cpp" />
     <ClCompile Include="Blam\Engine\interface\user_interface_globals.cpp" />
     <ClCompile Include="Blam\Engine\interface\user_interface_group_widget.cpp" />


### PR DESCRIPTION
* Restored original Rename-Squad option that existed back in H2x alpha
<img width="1025" height="741" alt="image" src="https://github.com/user-attachments/assets/c578e64f-0c8b-4910-b2ee-99fdb6edd73e" />


* Added UI Debug commands
``` - ui_debug_load_main_menu
 - ui_debug_text_bounds
 - ui_debug_show_title_safe_bounds
 - ui_debug_element_bounds
 - ui_transition_out_console_window (not sure but this feels broken)
 - ui_set_beta
 - ui_test_error_ok
 - ui_test_error_ok_cancel
 - ui_test_confirmation
 ```