### PR TITLE
allow dedicated server game update/ticks to run out of sync with per-frame game systems

### DIFF
--- a/xlive/Blam/Engine/effects/particle_system.cpp
+++ b/xlive/Blam/Engine/effects/particle_system.cpp
@@ -14,7 +14,7 @@ real32 particle_system_accumulated_time[k_max_particle_systems];
 
 c_particle_system_definition* c_particle_system::get_definition() const
 {
-	return INVOKE_TYPE(0xC3CE9, 0x0, c_particle_system_definition*(__thiscall*)(const c_particle_system*), this);
+	return INVOKE_TYPE(0xC3CE9, 0xB0BD4, c_particle_system_definition*(__thiscall*)(const c_particle_system*), this);
 }
 
 data_array* get_particle_system_table()
@@ -49,12 +49,12 @@ datum particle_system_get_by_ptr(c_particle_system* particle_system)
 
 void c_particle_system::destroy_children()
 {
-	return INVOKE_TYPE(0xC37DE, 0x0, void(__thiscall*)(c_particle_system*), this);
+	return INVOKE_TYPE(0xC37DE, 0xB06C9, void(__thiscall*)(c_particle_system*), this);
 }
 
 void c_particle_system::update_colors(bool v_mirrored_or_one_shot, bool one_shot, pixel32 color, pixel32 color_2)
 {
-	return INVOKE_TYPE(0xC381F, 0, void(__thiscall *)(c_particle_system*, bool, bool, pixel32, pixel32), this, v_mirrored_or_one_shot, one_shot, color, color_2);
+	return INVOKE_TYPE(0xC381F, 0xB070A, void(__thiscall *)(c_particle_system*, bool, bool, pixel32, pixel32), this, v_mirrored_or_one_shot, one_shot, color, color_2);
 }
 
 int32 c_particle_system::get_particle_count() const
@@ -78,28 +78,7 @@ int32 c_particle_system::get_particle_count() const
 
 void c_particle_system::change_parent_effect(datum* datum_1, datum* datum_2)
 {
-	return INVOKE_TYPE(0xC35F7, 0, void(__thiscall*)(c_particle_system*, datum*, datum*), this, datum_1, datum_2);
-}
-
-typedef void(__thiscall* t_c_particle_system__update_position)(c_particle_system* particle_system, s_particle_system_update* particle_system_update, const real_matrix4x3* matrix, bool a4);
-t_c_particle_system__update_position p_update_position;
-
-CLASS_HOOK_DECLARE_LABEL(c_particle_system__update_position, c_particle_system::update_position);
-void __thiscall c_particle_system::update_position(
-	s_particle_system_update* particle_system_update,
-	const real_matrix4x3* matrix,
-	bool a4)
-{
-	// the index is updated in the original code, so get it early
-	//c_particle_system_definition* particle_system_def = this->get_definition();
-	//datum location_index = particle_system_update->particle_system_location_index;
-	
-	p_update_position(this, particle_system_update, matrix, a4);
-}
-
-__declspec(naked) void jmp_c_particle_system_update_position()
-{
-	CLASS_HOOK_JMP(c_particle_system__update_position, c_particle_system::update_position);
+	return INVOKE_TYPE(0xC35F7, 0xB04E2, void(__thiscall*)(c_particle_system*, datum*, datum*), this, datum_1, datum_2);
 }
 
 typedef bool(__stdcall* c_particle_system_frame_advance_t)(c_particle_system* thisx, real32 dt);
