### PR TITLE
update windows sdk and windows runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   fetch-dxsdk2010:
-    runs-on: windows-2022
+    runs-on: windows-2025
     outputs:
       dxsdk-path: ${{steps.dxsdk-set-path.outputs.DXSDK_DIR}}
 
@@ -39,7 +39,7 @@ jobs:
 
   build-win:
     needs: fetch-dxsdk2010
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     env:
       SOLUTION_FILE_PATH: .

--- a/xlive/3rdparty/imgui/imguilib.vcxproj
+++ b/xlive/3rdparty/imgui/imguilib.vcxproj
@@ -31,7 +31,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{349ad4a3-7f10-438b-a15f-58f57a4d5f36}</ProjectGuid>
     <RootNamespace>imguilib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug_msvc|Win32'" Label="Configuration">

--- a/xlive/3rdparty/tinyxml/tinyxmllib.vcxproj
+++ b/xlive/3rdparty/tinyxml/tinyxmllib.vcxproj
@@ -31,7 +31,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{ECCF965A-3A41-455C-A0C2-5829F00D03B8}</ProjectGuid>
     <RootNamespace>tinyxmllib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug_msvc|Win32'" Label="Configuration">

--- a/xlive/3rdparty/zlib/zlib.vcxproj
+++ b/xlive/3rdparty/zlib/zlib.vcxproj
@@ -31,7 +31,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{0a00117c-c1d6-4c5c-b241-694d7f87421f}</ProjectGuid>
     <RootNamespace>zlib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug_msvc|Win32'" Label="Configuration">

--- a/xlive/Project_Cartographer.vcxproj
+++ b/xlive/Project_Cartographer.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DC9655D6-D9C0-4837-8A63-B0693EEED4E8}</ProjectGuid>
     <ProjectName>xlive</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug_msvc|Win32'" Label="Configuration">
@@ -496,6 +496,7 @@
       <SDLCheck>true</SDLCheck>
       <SupportJustMyCode>false</SupportJustMyCode>
       <TreatSpecificWarningsAsErrors>4700</TreatSpecificWarningsAsErrors>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -555,6 +556,7 @@
       <AdditionalOptions>/DPSAPI_VERSION=1 /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <SupportJustMyCode>false</SupportJustMyCode>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
- use latest windows sdk and update github runner to windows-2025
- make floating point model in llvm builds match msvc (fast)

Tested on Windows 7 and there aren't any issues when trying to run using the latest Windows SDK.