### PR TITLE
add improved hook for button update performance issue 

### DIFF
--- a/xlive/Blam/Engine/input/input_windows.cpp
+++ b/xlive/Blam/Engine/input/input_windows.cpp
@@ -37,6 +37,8 @@ struct s_key_remap
 
 static void input_stop_removed_controller_handler_from_panicking(void);
 
+static void input_rewrite_button_timing_loop(void);
+
 static ascii_key* ascii_to_key_table_get(void);
 
 static e_input_key_code input_map_ascii_to_keycode(uint8 ascii);
@@ -44,6 +46,9 @@ static e_input_key_code input_map_ascii_to_keycode(uint8 ascii);
 static void input_windows_initialize_key_remapping(void);
 
 static void __cdecl update_button(uint8* frames, uint16* msec, bool* key_bool, bool down, int32 elapsed_msec);
+
+// Hook for update_button call in input_update
+static void __cdecl update_button_input_update_hook(uint8 * frames, uint16 * msec, bool* key_bool, bool down, int32 elapsed_msec);
 
 static int compare_device_compatibility(const void* p1, const void* p2);
 
@@ -93,6 +98,8 @@ static s_key_remap g_key_remap[REMAPPED_KEY_COUNT] =
 	{ _key_c_cedilla, L'\xE7', NONE }
 };
 
+static bool g_keyboard_input_state[NUMBER_OF_KEYS];
+
 bool g_should_offset_gamepad_indices = false;
 
 bool g_notified_to_change_mapping = false;
@@ -127,6 +134,8 @@ void input_windows_apply_patches(void)
 
 	PatchCall(Memory::GetAddress(0x621C5), input_get_mouse_state);
 	PatchCall(Memory::GetAddress(0x20780B), input_get_mouse_state);
+
+	input_rewrite_button_timing_loop();
 	return;
 }
 
@@ -215,6 +224,7 @@ void input_add_key(int32 msg, uint32 wParam, uint32 lParam, bool fHandled)
 				break;
 			}
 			keystroke.key_code = input_map_ascii_to_keycode(key);
+			g_keyboard_input_state[keystroke.key_code] = true;
 		}
 		// Handle other characters
 		else if (msg == WM_CHAR || msg == WM_SYSCHAR)
@@ -229,6 +239,7 @@ void input_add_key(int32 msg, uint32 wParam, uint32 lParam, bool fHandled)
 				keystroke.ascii_code = (int8)(upper_bit_exists ? NONE : wParam);
 				keystroke.utf16_code = (wchar_t)wParam;
 				keystroke.key_code = input_map_ascii_to_keycode(key);
+				g_keyboard_input_state[keystroke.key_code] = true;
 			}
 		}
 
@@ -536,6 +547,25 @@ void input_windows_notify_change_device_mapping()
 	g_should_offset_gamepad_indices = !g_should_offset_gamepad_indices;
 }
 
+void input_windows_release_key(WCHAR param)
+{
+	ASSERT(VALID_INDEX(param, NUMBER_OF_KEYS));
+
+	const e_input_key_code code = (e_input_key_code)PIN(param, 0, _key_not_a_key);
+	if (code)
+	{
+		update_button(
+			&input_globals->keyboard.frames_down[code],
+			&input_globals->keyboard.msec_down[code],
+			&input_globals->keyboard.key_bool[code],
+			false,
+			0
+		);
+		g_keyboard_input_state[code] = false;
+	}
+	return;
+}
+
 /* private code */
 
 static void input_stop_removed_controller_handler_from_panicking(void)
@@ -543,6 +573,14 @@ static void input_stop_removed_controller_handler_from_panicking(void)
 	PatchCall(Memory::GetAddress(0x208D3C), input_has_gamepad_hook);
 	PatchCall(Memory::GetAddress(0x2084B3), input_has_gamepad_hook);
 	PatchCall(Memory::GetAddress(0x20844A), input_has_gamepad_hook);
+	return;
+}
+
+static void input_rewrite_button_timing_loop(void)
+{
+	NopFill(Memory::GetAddressRelative(0x42FA8A), 3);	// Remove call to GetAsyncKeyState in input_update 
+	NopFill(Memory::GetAddressRelative(0x42FAB9), 8);	// Remove loop code
+	PatchCall(Memory::GetAddress(0x2FAAB), update_button_input_update_hook);
 	return;
 }
 
@@ -610,6 +648,21 @@ static void __cdecl update_button(uint8* frames, uint16* msec, bool* key_bool, b
 		down = false;
 	}
 	INVOKE(0x2E4C5, 0x0, update_button, frames, msec, key_bool, down, elapsed_msec);
+	return;
+}
+
+static void __cdecl update_button_input_update_hook(uint8 * frames, uint16 * msec, bool* key_bool, bool down, int32 elapsed_msec)
+{
+	for (size_t code = 0; code < NUMBER_OF_KEYS; ++code)
+	{
+		update_button(
+			&input_globals->keyboard.frames_down[code],
+			&input_globals->keyboard.msec_down[code],
+			&input_globals->keyboard.key_bool[code],
+			g_keyboard_input_state[code],
+			elapsed_msec
+		);
+	}
 	return;
 }
 

--- a/xlive/Blam/Engine/input/input_windows.h
+++ b/xlive/Blam/Engine/input/input_windows.h
@@ -228,6 +228,8 @@ bool input_windows_processing_device_change();
 bool input_windows_has_split_device_active();
 void input_windows_notify_change_device_mapping();
 
+void input_windows_release_key(WCHAR param);
+
 void __cdecl input_set_gamepad_rumbler_state(int16 gamepad_index, uint16 left, uint16 right);
 
 

--- a/xlive/Blam/Engine/shell/shell_windows.cpp
+++ b/xlive/Blam/Engine/shell/shell_windows.cpp
@@ -5,6 +5,7 @@
 #include "shell_windows_internals.h"
 #include "shell_windows_pcc.h"
 
+#include "input/input_windows.h"
 #include "main/main.h"
 #include "rasterizer/dx9/rasterizer_dx9_main.h"
 
@@ -437,6 +438,9 @@ static LRESULT WINAPI H2WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 	switch (uMsg)
 	{
+	case WM_KEYUP:
+		input_windows_release_key((WCHAR)wParam);
+		break;
 	case WM_SETFOCUS:
 		g_custom_mouse_cursor_enabled = false;
 		break;

--- a/xlive/Blam/Engine/tag_files/tag_group_access.h
+++ b/xlive/Blam/Engine/tag_files/tag_group_access.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "data_reference.h"
+
+inline void* tag_data_get_address(data_reference* data)
+{
+	void* result = NULL;
+	if (data->data)
+	{
+		result = (void*)(data->data + *Memory::GetAddress<uintptr_t*>(0x482290, 0x4A6438));
+	}
+	return result;
+}

--- a/xlive/Blam/Engine/tag_files/tag_groups.cpp
+++ b/xlive/Blam/Engine/tag_files/tag_groups.cpp
@@ -20,7 +20,7 @@ static int32 g_string_id_table_count;
 
 static int32 g_string_id_block_offset;
 
-static int32 g_string_id_index_buffer[13478];
+static int32 g_string_id_index_buffer[0x6000];
 
 static char g_string_id_storage[k_maximum_string_id_storage];
 


### PR DESCRIPTION
- take advantage of the WM_KEYUP message passed from windows so we can update how long a key was held for
- use correct array size for g_string_id_index_buffer (fixes assert on certain campaign maps)
- add tag_data_get_address
