### PR TITLE
fix addDebugText truncating last character

### DIFF
--- a/xlive/Blam/Engine/text/unicode.cpp
+++ b/xlive/Blam/Engine/text/unicode.cpp
@@ -288,7 +288,7 @@ int32 usnprintf(wchar_t* string, size_t size, const wchar_t* format, ...)
 	ASSERT(string != NULL);
 	ASSERT(size > 0);
 
-	int32 result = _vsnwprintf_s(string, size - 1, UINT_MAX, format, va_args);
+	int32 result = _vsnwprintf_s(string, size - 1, _TRUNCATE, format, va_args);
 	va_end(va_args);
 	return result;
 }
@@ -311,7 +311,7 @@ int32 uvsnprintf(wchar_t* string, size_t size, const wchar_t* format, char* ap)
 	ASSERT(string && format);
 	ASSERT(size > 0);
 
-	return _vsnwprintf_s(string, size - 1, UINT_MAX, format, ap);
+	return _vsnwprintf_s(string, size - 1, _TRUNCATE, format, ap);
 }
 
 _iobuf* ufdopen(int32 fd, const wchar_t* path)

--- a/xlive/H2MOD/Modules/OnScreenDebug/OnscreenDebug.cpp
+++ b/xlive/H2MOD/Modules/OnScreenDebug/OnscreenDebug.cpp
@@ -56,7 +56,7 @@ void addDebugText(const wchar_t* format, ...)
 	}
 
 	wchar_t* textBufferW = (wchar_t*)calloc(stringLength, sizeof(wchar_t));
-	uvsnprintf(textBufferW, stringLength, format, valist);
+	_vsnwprintf_s(textBufferW, stringLength, _TRUNCATE, format, valist);
 
 	char* textBufferA = (char*)calloc(stringLength, sizeof(char));
 	csprintf(textBufferA, stringLength, "%ls", textBufferW);


### PR DESCRIPTION
uvsnprintf (for some reason?) subtracts 1 from the buffer size, which is reserved for the last character. addDebugText computes strictly the required size for the buffer, including the null character
