### PR TITLE
fix typos in object code

### DIFF
--- a/xlive/Blam/Engine/objects/objects.cpp
+++ b/xlive/Blam/Engine/objects/objects.cpp
@@ -112,7 +112,7 @@ static void object_occlusion_data_initialize(datum object_index);
 
 static void __cdecl object_cleanup_havok(datum object_index);
 
-static bool set_object_position_if_in_cluster(s_location* location, datum object_index);
+static bool object_find_initial_location(datum object_index, s_location* location);
 
 static bool __cdecl object_compute_change_colors(datum object_index);
 
@@ -716,7 +716,7 @@ datum __cdecl object_new(object_placement_data* data)
 				// If the object (can) connect to the map we make sure it gets connected
 				if (objects_can_connect_to_map())
 				{
-					data->location_valid = set_object_position_if_in_cluster(&data->location, object_index);
+					data->location_valid = object_find_initial_location(object_index, &data->location);
 
 					// If the object is inside a cluster set the location to the one passed in the placement data
 					// If not then pass null
@@ -757,7 +757,7 @@ datum __cdecl object_new(object_placement_data* data)
 					objects_can_connect_to_map() && 
 					!TEST_BIT(data->flags, 1))
 				{
-					if (!TEST_BIT(data->flags, 2))
+					if (TEST_BIT(data->flags, 2))
 					{
 						if (object->object.location.cluster_index != NONE)
 						{
@@ -1168,11 +1168,11 @@ void __cdecl object_set_hidden(datum object_index, bool hidden)
 	}
 	else
 	{
-		object->object.flags.set(_object_hidden_bit, false);
 		if (object_is_connected_to_map(object_index))
 		{
 			object_disconnect_from_map(object_index, true, false);
 		}
+		object->object.flags.set(_object_hidden_bit, true);
 		object_update_collision_culling(object_index);
 	}
 	return;
@@ -1453,7 +1453,7 @@ static void __cdecl object_cleanup_havok(datum object_index)
 	return;
 }
 
-static bool set_object_position_if_in_cluster(s_location* location, datum object_index)
+static bool object_find_initial_location(datum object_index, s_location* location)
 {
 	object_datum* object = object_get(object_index);
 
@@ -1570,13 +1570,14 @@ static void object_reconnect_to_map(s_location* location, datum object_index)
 	s_object_payload payload;
 	object_get_payload(object_index, &payload);
 
-	const cluster_partition* partition = collideable_object_cluster_partition_get();
+	cluster_partition* partition = collideable_object_cluster_partition_get();
 	if (!object->object.flags.test(_object_uses_collidable_list_bit))
 	{
 		partition = noncollideable_object_cluster_partition_get();
 	}
 
-	cluster_partition_reconnect(partition,
+	cluster_partition_reconnect(
+		partition,
 		object_index,
 		&object->object.first_cluster_reference,
 		&object->object.object_origin_point,

--- a/xlive/Blam/Engine/objects/objects.cpp
+++ b/xlive/Blam/Engine/objects/objects.cpp
@@ -68,19 +68,6 @@ struct dump_datum
 };
 #endif
 
-/* globals */
-
-t_object_new p_object_new;
-
-#ifdef OBJECT_OVERRIDE_ENABLED
-s_object_override_data g_object_override_data[k_maximum_object_override_count];
-#endif
-
-#ifdef OBJECT_DEBUG
-int32 debug_last_out_of_memory_dump_game_time;
-int32 g_object_memory_dump_number;
-#endif
-
 /* prototypes */
 
 static s_memory_pool* object_memory_pool_get(void);
@@ -160,6 +147,19 @@ static void object_add_to_dump(datum object_index, dump_datum* dump);
 static void object_dump_print_info(_iobuf* handle, const dump_datum* dump);
 
 static int sort_dumps(const dump_datum* dump1, const dump_datum* dump2);
+#endif
+
+/* globals */
+
+static t_object_new p_object_new;
+
+#ifdef OBJECT_OVERRIDE_ENABLED
+static s_object_override_data g_object_override_data[k_maximum_object_override_count];
+#endif
+
+#ifdef OBJECT_DEBUG
+static int32 debug_last_out_of_memory_dump_game_time;
+static int32 g_object_memory_dump_number;
 #endif
 
 /* public code */

--- a/xlive/Blam/Engine/structures/cluster_partitions.cpp
+++ b/xlive/Blam/Engine/structures/cluster_partitions.cpp
@@ -20,7 +20,7 @@ void __cdecl cluster_partition_make_valid(cluster_partition* partition)
 }
 
 void __cdecl cluster_partition_reconnect(
-	const cluster_partition* partition,
+	cluster_partition* partition,
 	datum object_datum,
 	int32* first_cluster_reference,
 	const real_point3d* position,

--- a/xlive/Blam/Engine/structures/cluster_partitions.h
+++ b/xlive/Blam/Engine/structures/cluster_partitions.h
@@ -57,7 +57,7 @@ cluster_partition* noncollideable_object_cluster_partition_get(void);
 void __cdecl cluster_partition_make_valid(cluster_partition* partition);
 
 void __cdecl cluster_partition_reconnect(
-	const cluster_partition* partition,
+	cluster_partition* partition,
 	datum object_datum,
 	int32* first_cluster_reference,
 	const real_point3d* position,


### PR DESCRIPTION
- fixes bug where you could throw grenades into the wall
- give proper name to object_find_initial_location
- cluster partition is not constant in cluster_partition_reconnect