### PR TITLE
set UDP sockets SIO_UDP_CONNRESET option to false

### DIFF
--- a/xlive/Blam/Engine/physics/character_physics_mode_melee.cpp
+++ b/xlive/Blam/Engine/physics/character_physics_mode_melee.cpp
@@ -402,7 +402,7 @@ void __thiscall c_character_physics_mode_melee_datum::update_internal
 					// acceleration
 					real32 final_accel = MIN(acceleration, MAX(0.0f, max_speed_per_tick - MAX(0.0f, translational_velocity_magnitude_per_tick)));
 
-					scale_vector3d(&m_initial_aiming_vector, final_accel, &physics_output->new_velocity);
+					scale_vector3d(&m_target_vector, final_accel, &physics_output->new_velocity);
 					add_vectors3d(&physics_output->new_velocity, &current_velocity_per_tick_vector, &physics_output->new_velocity);
 					scale_vector3d(&physics_output->new_velocity, game_seconds_to_ticks_real(1.0f), &physics_output->new_velocity);
 
@@ -463,7 +463,7 @@ void __thiscall c_character_physics_mode_melee_datum::update_internal
 		vector_from_points3d(position, &m_target_position, &vector_to_target);
 		real32 remaining_distance = magnitude3d(&vector_to_target);
 
-		real32 unk_real32_distance = dot_product3d(&m_initial_aiming_vector, velocity);
+		real32 unk_real32_distance = dot_product3d(&m_target_vector, velocity);
 		unk_real32_distance *= game_tick_length();
 		real32 acceleration = melee_lunge_get_max_speed_per_tick(game_tick_length(), m_target_distance, m_weapon_is_sword);
 		acceleration = melee_get_acceleration(acceleration);
@@ -491,12 +491,12 @@ void __thiscall c_character_physics_mode_melee_datum::update_internal
 
 	LOG_TRACE_MELEE("{} : aiming vector adjusted length (should be 1.0 or a little lower): {}",
 		__FUNCTION__,
-		magnitude3d(&m_initial_aiming_vector));
+		magnitude3d(&m_target_vector));
 
 	LOG_TRACE_MELEE("{} : previous velocity: {}, previous velocity dot product with aiming vector adjusted: {}",
 		__FUNCTION__,
 		magnitude3d(velocity),
-		dot_product3d(&m_initial_aiming_vector, velocity));
+		dot_product3d(&m_target_vector, velocity));
 
 	if ((real32)(m_maximum_counter - m_counter) <= k_deceleration_ticks_real && !m_started_decelerating)
 		LOG_TRACE_MELEE("{} : we are about to start decelerating @ next tick : {}", __FUNCTION__, m_counter);

--- a/xlive/Blam/Engine/units/bipeds.cpp
+++ b/xlive/Blam/Engine/units/bipeds.cpp
@@ -36,7 +36,7 @@ void biped_build_2d_camera_frame(const real_vector3d* forward, const real_vector
 	perpendicular2d(forward_out, up_out);
 }
 
-void __cdecl biped_offset_first_person_camera(const real_vector3d* camera_forward, datum object_index, real_point3d* camera_position, const real_vector3d* camera_up)
+void __cdecl biped_offset_first_person_camera(datum object_index, real_point3d* camera_position, const real_vector3d* camera_forward, const real_vector3d* camera_up)
 {
 	const biped_datum* biped = biped_get(object_index);
 	const biped_definition* biped_def = (biped_definition*)tag_get_fast(biped->definition_index);
@@ -178,7 +178,7 @@ void __cdecl biped_get_sight_position(
 	real_vector3d forward = biped->unit.aiming_vector;
 	real_vector3d up;
 	generate_up_vector3d(&forward, &up);
-	biped_offset_first_person_camera(&forward, biped_index, &origin_copy, &up);
+	biped_offset_first_person_camera(biped_index, &origin_copy, &forward, &up);
 	real_vector3d origin_vector;
 	vector_from_points3d(sight_position, &origin_copy, &origin_vector);
 	if (normalize3d(&origin_vector) > 0.0f)
@@ -269,9 +269,9 @@ __declspec(naked) void biped_offset_first_person_camera_usercall_to_rewritten(vo
 
 		// Push values for function call
 		push ebx                // push camera_up
+		push eax                // push camera_forward
 		push ecx                // push camera_position
 		push edx                // push object_index
-		push eax                // push camera_forward
 
 		call biped_offset_first_person_camera
 

--- a/xlive/XLive/xnet/Sockets/XSocket.cpp
+++ b/xlive/XLive/xnet/Sockets/XSocket.cpp
@@ -6,6 +6,9 @@
 
 #include "XLive/xnet/net_utils.h"
 
+/* for SIO_UDP_CONNRESET */
+#include <mswsock.h>
+
 XSocketManager g_XSockMgr;
 
 // #5310: XOnlineStartup
@@ -74,22 +77,22 @@ SOCKET WINAPI XSocketCreate(int af, int type, int protocol)
 		LOG_TRACE_NETWORK("XSocketCreate() - Socket: {} is VDP protocol", ret);
 	}
 
-	// disable SIO_UDP_CONNRESET
-	// TODO re-enable this if the issue https://github.com/pnill/cartographer/issues/320 is not caused by this
-
-	/*DWORD ioctlSetting = 0;
-	DWORD cbBytesReturned;
-	if (WSAIoctl(newXSocket->systemSocketHandle, SIO_UDP_CONNRESET, &ioctlSetting, 4u, 0, 0, &cbBytesReturned, 0, 0) == SOCKET_ERROR)
+	if (protocol == IPPROTO_UDP)
 	{
-		LOG_ERROR_NETWORK("XSocketCreate() - couldn't disable SIO_UDP_CONNRESET", ret);
+		// disable SIO_UDP_CONNRESET
+		DWORD cbBytesReturned;
+		BOOL udpConnResetIoctl = FALSE;
+		if (WSAIoctl(newXSocket->systemSocketHandle, SIO_UDP_CONNRESET, &udpConnResetIoctl, sizeof(udpConnResetIoctl), 0, 0, &cbBytesReturned, 0, 0) != SOCKET_ERROR)
+		{
+			LOG_TRACE_NETWORK("XSocketCreate() - disabled SIO_UDP_CONNRESET");
+		}
+		else
+		{
+			LOG_ERROR_NETWORK("XSocketCreate() - unable to disable SIO_UDP_CONNRESET for UDP socket, error {}", ret);
+		}
 	}
-	else
-	{
-		LOG_TRACE_NETWORK("XSocketCreate() - disabled SIO_UDP_CONNRESET");
-	}*/
 
 	g_XSockMgr.sockets.push_back(newXSocket);
-
 	/*newXSocket->SetBufferSize(SO_SNDBUF, gXnIpMgr.GetMinSockSendBufferSizeInBytes());
 	newXSocket->SetBufferSize(SO_RCVBUF, gXnIpMgr.GetMinSockRecvBufferSizeInBytes());*/
 


### PR DESCRIPTION
- prevent recv(from) reporting WSAECONNRESET if port is unreachable, which could potentially lead to delayed game traffic processing