@@ -276,10 +255,8 @@ void __cdecl particle_system_remove_from_effects_cache(datum effect_index, datum
 
 void apply_particle_system_patches()
 {
-	p_c_particle_system_frame_advance = (c_particle_system_frame_advance_t)DetourClassFunc(Memory::GetAddress<uint8*>(0xC43F9), (uint8*)c_particle_system::frame_advance, 10);
-	p_c_particle_system__restart = (t_c_particle_system__update_location_time)DetourClassFunc(Memory::GetAddress<uint8*>(0xC3E32), (uint8*)c_particle_system::restart, 11);
-
-	DETOUR_ATTACH(p_update_position, Memory::GetAddress<t_c_particle_system__update_position>(0xC376A), jmp_c_particle_system_update_position);
+	p_c_particle_system_frame_advance = (c_particle_system_frame_advance_t)DetourClassFunc(Memory::GetAddress<uint8*>(0xC43F9, 0xB12E4), (uint8*)c_particle_system::frame_advance, 10);
+	p_c_particle_system__restart = (t_c_particle_system__update_location_time)DetourClassFunc(Memory::GetAddress<uint8*>(0xC3E32, 0xB0D1D), (uint8*)c_particle_system::restart, 11);
 
 	// TODO fixme info in particle emitter
 	// allow world coordinate system particles to be updated

--- a/xlive/Blam/Engine/effects/particle_update.cpp
+++ b/xlive/Blam/Engine/effects/particle_update.cpp
@@ -23,7 +23,7 @@ void particle_update(real32 delta)
 	}
 }
 
-void apply_particle_update_patches()
+void particle_update_apply_patches()
 {
 	apply_particle_system_patches();
 

--- a/xlive/Blam/Engine/effects/particle_update.h
+++ b/xlive/Blam/Engine/effects/particle_update.h
@@ -1,4 +1,4 @@
 #pragma once
 
-void apply_particle_update_patches();
+void particle_update_apply_patches();
 

--- a/xlive/Blam/Engine/main/main_time.cpp
+++ b/xlive/Blam/Engine/main/main_time.cpp
@@ -199,9 +199,9 @@ real32 __cdecl main_time_update(void)
 			// if there's game tick leftover time (i.e the actual game tick update executed faster than the actual engine's fixed time step)
 			// FIXED by interpolation: 
 			// limit the framerate to get back in sync with the renderer to prevent ghosting and jagged movement
-			while (dt_sec < game_time_get_max_frame_time())
+			while (dt_sec < game_tick_length())
 			{
-				real32 fMsSleep = (real32)(game_time_get_max_frame_time() - dt_sec) * 1000.f;
+				real32 fMsSleep = (real32)(game_tick_length() - dt_sec) * 1000.f;
 
 				// to reduce stuttering, spend some of the time to sleep by CPU spinning,
 				// Sleep is not precise since Windows is not a RTOS

--- a/xlive/Blam/Engine/render/render_visibility_collection.cpp
+++ b/xlive/Blam/Engine/render/render_visibility_collection.cpp
@@ -17,7 +17,7 @@ void __cdecl predicted_resources_precache(int32 cluster_index)
 
 bool __cdecl render_visibility_check_location_cluster_active(s_location* location)
 {
-	return INVOKE(0x19447C, 0, render_visibility_check_location_cluster_active, location);
+	return INVOKE(0x19447C, 0x180490, render_visibility_check_location_cluster_active, location);
 }
 
 void render_view_visibility_compute_to_usercall(int32 user_index)

--- a/xlive/H2MOD.cpp
+++ b/xlive/H2MOD.cpp
@@ -575,6 +575,8 @@ static void h2mod_apply_hooks(void)
 	players_apply_patches();
 	objects_apply_patches();
 
+	particle_update_apply_patches();
+
 	c_character_physics_mode_melee_datum::apply_hooks();
 	character_physics_mode_ground_apply_patches();
 	
@@ -675,7 +677,6 @@ static void h2mod_apply_hooks(void)
 
 		cinematics_apply_patches();
 		game_state_procs_apply_patches();
-		apply_particle_update_patches();
 		apply_dead_camera_patches();
 		liquid_apply_patches();
 		contrails_apply_patches();


### PR DESCRIPTION
Further improves (possibly significantly) server responsiveness since network and other systems will not wait for a game tick to execute, thus replicating the same behavior present in the game client since interpolation has been implemented.
Particle system hooks have to be enabled now, since the effects (some of the explosions, etc) are synchronized over the network.
There's a possibility that the algorithm computing when a game tick should be executed during a frame to be slightly off, which could be further investigated.
