### PR TITLE
h2server live autosignin bypass

### DIFF
--- a/xlive/Blam/Engine/kablam/kablam_config.cpp
+++ b/xlive/Blam/Engine/kablam/kablam_config.cpp
@@ -29,8 +29,21 @@ void kablam_config_apply_patches(void)
 void __cdecl kablam_config_initialize(HKEY key, LPCWSTR subkey)
 {
 	INVOKE(0x0, 0x8EFA, kablam_config_initialize, key, subkey);
+
+	c_kablam_config_live* live_config = kablam_config_live_get();
+
+	if (live_config)
+	{
+		wcsncpy_s(live_config->live_id, L"live bypass", NUMBEROF(live_config->live_id));
+	}
+
 	kablam_config_cartographer_initialize();
 	return;
+}
+
+c_kablam_config_live* kablam_config_live_get()
+{
+	return INVOKE(0, 0x8A29, kablam_config_live_get);
 }
 
 /* private code */

--- a/xlive/Blam/Engine/kablam/kablam_config.cpp
+++ b/xlive/Blam/Engine/kablam/kablam_config.cpp
@@ -34,7 +34,7 @@ void __cdecl kablam_config_initialize(HKEY key, LPCWSTR subkey)
 
 	if (live_config)
 	{
-		wcsncpy_s(live_config->live_id, L"live bypass", NUMBEROF(live_config->live_id));
+		wcsncpy_s(live_config->m_live_id, L"live bypass", NUMBEROF(live_config->m_live_id));
 	}
 
 	kablam_config_cartographer_initialize();

--- a/xlive/Blam/Engine/kablam/kablam_config.h
+++ b/xlive/Blam/Engine/kablam/kablam_config.h
@@ -16,13 +16,13 @@ class c_kablam_config
 class c_kablam_config_live
 {
 public:
-	wchar_t live_id[256];
-	wchar_t description[32];
-	wchar_t owner[16];
-	int32 privacy_type;
-	bool enable_multiple_instances;
-	int32 override_port;
-	void* kablam_registry_key;
+	wchar_t m_live_id[256];
+	wchar_t m_description[32];
+	wchar_t m_owner[16];
+	int32 m_privacy_type;
+	bool m_enable_multiple_instances;
+	int32 m_override_port;
+	void* m_kablam_registry_key;
 };
 
 /* prototypes */

--- a/xlive/Blam/Engine/kablam/kablam_config.h
+++ b/xlive/Blam/Engine/kablam/kablam_config.h
@@ -13,8 +13,22 @@ class c_kablam_config
 	wchar_t m_playlist_folder[MAX_PATH];
 };
 
+class c_kablam_config_live
+{
+public:
+	wchar_t live_id[256];
+	wchar_t description[32];
+	wchar_t owner[16];
+	int32 privacy_type;
+	bool enable_multiple_instances;
+	int32 override_port;
+	void* kablam_registry_key;
+};
+
 /* prototypes */
 
 void __cdecl kablam_config_initialize(HKEY key, LPCWSTR subkey);
+
+c_kablam_config_live* kablam_config_live_get();
 
 void kablam_config_apply_patches(void);


### PR DESCRIPTION
removes the requirement for running the 'live autosignin' command for a server to startup.