### PR TITLE
move tinyxml include into xml_definition_block.cpp

### DIFF
--- a/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_block.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_block.cpp
@@ -1,9 +1,11 @@
 #include "stdafx.h"
 #include "xml_definition_block.h"
 
+#include <tinyxml/tinyxml2.h>
+
 /* public code */
 
-c_xml_definition_block::c_xml_definition_block(const tinyxml2::XMLElement* base_element, uint32 offset, uint32 size)
+c_xml_definition_block::c_xml_definition_block(const void* base_element, uint32 offset, uint32 size)
 {
 	// Checks to make sure the correct parameters were passed.
 	// offset and size are default -1 and overwritten if the attribute exists
@@ -30,8 +32,10 @@ c_xml_definition_block::c_xml_definition_block(const tinyxml2::XMLElement* base_
 
 	reset_counts();
 
-	if (m_element->Attribute("name"))
-		m_name.set(m_element->Attribute("name"));
+	if (((tinyxml2::XMLElement*)m_element)->Attribute("name"))
+	{
+		m_name.set(((tinyxml2::XMLElement*)m_element)->Attribute("name"));
+	}
 	
 	// do a first pass of the current element to get the counts we need
 	// for allocating the buffers
@@ -56,7 +60,7 @@ void c_xml_definition_block::reset_counts()
 
 void c_xml_definition_block::get_element_counts()
 {
-	const tinyxml2::XMLElement* element = m_element->FirstChildElement();
+	const tinyxml2::XMLElement* element = ((tinyxml2::XMLElement*)m_element)->FirstChildElement();
 	while (element)
 	{
 		const char* element_name = element->Name();
@@ -132,7 +136,7 @@ void c_xml_definition_block::allocate_buffers()
 
 void c_xml_definition_block::populate_buffers()
 {
-	const tinyxml2::XMLElement* element = m_element->FirstChildElement();
+	const tinyxml2::XMLElement* element = ((tinyxml2::XMLElement*)m_element)->FirstChildElement();
 	while (element)
 	{
 		const char* element_name = element->Name();

--- a/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_block.h
+++ b/xlive/Blam/Engine/tag_files/tag_loader/xml/xml_definition_block.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "tag_files/tag_loader/tag_injection_define.h"
-#include <tinyxml/tinyxml2.h>
 
 /* classes */
 
@@ -8,7 +7,7 @@ class c_xml_definition_block
 {
 public:
 	c_xml_definition_block(void) = default;
-	c_xml_definition_block(const tinyxml2::XMLElement* base_element, uint32 offset, uint32 size);
+	c_xml_definition_block(const void* base_element, uint32 offset, uint32 size);
 	~c_xml_definition_block(void) = default;
 
 	void reset_counts();
@@ -44,7 +43,7 @@ public:
 #endif
 
 private:
-	const tinyxml2::XMLElement* m_element;
+	const void* m_element;	// tinyxml2::XMLElement
 	uint32 m_offset;
 	uint32 m_size;
 	c_static_string<64> m_name;


### PR DESCRIPTION
- prevents tinyxml from being included in places it doesn't need to be