### PR TITLE
treat 16:9 as the default aspect ratio for special aspect ratios

### DIFF
--- a/xlive/Blam/Engine/rasterizer/rasterizer_settings.cpp
+++ b/xlive/Blam/Engine/rasterizer/rasterizer_settings.cpp
@@ -541,9 +541,10 @@ void create_new_display_setting_array(void)
 			{
 				g_display_options[count].aspect_ratio = _aspect_ratio_16x10;
 			}
+			// Treat as 16:9 by default
 			else
 			{
-				g_display_options[count].aspect_ratio = _aspect_ratio_4x3;
+				g_display_options[count].aspect_ratio = _aspect_ratio_16x9;
 			}
 			count++;
 		}


### PR DESCRIPTION
- this removes black bars on ultrawide monitors since we treat them as 16:9